### PR TITLE
chore: add local release script for Android + iOS

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*"; exit 1; }
+
+# ── Pre-flight checks ──────────────────────────────────────────────
+command -v node       >/dev/null || error "node is not installed"
+command -v gh         >/dev/null || error "gh CLI is not installed (brew install gh)"
+command -v xcodebuild >/dev/null || error "xcodebuild is not installed (need Xcode)"
+[ -f android/gradlew ]          || error "android/gradlew not found"
+[ -n "${ANDROID_HOME:-}" ]      || error "ANDROID_HOME is not set"
+
+# Ensure clean working tree
+if [ -n "$(git status --porcelain)" ]; then
+  error "Working tree is dirty. Commit or stash changes first."
+fi
+
+# ── 1. Bump version ────────────────────────────────────────────────
+info "Bumping patch version..."
+npm version patch --no-git-tag-version
+NEW_VERSION=$(node -p "require('./package.json').version")
+VERSION_CODE=$(date +%s)
+
+info "New version: ${BOLD}$NEW_VERSION${NC}  (versionCode: $VERSION_CODE)"
+
+# Update Android build.gradle
+sed -i '' "s/versionCode .*/versionCode $VERSION_CODE/" android/app/build.gradle
+sed -i '' "s/versionName .*/versionName \"$NEW_VERSION\"/" android/app/build.gradle
+
+# Update iOS project.pbxproj (MARKETING_VERSION + CURRENT_PROJECT_VERSION)
+PBXPROJ="ios/OffgridMobile.xcodeproj/project.pbxproj"
+sed -i '' "s/MARKETING_VERSION = .*/MARKETING_VERSION = $NEW_VERSION;/" "$PBXPROJ"
+sed -i '' "s/CURRENT_PROJECT_VERSION = .*/CURRENT_PROJECT_VERSION = $VERSION_CODE;/" "$PBXPROJ"
+
+info "iOS version synced: MARKETING_VERSION=$NEW_VERSION, CURRENT_PROJECT_VERSION=$VERSION_CODE"
+
+git add package.json package-lock.json android/app/build.gradle "$PBXPROJ"
+git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+
+# ── 2. Generate grouped release notes ──────────────────────────────
+info "Generating release notes..."
+
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -z "$LAST_TAG" ]; then
+  COMMITS=$(git log --pretty=format:"%s (%h)" --no-merges -50)
+else
+  COMMITS=$(git log "${LAST_TAG}..HEAD" --pretty=format:"%s (%h)" --no-merges)
+fi
+
+FEATURES="" FIXES="" CHORES="" REFACTORS="" TESTS="" DOCS="" CI_CHANGES="" OTHER=""
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  case "$line" in
+    feat:*|feat\(*) FEATURES="${FEATURES}- ${line}\n" ;;
+    fix:*|fix\(*)   FIXES="${FIXES}- ${line}\n" ;;
+    chore:*|chore\(*) CHORES="${CHORES}- ${line}\n" ;;
+    refactor:*|refactor\(*) REFACTORS="${REFACTORS}- ${line}\n" ;;
+    test:*|test\(*) TESTS="${TESTS}- ${line}\n" ;;
+    docs:*|docs\(*) DOCS="${DOCS}- ${line}\n" ;;
+    ci:*|ci\(*)     CI_CHANGES="${CI_CHANGES}- ${line}\n" ;;
+    *)              OTHER="${OTHER}- ${line}\n" ;;
+  esac
+done <<< "$COMMITS"
+
+NOTES_FILE="$ROOT_DIR/release-notes.md"
+{
+  echo "## What's Changed in v${NEW_VERSION}"
+  echo ""
+  [ -n "$FEATURES" ]   && echo "### Features"      && echo -e "$FEATURES"
+  [ -n "$FIXES" ]      && echo "### Bug Fixes"      && echo -e "$FIXES"
+  [ -n "$REFACTORS" ]  && echo "### Refactors"      && echo -e "$REFACTORS"
+  [ -n "$CHORES" ]     && echo "### Chores"          && echo -e "$CHORES"
+  [ -n "$TESTS" ]      && echo "### Tests"           && echo -e "$TESTS"
+  [ -n "$DOCS" ]       && echo "### Documentation"   && echo -e "$DOCS"
+  [ -n "$CI_CHANGES" ] && echo "### CI/CD"           && echo -e "$CI_CHANGES"
+  [ -n "$OTHER" ]      && echo "### Other"           && echo -e "$OTHER"
+  echo "---"
+  echo "**Full Changelog**: https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/compare/${LAST_TAG:-v0.0.0}...v${NEW_VERSION}"
+} > "$NOTES_FILE"
+
+info "Release notes:"
+cat "$NOTES_FILE"
+echo ""
+
+# ── 3. Build APK ───────────────────────────────────────────────────
+info "Building release APK..."
+cd android
+./gradlew assembleRelease
+cd "$ROOT_DIR"
+
+APK_SRC="android/app/build/outputs/apk/release/app-release.apk"
+APK_DST="android/app/build/outputs/apk/release/OffgridMobile-v${NEW_VERSION}.apk"
+[ -f "$APK_SRC" ] || error "APK not found at $APK_SRC"
+mv "$APK_SRC" "$APK_DST"
+info "APK ready: $APK_DST"
+
+# ── 4. Build AAB ───────────────────────────────────────────────────
+info "Building release AAB..."
+cd android
+./gradlew bundleRelease
+cd "$ROOT_DIR"
+
+AAB_SRC="android/app/build/outputs/bundle/release/app-release.aab"
+AAB_DST="android/app/build/outputs/bundle/release/OffgridMobile-v${NEW_VERSION}.aab"
+[ -f "$AAB_SRC" ] || error "AAB not found at $AAB_SRC"
+mv "$AAB_SRC" "$AAB_DST"
+info "AAB ready: $AAB_DST (not uploaded — copy manually for Play Store)"
+
+# ── 5. Build iOS Archive ──────────────────────────────────────────
+info "Building iOS archive..."
+ARCHIVE_DIR="$ROOT_DIR/build"
+ARCHIVE_PATH="$ARCHIVE_DIR/OffgridMobile-v${NEW_VERSION}.xcarchive"
+mkdir -p "$ARCHIVE_DIR"
+
+xcodebuild archive \
+  -project ios/OffgridMobile.xcodeproj \
+  -scheme OffgridMobile \
+  -configuration Release \
+  -archivePath "$ARCHIVE_PATH" \
+  -destination "generic/platform=iOS" \
+  CODE_SIGN_IDENTITY=- \
+  AD_HOC_CODE_SIGNING_ALLOWED=YES \
+  | tail -5
+
+[ -d "$ARCHIVE_PATH" ] || error "iOS archive not found at $ARCHIVE_PATH"
+info "iOS archive ready: $ARCHIVE_PATH"
+info "  Open in Xcode to distribute: open \"$ARCHIVE_PATH\""
+
+# ── 6. Push version bump & create GitHub release ───────────────────
+info "Pushing version bump..."
+git push
+
+info "Creating GitHub release v${NEW_VERSION}..."
+gh release create "v${NEW_VERSION}" \
+  "$APK_DST" \
+  --title "Off Grid v${NEW_VERSION}" \
+  --notes-file "$NOTES_FILE"
+
+# Clean up temp file
+rm -f "$NOTES_FILE"
+
+echo ""
+info "${BOLD}Release v${NEW_VERSION} published!${NC}"
+echo ""
+info "Artifacts:"
+info "  APK (GitHub release): $APK_DST"
+info "  AAB (Play Store):     $AAB_DST"
+info "  iOS archive:          $ARCHIVE_PATH"
+info ""
+info "Next steps:"
+info "  Android: Upload AAB to Play Console"
+info "  iOS:     open \"$ARCHIVE_PATH\" → Distribute App in Xcode Organizer"
+info ""
+info "  GitHub: $(gh release view "v${NEW_VERSION}" --json url -q .url)"


