### PR TITLE
fix: skip LAN scan on cellular and delay until home screen renders

### DIFF
--- a/src/screens/HomeScreen/hooks/useHomeScreen.ts
+++ b/src/screens/HomeScreen/hooks/useHomeScreen.ts
@@ -135,7 +135,8 @@ export const useHomeScreen = (navigation: HomeScreenNavigationProp) => {
       }
       if (!hasRunLANDiscovery) {
         hasRunLANDiscovery = true;
-        runLANDiscovery();
+        // Delay LAN scan so the home screen is fully rendered and interactive first
+        setTimeout(runLANDiscovery, 3000);
       }
     });
     isFirstMount.current = false;

--- a/src/services/networkDiscovery.ts
+++ b/src/services/networkDiscovery.ts
@@ -153,9 +153,8 @@ export async function discoverLANServers(): Promise<DiscoveredServer[]> {
     if (!base) {
       logger.warn('[Discovery] IP is not on a private network:', ip, '— skipping LAN scan');
       return [];
-    } else {
-      subnetsToScan = [base];
     }
+    subnetsToScan = [base];
   }
 
   logger.log('[Discovery] Scanning subnets:', subnetsToScan.map(s => `${s}.0/24`).join(', '));


### PR DESCRIPTION
## Summary

LAN auto-discovery was slow/hanging when not on WiFi — it would scan 1000+ IPs that all timeout. This PR:
- Returns `[]` immediately when device has no private IPv4 (cellular/no WiFi)
- Quick-probes gateway IPs (~800ms) before committing to a full subnet scan when on IPv6
- Fixes `no-else-return` lint error introduced in the main commit
- Delays LAN discovery 3 seconds after home screen renders so UI is fully interactive first

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots / Screen Recordings

No UI changes — this is a timing/network logic fix.

## Checklist

### General

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have added/updated comments where the logic isn't self-evident
- [x] My changes generate no new warnings or errors

### Testing

- [ ] I have tested on **Android** (physical device or emulator)
- [ ] I have tested on **iOS** (physical device or simulator)
- [ ] I have tested in **light mode** and **dark mode**
- [x] Existing tests pass locally (`npm test`)
- [ ] I have added tests that prove my fix is effective or my feature works

### React Native Specific

- [x] No new native module without corresponding platform implementation (Android + iOS)
- [x] No hardcoded pixel values — uses `SPACING` / `TYPOGRAPHY` constants from the theme
- [x] No unnecessary re-renders introduced

### Security

- [x] No secrets, API keys, or credentials are included in the code
- [x] User input is validated/sanitized where applicable

## Additional Notes

The main WiFi-skip logic was pushed directly to main in commit 56790cf. This PR adds the lint fix and the 3s startup delay.