### PR TITLE
fix: remove installreferrer dep — fixes crash on GrapheneOS / no-GMS devices

### DIFF
--- a/patches/react-native-device-info+15.0.2.patch
+++ b/patches/react-native-device-info+15.0.2.patch
@@ -1,7 +1,9 @@
 diff --git a/node_modules/react-native-device-info/android/build.gradle b/node_modules/react-native-device-info/android/build.gradle
+index e352534..ebe9346 100644
 --- a/node_modules/react-native-device-info/android/build.gradle
 +++ b/node_modules/react-native-device-info/android/build.gradle
-@@ -57,7 +57,6 @@ repositories {
+@@ -56,7 +56,6 @@ repositories {
+ 
  dependencies {
    implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
 -  implementation "com.android.installreferrer:installreferrer:${safeExtGet('installReferrerVersion', '1.1.2')}"


### PR DESCRIPTION
## Summary

- Removes `com.android.installreferrer:installreferrer` from `react-native-device-info`'s Android build via a `patch-package` patch
- This library binds to the Google Play Store AIDL service at module init time (before any JS runs), triggering the *"Check that Google Play is enabled on your device"* error dialog on devices without Google Play Services
- The app never calls `getInstallReferrer()` anywhere in JS, so dropping this dependency has zero functional impact

## Root cause

`RNInstallReferrerClient` calls `startConnection()` in its constructor, which is invoked when React Native initialises the `RNDeviceModule` native module on startup. On GrapheneOS (or any device with Play Store disabled/absent), the AIDL service binding fails and Android shows the blocking error dialog.

## Test plan

- [ ] Build a release APK and install on a device without Google Play Services (GrapheneOS, emulator with no GMS)
- [ ] Confirm app launches without the "Check that Google Play is enabled" dialog
- [ ] Confirm all `react-native-device-info` features used by the app still work (memory info, model name, system version, hardware, IP address)
- [ ] Confirm `yarn install` re-applies the patch cleanly via `postinstall`

## Note

This fixes the JS/native layer issue. For full Play-free distribution, a universal APK should also be published via GitHub Releases (already supported by `useLegacyPackaging = true` + `extractNativeLibs="true"`).