### PR DESCRIPTION
## Summary

Adds a local release script (`scripts/release.sh`) that replaces the slow CI-based release workflow. Builds APK, AAB, and iOS archive locally, then creates a GitHub release with the APK attached.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [x] Chore (build process, CI, dependency updates, etc.)

## What the script does

| Step | Action |
|------|--------|
| 1 | Bumps patch version across `package.json`, Android `build.gradle`, and iOS `project.pbxproj` |
| 2 | Generates grouped release notes (features, fixes, chores, refactors, tests, docs, CI) |
| 3 | Builds release APK (`assembleRelease`) |
| 4 | Builds release AAB (`bundleRelease`) — kept locally for Play Store upload |
| 5 | Builds iOS archive (`xcodebuild archive`) — equivalent of Xcode Product → Archive |
| 6 | Pushes version bump commit and creates GitHub release with APK |

## Checklist

### General

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have added/updated comments where the logic isn't self-evident
- [x] My changes generate no new warnings or errors

### Security

- [x] No secrets, API keys, or credentials are included in the code
- [x] User input is validated/sanitized where applicable

## Additional Notes

- The existing CI workflow (`.github/workflows/release.yml`) is unchanged — this is an alternative for faster local builds
- AAB and iOS archive are built but not uploaded to GitHub release — intended for manual upload to Play Store / App Store Connect
- Run with `./scripts/release.sh`