### PR TITLE
fix: remove async from void onPress callback (SonarCloud bug)

### DIFF
--- a/src/screens/RemoteServersScreen.tsx
+++ b/src/screens/RemoteServersScreen.tsx
@@ -106,7 +106,9 @@ export const RemoteServersScreen: React.FC = () => {
           style: 'destructive',
           onPress: () => {
             if (activeServerId === server.id) setActiveServerId(null);
-            remoteServerManager.removeServer(server.id);
+            remoteServerManager.removeServer(server.id).catch(error =>
+              setAlertState(showAlert('Deletion Failed', error instanceof Error ? error.message : 'An unknown error occurred.'))
+            );
           },
         },
       ]

--- a/src/screens/RemoteServersScreen.tsx
+++ b/src/screens/RemoteServersScreen.tsx
@@ -104,9 +104,9 @@ export const RemoteServersScreen: React.FC = () => {
         {
           text: 'Delete',
           style: 'destructive',
-          onPress: async () => {
+          onPress: () => {
             if (activeServerId === server.id) setActiveServerId(null);
-            await remoteServerManager.removeServer(server.id);
+            remoteServerManager.removeServer(server.id);
           },
         },
       ]


### PR DESCRIPTION
## Summary
- Removes `async`/`await` from the delete server `onPress` callback in `RemoteServersScreen`
- SonarCloud flagged this as a bug: Promise-returning function provided where `() => void` was expected
- `removeServer` is fire-and-forget in this context, so dropping async is safe

## Test plan
- [x] All JS/TS tests pass
- [x] Android unit tests pass
- [x] iOS unit tests pass
- [ ] Verify SonarCloud quality gate passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)