### PR TITLE
chore: add CLAUDE.md project instructions and GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear and concise description of what the bug is -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened -->
+
+## Screenshots / Screen Recordings
+
+<!-- If applicable, add screenshots or recordings to help explain the problem -->
+
+## Environment
+
+- **Platform**: <!-- Android / iOS / Both -->
+- **OS Version**: <!-- e.g. Android 14, iOS 17.2 -->
+- **Device**: <!-- e.g. Pixel 8, iPhone 15 Pro, emulator -->
+- **App Version**: <!-- e.g. 1.2.0 -->
+- **Model in use**: <!-- e.g. llama-3.2-1b-instruct, or N/A -->
+
+## Logs
+
+<!-- Paste any relevant logs, error messages, or crash reports -->
+
+```
+(paste logs here)
+```
+
+## Additional Context
+
+<!-- Any other context about the problem -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+<!-- A clear and concise description of the feature you'd like -->
+
+## Problem / Motivation
+
+<!-- What problem does this solve? Why is this feature needed? -->
+
+## Proposed Solution
+
+<!-- Describe the solution you'd like -->
+
+## Alternatives Considered
+
+<!-- Any alternative solutions or features you've considered -->
+
+## Platform
+
+- [ ] Android
+- [ ] iOS
+- [ ] Both
+
+## Additional Context
+
+<!-- Any mockups, references, or extra context -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# Project Instructions
+
+## Pre-Commit Quality Gates
+
+Before EVERY commit, you MUST run all of the following checks and ensure they pass. Do NOT commit until all three are green:
+
+1. **Tests**: `npm test` — if you wrote or modified code, first ensure tests exist for the changes. Write missing tests before running.
+2. **Linting**: `npm run lint`
+3. **TypeScript**: `npx tsc --noEmit`
+
+Run all three in parallel. If any fail, fix the issues and re-run until they all pass. Never skip these checks.
+
+## Push = Create PR + Address Review
+
+When asked to push code, follow this full workflow:
+
+0. ensure that you are on a branch that is specific to this change i.e feat/new-feature or fix/bug-fix or docs/update-readme or chore/update-dependencies, or test/new-test, etc
+1. Push the branch to the remote (`git push -u origin <branch>`)
+2. Create a PR using `gh pr create`. Ensure that you are adhering to the PR template
+3. Wait for Gemini to review the PR (poll with `gh pr checks` and `gh api repos/{owner}/{repo}/pulls/{number}/reviews` until a review appears)
+4. Once a review exists, pull down the review comments: `gh api repos/{owner}/{repo}/pulls/{number}/comments` and `gh api repos/{owner}/{repo}/pulls/{number}/reviews`
+5. Address every review comment — fix the code, re-run the quality gates (tests, lint, tsc)
+6. Push the fixes
+7. Report what was changed in response to the review


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` at the repo root with pre-commit quality gates and the push → PR → Gemini review → address workflow that all contributors (human and AI) must follow
- Adds `.github/ISSUE_TEMPLATE/bug_report.md` for structured bug reports (steps to reproduce, environment, logs)
- Adds `.github/ISSUE_TEMPLATE/feature_request.md` for feature suggestions (motivation, proposed solution, alternatives, platform)

## Type of Change

- [x] Chore (build process, CI, dependency updates, etc.)

## Screenshots / Screen Recordings

N/A — documentation and tooling only

## Checklist

### General

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

### Testing

- [x] Existing tests pass locally (`npm test`)

### Security

- [x] No secrets, API keys, or credentials are included in the code

## Related Issues

N/A

## Additional Notes

`CLAUDE.md` is automatically loaded by Claude Code as project-level instructions, enforcing consistent quality gates and PR workflow across all AI-assisted sessions.