### PR TITLE
feat: add SmolVLM2 500M and SmolLM2 360M for ≤6GB devices

### DIFF
--- a/src/constants/models.ts
+++ b/src/constants/models.ts
@@ -91,6 +91,27 @@ export const RECOMMENDED_MODELS = [
     type: 'text' as const,
     org: 'mistralai',
   },
+  // --- Low-RAM only (≤ 6 GB) ---
+  {
+    id: 'ggml-org/SmolVLM2-500M-Video-Instruct-GGUF',
+    name: 'SmolVLM2 500M',
+    params: 0.5,
+    description: 'Tiny vision + video model for constrained devices',
+    minRam: 3,
+    maxRam: 6,
+    type: 'vision' as const,
+    org: 'HuggingFaceTB',
+  },
+  {
+    id: 'QuantFactory/SmolLM2-360M-Instruct-GGUF',
+    name: 'SmolLM2 360M',
+    params: 0.36,
+    description: 'Ultra-light language model for low-RAM devices',
+    minRam: 3,
+    maxRam: 6,
+    type: 'text' as const,
+    org: 'HuggingFaceTB',
+  },
   // --- Vision ---
   {
     id: 'ggml-org/SmolVLM-Instruct-GGUF',

--- a/src/screens/ModelDownloadScreen.tsx
+++ b/src/screens/ModelDownloadScreen.tsx
@@ -47,7 +47,7 @@ const RecommendedModelCard: React.FC<RecommendedCardProps> = ({ model, recFile, 
     isDownloaded={!!downloaded}
     isDownloading={!!progress}
     downloadProgress={progress?.progress}
-    isCompatible={model.minRam <= totalRamGB}
+    isCompatible={model.minRam <= totalRamGB && (!model.maxRam || totalRamGB <= model.maxRam)}
     isTrending={isTrending}
     onPress={() => {}}
     onDownload={downloaded ? undefined : onDownload}
@@ -91,7 +91,7 @@ export const ModelDownloadScreen: React.FC<Props> = ({ navigation }) => {
         if (cancelled) return;
         setModelRecommendation(rec);
         const ram = hardwareService.getTotalMemoryGB();
-        const compat = RECOMMENDED_MODELS.filter((m) => m.minRam <= ram);
+        const compat = RECOMMENDED_MODELS.filter((m) => m.minRam <= ram && (!m.maxRam || ram <= m.maxRam));
         if (cancelled) return;
         setRecommendedModels(compat);
         const files = await fetchModelFiles(compat);
@@ -230,7 +230,7 @@ export const ModelDownloadScreen: React.FC<Props> = ({ navigation }) => {
     const ids = new Set<string>();
     for (const familyIds of Object.values(TRENDING_FAMILIES)) {
       const best = RECOMMENDED_MODELS
-        .filter(m => familyIds.includes(m.id) && m.minRam <= totalRamGB)
+        .filter(m => familyIds.includes(m.id) && m.minRam <= totalRamGB && (!m.maxRam || totalRamGB <= m.maxRam))
         .sort((a, b) => score(a) - score(b))[0];
       if (best) ids.add(best.id);
     }

--- a/src/screens/ModelsScreen/useTextModels.ts
+++ b/src/screens/ModelsScreen/useTextModels.ts
@@ -293,7 +293,7 @@ export function useTextModels(setAlertState: (s: AlertState) => void) {
   const recommendedAsModelInfo = useMemo((): ModelInfo[] => {
     const maxParams = deviceRecommendation.maxParameters;
     const models = RECOMMENDED_MODELS
-      .filter(m => m.params <= maxParams)
+      .filter(m => m.params <= maxParams && (!m.maxRam || ramGB <= m.maxRam))
       .filter(m => {
         if (filterState.type !== 'all' && m.type !== filterState.type) return false;
         if (filterState.orgs.length > 0 && !filterState.orgs.includes(m.org)) return false;
@@ -312,7 +312,7 @@ export function useTextModels(setAlertState: (s: AlertState) => void) {
     // Pick the best-fit per family using the same bestFitScore used for "for you" recommendations
     return Object.values(TRENDING_FAMILIES)
       .map(ids => RECOMMENDED_MODELS
-        .filter(m => ids.includes(m.id) && m.params <= maxParams)
+        .filter(m => ids.includes(m.id) && m.params <= maxParams && (!m.maxRam || ramGB <= m.maxRam))
         .map(m => mapCuratedModel(m, recommendedModelDetails))
         .sort((a, b) => bestFitScore(a, ramGB) - bestFitScore(b, ramGB))[0])
       .filter((m): m is ModelInfo => Boolean(m));


### PR DESCRIPTION
## Summary
- Adds SmolVLM2 500M (vision+video) and SmolLM2 360M (text) to recommended models
- New `maxRam` field gates them to devices with ≤6GB RAM only
- Filtering applied in onboarding, models screen, and trending selection

## Test plan
- [x] TypeScript compiles clean
- [x] All 58 related tests pass
- [ ] Verify models appear on 4GB device
- [ ] Verify models hidden on 12GB device