### PR TITLE
feat(android): switch model downloads to WorkManager + OkHttp

### DIFF
--- a/__tests__/rntl/screens/DownloadManagerScreen.test.tsx
+++ b/__tests__/rntl/screens/DownloadManagerScreen.test.tsx
@@ -407,7 +407,7 @@ describe('DownloadManagerScreen', () => {
     });
 
     const { getByText } = render(<DownloadManagerScreen />);
-    expect(getByText('downloading')).toBeTruthy();
+    expect(getByText('Downloading...')).toBeTruthy();
   });
 
   it('does not show storage section when no completed models', () => {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
+apply plugin: "org.jetbrains.kotlin.kapt"
 apply plugin: "com.facebook.react"
 apply from: file("../../node_modules/react-native-vector-icons/fonts.gradle")
 
@@ -155,6 +156,15 @@ dependencies {
 
     // PDF text extraction (used by PDFExtractorModule)
     implementation("io.legere:pdfiumandroid:1.0.35")
+
+    // Download layer — mirrors PocketPal's dependency set
+    def room_version = "2.8.2"
+    implementation("androidx.room:room-runtime:$room_version")
+    implementation("androidx.room:room-ktx:$room_version")
+    kapt("androidx.room:room-compiler:$room_version")
+    implementation("androidx.work:work-runtime-ktx:2.10.0")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.7")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.robolectric:robolectric:4.13")

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -157,7 +157,7 @@ dependencies {
     // PDF text extraction (used by PDFExtractorModule)
     implementation("io.legere:pdfiumandroid:1.0.35")
 
-    // Download layer — mirrors PocketPal's dependency set
+    // Download layer — Room + WorkManager + OkHttp
     def room_version = "2.8.2"
     implementation("androidx.room:room-runtime:$room_version")
     implementation("androidx.room:room-ktx:$room_version")

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadDao.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadDao.kt
@@ -1,0 +1,29 @@
+package ai.offgridmobile.download
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface DownloadDao {
+    @Query("SELECT * FROM downloads")
+    fun getAllDownloads(): Flow<List<DownloadEntity>>
+
+    @Query("SELECT * FROM downloads WHERE id = :downloadId")
+    suspend fun getDownload(downloadId: Long): DownloadEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertDownload(download: DownloadEntity)
+
+    @Delete
+    suspend fun deleteDownload(download: DownloadEntity)
+
+    @Query("UPDATE downloads SET downloadedBytes = :bytes, totalBytes = :totalBytes, status = :status WHERE id = :downloadId")
+    suspend fun updateProgress(downloadId: Long, bytes: Long, totalBytes: Long, status: DownloadStatus)
+
+    @Query("UPDATE downloads SET status = :status, error = :error WHERE id = :downloadId")
+    suspend fun updateStatus(downloadId: Long, status: DownloadStatus, error: String? = null)
+}

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadDatabase.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadDatabase.kt
@@ -1,0 +1,32 @@
+package ai.offgridmobile.download
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [DownloadEntity::class],
+    version = 1,
+    exportSchema = false,
+)
+abstract class DownloadDatabase : RoomDatabase() {
+    abstract fun downloadDao(): DownloadDao
+
+    companion object {
+        private const val DATABASE_NAME = "downloads.db"
+
+        @Volatile
+        private var INSTANCE: DownloadDatabase? = null
+
+        fun getInstance(context: Context): DownloadDatabase {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    DownloadDatabase::class.java,
+                    DATABASE_NAME,
+                ).build().also { INSTANCE = it }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadDatabase.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadDatabase.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [DownloadEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = false,
 )
 abstract class DownloadDatabase : RoomDatabase() {
@@ -19,13 +21,19 @@ abstract class DownloadDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: DownloadDatabase? = null
 
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE downloads ADD COLUMN expectedSha256 TEXT")
+            }
+        }
+
         fun getInstance(context: Context): DownloadDatabase {
             return INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Room.databaseBuilder(
                     context.applicationContext,
                     DownloadDatabase::class.java,
                     DATABASE_NAME,
-                ).build().also { INSTANCE = it }
+                ).addMigrations(MIGRATION_1_2).build().also { INSTANCE = it }
             }
         }
     }

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadEntity.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadEntity.kt
@@ -1,0 +1,24 @@
+package ai.offgridmobile.download
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "downloads")
+data class DownloadEntity(
+    @PrimaryKey
+    val id: Long,
+    val url: String,
+    val fileName: String,
+    val modelId: String,
+    val title: String,
+    val destination: String,
+    val totalBytes: Long,
+    val downloadedBytes: Long,
+    val status: DownloadStatus,
+    val createdAt: Long,
+    val error: String? = null,
+)
+
+enum class DownloadStatus {
+    QUEUED, RUNNING, PAUSED, COMPLETED, FAILED, CANCELLED
+}

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadEntity.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadEntity.kt
@@ -17,6 +17,7 @@ data class DownloadEntity(
     val status: DownloadStatus,
     val createdAt: Long,
     val error: String? = null,
+    val expectedSha256: String? = null,
 )
 
 enum class DownloadStatus {

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadEventBridge.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadEventBridge.kt
@@ -1,0 +1,87 @@
+package ai.offgridmobile.download
+
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import java.lang.ref.WeakReference
+
+object DownloadEventBridge {
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var reactContextRef: WeakReference<ReactApplicationContext>? = null
+
+    fun attach(reactContext: ReactApplicationContext) {
+        reactContextRef = WeakReference(reactContext)
+        log("I", "[Bridge] React context attached")
+    }
+
+    fun log(level: String, msg: String) {
+        when (level) {
+            "E" -> Log.e("DownloadBridge", msg)
+            "W" -> Log.w("DownloadBridge", msg)
+            "I" -> Log.i("DownloadBridge", msg)
+            else -> Log.d("DownloadBridge", msg)
+        }
+        emit("DownloadLog") {
+            putString("level", level)
+            putString("msg", msg)
+            putDouble("ts", System.currentTimeMillis().toDouble())
+        }
+    }
+
+    fun progress(
+        downloadId: Long,
+        fileName: String,
+        modelId: String,
+        bytesDownloaded: Long,
+        totalBytes: Long,
+        status: String,
+        reason: String? = null,
+    ) {
+        emit("DownloadProgress") {
+            putDouble("downloadId", downloadId.toDouble())
+            putString("fileName", fileName)
+            putString("modelId", modelId)
+            putDouble("bytesDownloaded", bytesDownloaded.toDouble())
+            putDouble("totalBytes", totalBytes.toDouble())
+            putString("status", status)
+            putString("reason", reason ?: "")
+            putDouble("percent", if (totalBytes > 0) (bytesDownloaded.toDouble() / totalBytes.toDouble()) * 100.0 else 0.0)
+        }
+    }
+
+    fun complete(downloadId: Long, fileName: String, modelId: String, localUri: String, bytesDownloaded: Long, totalBytes: Long) {
+        emit("DownloadComplete") {
+            putDouble("downloadId", downloadId.toDouble())
+            putString("fileName", fileName)
+            putString("modelId", modelId)
+            putDouble("bytesDownloaded", bytesDownloaded.toDouble())
+            putDouble("totalBytes", totalBytes.toDouble())
+            putString("status", "completed")
+            putString("localUri", localUri)
+        }
+    }
+
+    fun error(downloadId: Long, fileName: String, modelId: String, reason: String, status: String = "failed") {
+        emit("DownloadError") {
+            putDouble("downloadId", downloadId.toDouble())
+            putString("fileName", fileName)
+            putString("modelId", modelId)
+            putString("reason", reason)
+            putString("status", status)
+        }
+    }
+
+    private inline fun emit(eventName: String, crossinline build: com.facebook.react.bridge.WritableMap.() -> Unit) {
+        val reactContext = reactContextRef?.get() ?: return
+        if (!reactContext.hasActiveReactInstance()) return
+        mainHandler.post {
+            val map = Arguments.createMap().apply(build)
+            reactContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+                .emit(eventName, map)
+        }
+    }
+}

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadEventBridge.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadEventBridge.kt
@@ -74,6 +74,17 @@ object DownloadEventBridge {
         }
     }
 
+    fun retrying(downloadId: Long, fileName: String, modelId: String, reason: String, attempt: Int) {
+        emit("DownloadRetrying") {
+            putDouble("downloadId", downloadId.toDouble())
+            putString("fileName", fileName)
+            putString("modelId", modelId)
+            putString("reason", reason)
+            putInt("attempt", attempt)
+            putString("status", "retrying")
+        }
+    }
+
     private inline fun emit(eventName: String, crossinline build: com.facebook.react.bridge.WritableMap.() -> Unit) {
         val reactContext = reactContextRef?.get() ?: return
         if (!reactContext.hasActiveReactInstance()) return

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -160,7 +160,12 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
                     downloadDao.updateStatus(id, DownloadStatus.QUEUED)
                     // Only re-enqueue if WorkManager has no live work for this id
                     val workName = WorkerDownload.workName(id)
-                    val workInfo = workManager.getWorkInfosForUniqueWork(workName).get().firstOrNull()
+                    val workInfos = try {
+                        workManager.getWorkInfosForUniqueWork(workName).get()
+                    } catch (_: Exception) {
+                        null
+                    }
+                    val workInfo = workInfos?.firstOrNull()
                     if (workInfo == null || workInfo.state.isFinished) {
                         WorkerDownload.enqueue(reactApplicationContext, id)
                     }
@@ -443,5 +448,16 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
 
     companion object {
         const val NAME = "DownloadManagerModule"
+
+        // Legacy SharedPreferences constants — retained so WorkerDownloadStore compiles
+        // during the transition period while both download paths coexist.
+        const val PREFS_NAME = "OffgridMobileDownloads"
+        const val DOWNLOADS_KEY = "active_downloads"
+        const val STATUS_PENDING = "pending"
+        const val STATUS_RUNNING = "running"
+        const val STATUS_PAUSED = "paused"
+        const val STATUS_COMPLETED = "completed"
+        const val STATUS_FAILED = "failed"
+        const val STATUS_UNKNOWN = "unknown"
     }
 }

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -1,693 +1,336 @@
 package ai.offgridmobile.download
 
-import android.app.DownloadManager
 import android.content.Context
 import android.content.Intent
-import android.content.SharedPreferences
-import android.database.Cursor
-import android.net.ConnectivityManager
-import android.net.Network
-import android.net.NetworkCapabilities
-import android.net.NetworkRequest
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
-import android.os.Handler
-import android.os.Looper
 import android.os.PowerManager
 import android.provider.Settings
-import com.facebook.react.bridge.*
-import com.facebook.react.modules.core.DeviceEventManagerModule
-import org.json.JSONArray
-import org.json.JSONObject
+import androidx.lifecycle.Observer
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
-import java.net.HttpURLConnection
-import java.net.URL
-import ai.offgridmobile.SafePromise
-import java.util.concurrent.Executors
-
 
 class DownloadManagerModule(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val downloadDao = DownloadDatabase.getInstance(reactContext).downloadDao()
+    private val workManager = WorkManager.getInstance(reactContext)
+
+    // LiveData observers keyed by downloadId — same pattern as PocketPal
+    private val workObservers = mutableMapOf<Long, Observer<List<WorkInfo>>>()
 
     init {
         DownloadEventBridge.attach(reactContext)
     }
 
-    private fun safeReject(promise: Promise, code: String, message: String, throwable: Throwable? = null) =
-        SafePromise(promise, NAME).reject(code, message, throwable)
-
-    private fun safeResolve(promise: Promise, value: Any?) =
-        SafePromise(promise, NAME).resolve(value)
-
-    companion object {
-        const val NAME = "DownloadManagerModule"
-        const val PREFS_NAME = "OffgridMobileDownloads"
-        const val DOWNLOADS_KEY = "active_downloads"
-        private const val POLL_INTERVAL_MS = 500L
-        internal const val WATCHDOG_INTERVAL_MS = 15_000L  // Check every 15 seconds
-        internal const val STUCK_THRESHOLD = 3             // 3 × 15s = 45 seconds of zero progress after first byte
-        internal const val STARTUP_TIMEOUT_POLLS = 8       // 8 × 15s = 2 minutes waiting for first byte before giving up
-        internal const val MAX_RETRY_ATTEMPTS = 3          // give up after 3 retries
-
-        internal const val STATUS_PENDING = "pending"
-        internal const val STATUS_RUNNING = "running"
-        internal const val STATUS_PAUSED = "paused"
-        internal const val STATUS_COMPLETED = "completed"
-        internal const val STATUS_FAILED = "failed"
-        internal const val STATUS_UNKNOWN = "unknown"
-
-        internal fun statusToString(status: Int): String = when (status) {
-            DownloadManager.STATUS_PENDING -> STATUS_PENDING
-            DownloadManager.STATUS_RUNNING -> STATUS_RUNNING
-            DownloadManager.STATUS_PAUSED -> STATUS_PAUSED
-            DownloadManager.STATUS_SUCCESSFUL -> STATUS_COMPLETED
-            DownloadManager.STATUS_FAILED -> STATUS_FAILED
-            else -> STATUS_UNKNOWN
-        }
-
-        internal fun reasonToString(status: Int, reason: Int): String {
-            if (status == DownloadManager.STATUS_PAUSED) {
-                return when (reason) {
-                    DownloadManager.PAUSED_QUEUED_FOR_WIFI -> "Waiting for WiFi"
-                    DownloadManager.PAUSED_WAITING_FOR_NETWORK -> "Waiting for network"
-                    DownloadManager.PAUSED_WAITING_TO_RETRY -> "Waiting to retry"
-                    else -> "Paused"
-                }
-            }
-            if (status == DownloadManager.STATUS_FAILED) {
-                return when (reason) {
-                    DownloadManager.ERROR_CANNOT_RESUME -> "Cannot resume"
-                    DownloadManager.ERROR_DEVICE_NOT_FOUND -> "Device not found"
-                    DownloadManager.ERROR_FILE_ALREADY_EXISTS -> "File already exists"
-                    DownloadManager.ERROR_FILE_ERROR -> "File error"
-                    DownloadManager.ERROR_HTTP_DATA_ERROR -> "HTTP data error"
-                    DownloadManager.ERROR_INSUFFICIENT_SPACE -> "Insufficient space"
-                    DownloadManager.ERROR_TOO_MANY_REDIRECTS -> "Too many redirects"
-                    DownloadManager.ERROR_UNHANDLED_HTTP_CODE -> "Unhandled HTTP code"
-                    DownloadManager.ERROR_UNKNOWN -> "Unknown error"
-                    else -> "Error: $reason"
-                }
-            }
-            return ""
-        }
-
-        /**
-         * Returns true if the given download entry should be pruned from the persisted list.
-         *
-         * A download is removed when:
-         * - [liveStatus] is "unknown" (DownloadManager no longer tracks it), OR
-         * - its stored status is "completed", the JS side has confirmed the move by
-         *   setting "moveCompleted" to true, and it's been at least 5 seconds since.
-         *
-         * Time-based removal alone is wrong — the JS side may not call
-         * moveCompletedDownload for minutes (phone sleeping, app backgrounded).
-         * Only moveCompletedDownload (or explicit cleanup) should remove entries.
-         *
-         * The [currentTimeMs] parameter is injectable so tests can control the clock.
-         */
-        /**
-         * Returns true if all persisted downloads are in a terminal state
-         * (completed, failed, or unknown) — i.e., no download is pending,
-         * running, or paused. Used to decide when to stop the foreground service.
-         */
-        private val ACTIVE_STATUSES = setOf(STATUS_PENDING, STATUS_RUNNING, STATUS_PAUSED)
-
-        internal fun hasNoActiveDownloads(downloads: JSONArray): Boolean {
-            for (i in 0 until downloads.length()) {
-                val status = downloads.getJSONObject(i).optString("status", STATUS_PENDING)
-                if (status in ACTIVE_STATUSES) return false
-            }
-            return true
-        }
-
-        internal fun shouldRemoveDownload(
-            download: JSONObject,
-            liveStatus: String,
-            currentTimeMs: Long = System.currentTimeMillis(),
-        ): Boolean {
-            if (liveStatus == STATUS_UNKNOWN) return true
-            if (download.optString("status", STATUS_PENDING) == STATUS_COMPLETED) {
-                val moveCompleted = download.optBoolean("moveCompleted", false)
-                if (moveCompleted) {
-                    val completedAt = download.optLong("completedAt", 0L)
-                    val ageMs = currentTimeMs - completedAt
-                    return completedAt > 0 && ageMs > 5_000
-                }
-            }
-            return false
-        }
-
-        internal fun evaluateStuckProgress(track: BytesTrack, currentBytes: Long): StuckAction {
-            val bytesDelta = currentBytes - track.lastBytes
-            if (bytesDelta > 0) {
-                // Progress made — reset stuck counter
-                return StuckAction.ResetCounter(BytesTrack(currentBytes, 0, track.retryCount))
-            }
-
-            val newCount = track.unchangedCount + 1
-
-            if (track.lastBytes == 0L && currentBytes == 0L) {
-                // Download hasn't received its first byte yet (still connecting / CDN handshake).
-                // Wait up to STARTUP_TIMEOUT_POLLS before giving up — no auto-retry, let the user decide.
-                if (newCount >= STARTUP_TIMEOUT_POLLS) return StuckAction.StartupTimeout
-                return StuckAction.IncrementCounter(BytesTrack(0L, newCount, track.retryCount))
-            }
-
-            // Was downloading but has now frozen — use the shorter stuck threshold
-            if (newCount >= STUCK_THRESHOLD) {
-                if (track.retryCount >= MAX_RETRY_ATTEMPTS) return StuckAction.GiveUp
-                return StuckAction.Retry(track.retryCount + 1)
-            }
-            return StuckAction.IncrementCounter(BytesTrack(track.lastBytes, newCount, track.retryCount))
-        }
-    }
-
-    /** Tracks byte progress for a single download across watchdog poll intervals. */
-    internal data class BytesTrack(val lastBytes: Long, val unchangedCount: Int, val retryCount: Int = 0)
-
-    /**
-     * Result of [evaluateStuckProgress] — tells the watchdog what to do next.
-     *
-     * - [ResetCounter] — progress was made, reset the stuck counter
-     * - [IncrementCounter] — no progress, increment counter (not stuck yet)
-     * - [Retry] — stuck threshold reached, retry the download
-     * - [GiveUp] — max retries exhausted, give up
-     */
-    internal sealed class StuckAction {
-        data class ResetCounter(val newTrack: BytesTrack) : StuckAction()
-        data class IncrementCounter(val newTrack: BytesTrack) : StuckAction()
-        data class Retry(val retryCount: Int) : StuckAction()
-        object GiveUp : StuckAction()
-        object StartupTimeout : StuckAction() // never received first byte — let user retry
-    }
-
-    private val executor = Executors.newSingleThreadExecutor()
-
-    private val allowedDownloadHosts = setOf(
-        "huggingface.co",
-        "cdn-lfs.huggingface.co",
-        "cas-bridge.xethub.hf.co",
-    )
-
-    private val downloadManager: DownloadManager by lazy {
-        reactApplicationContext.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-    }
-
-    private val sharedPrefs: SharedPreferences by lazy {
-        reactApplicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    }
-
-    // --- Progress polling (500ms) ---
-    private val handler = Handler(Looper.getMainLooper())
-    private var isPolling = false
-    private val pollRunnable = object : Runnable {
-        override fun run() {
-            if (isPolling) {
-                pollWorkerDownloads()
-                pollAllDownloads()
-                handler.postDelayed(this, POLL_INTERVAL_MS)
-            }
-        }
-    }
-
-    // --- Stuck-download watchdog ---
-    private val watchdogHandler = Handler(Looper.getMainLooper())
-    private val downloadBytesTracker = mutableMapOf<Long, BytesTrack>()
-
-    private val watchdogRunnable = object : Runnable {
-        override fun run() {
-            if (isPolling && networkAvailable) {
-                checkForStuckDownloads()
-            }
-            if (isPolling) {
-                watchdogHandler.postDelayed(this, WATCHDOG_INTERVAL_MS)
-            }
-        }
-    }
-
-    // --- Network connectivity ---
-    @Volatile private var networkAvailable = true
-    private var networkCallbackRegistered = false
-    private val useWorkerDownloader = true
-
-    private val networkCallback = object : ConnectivityManager.NetworkCallback() {
-        override fun onAvailable(network: Network) {
-            android.util.Log.d("DownloadService", "Network available - checking download status")
-            networkAvailable = true
-            handler.post { checkNetworkRestored() }
-        }
-
-        override fun onLost(network: Network) {
-            android.util.Log.d("DownloadService", "Network lost - download paused")
-            networkAvailable = false
-        }
-    }
-
     override fun getName(): String = NAME
 
     override fun onCatalystInstanceDestroy() {
+        workObservers.keys.toList().forEach { removeWorkObserver(it) }
+        workObservers.clear()
         super.onCatalystInstanceDestroy()
-        isPolling = false
-        handler.removeCallbacks(pollRunnable)
-        watchdogHandler.removeCallbacksAndMessages(null) // clears watchdog + any pending retry postDelayed callbacks
-        unregisterNetworkCallback()
-        if (!executor.isShutdown) {
-            executor.shutdown()
-        }
+        scope.cancel()
     }
+
+    // -------------------------------------------------------------------------
+    // React methods
+    // -------------------------------------------------------------------------
 
     @ReactMethod
     fun startDownload(params: ReadableMap, promise: Promise) {
-        val url = params.getString("url") ?: run {
-            safeReject(promise, "DOWNLOAD_ERROR", "URL is required")
-            return
-        }
-        val fileName = params.getString("fileName")?.let { File(it).name } ?: run {
-            safeReject(promise, "DOWNLOAD_ERROR", "fileName is required")
-            return
-        }
-        val title = params.getString("title") ?: fileName
-        val description = params.getString("description") ?: "Downloading model..."
-        val modelId = params.getString("modelId") ?: ""
-        val totalBytes = if (params.hasKey("totalBytes")) params.getDouble("totalBytes").toLong() else 0L
-        val hideNotification = params.hasKey("hideNotification") && params.getBoolean("hideNotification")
-
-        // Validate URL against allowed download hosts to prevent SSRF
-        val parsedHost = try { URL(url).host } catch (_: Exception) { null }
-        if (parsedHost == null || !allowedDownloadHosts.any { parsedHost == it || parsedHost.endsWith(".$it") }) {
-            safeReject(promise, "DOWNLOAD_ERROR", "Download URL host not allowed: $parsedHost")
-            return
-        }
-
-        if (useWorkerDownloader && tryStartWorkerDownload(url, fileName, modelId, title, description, totalBytes, promise)) {
-            return
-        }
-
-        // Resolve redirects on a background thread (network I/O)
-        executor.execute {
+        scope.launch {
             try {
-                // Clean up any existing file with the same name to prevent DownloadManager
-                // from auto-renaming (e.g., file.gguf → file-1.gguf)
-                val existingFile = File(
+                val url = params.getString("url")
+                    ?: return@launch SafePromise(promise, NAME).reject("DOWNLOAD_ERROR", "URL is required")
+                val fileName = params.getString("fileName")?.let { File(it).name }
+                    ?: return@launch SafePromise(promise, NAME).reject("DOWNLOAD_ERROR", "fileName is required")
+
+                // SSRF: validate host against allowlist
+                if (!WorkerDownload.isHostAllowed(url)) {
+                    return@launch SafePromise(promise, NAME).reject("DOWNLOAD_ERROR", "Download URL host not allowed")
+                }
+
+                val modelId = params.getString("modelId") ?: ""
+                val title = params.getString("title") ?: fileName
+                val totalBytes = if (params.hasKey("totalBytes")) params.getDouble("totalBytes").toLong() else 0L
+
+                val downloadId = System.currentTimeMillis()
+                val destination = File(
                     reactApplicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-                    fileName
+                    fileName,
+                ).absolutePath
+
+                val entity = DownloadEntity(
+                    id = downloadId,
+                    url = url,
+                    fileName = fileName,
+                    modelId = modelId,
+                    title = title,
+                    destination = destination,
+                    totalBytes = totalBytes,
+                    downloadedBytes = 0L,
+                    status = DownloadStatus.QUEUED,
+                    createdAt = System.currentTimeMillis(),
                 )
-                if (existingFile.exists()) {
-                    android.util.Log.d("DownloadService", "Deleting existing file before download: ${existingFile.absolutePath}")
-                    existingFile.delete()
+
+                withContext(Dispatchers.IO) {
+                    downloadDao.insertDownload(entity)
                 }
 
-                // Also clean up any stale entries from previous sessions
-                cleanupStaleDownloads()
+                DownloadEventBridge.log("I", "[Module] startDownload id=$downloadId file=$fileName model=$modelId")
 
-                // Pre-resolve redirects so DownloadManager gets the final CDN URL directly.
-                // HuggingFace returns a 302 redirect to a long signed CDN URL (~1350 chars)
-                // that some OEM DownloadManager implementations fail to follow silently.
-                val resolvedUrl = resolveRedirects(url)
-                android.util.Log.d("DownloadService", "Resolved URL: ${resolvedUrl.take(120)}...")
-
-                val request = DownloadManager.Request(Uri.parse(resolvedUrl))
-                    .setTitle(title)
-                    .setDescription(description)
-                    .setNotificationVisibility(
-                        if (hideNotification) DownloadManager.Request.VISIBILITY_HIDDEN
-                        else DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED
-                    )
-                    .setDestinationInExternalFilesDir(
-                        reactApplicationContext,
-                        Environment.DIRECTORY_DOWNLOADS,
-                        fileName
-                    )
-                    .setAllowedOverMetered(true)
-                    .setAllowedOverRoaming(true)
-
-                val downloadId = downloadManager.enqueue(request)
-                android.util.Log.d("DownloadService", "Download enqueued - id: $downloadId | file: $fileName")
-
-                // Start foreground service to prevent Android from throttling the download
-                try {
-                    DownloadForegroundService.start(reactApplicationContext, title, downloadId)
-                } catch (e: Exception) {
-                    android.util.Log.w("DownloadService", "Failed to start foreground service (non-fatal)", e)
-                }
-
-                // Persist download info
-                val downloadInfo = JSONObject().apply {
-                    put("downloadId", downloadId)
-                    put("url", url)
-                    put("fileName", fileName)
-                    put("modelId", modelId)
-                    put("title", title)
-                    put("totalBytes", totalBytes)
-                    put("status", STATUS_PENDING)
-                    put("startedAt", System.currentTimeMillis())
-                }
-                persistDownload(downloadId, downloadInfo)
+                registerObserver(downloadId)
+                WorkerDownload.enqueue(reactApplicationContext, downloadId)
 
                 val result = Arguments.createMap().apply {
                     putDouble("downloadId", downloadId.toDouble())
                     putString("fileName", fileName)
                     putString("modelId", modelId)
                 }
-                safeResolve(promise, result)
+                SafePromise(promise, NAME).resolve(result)
             } catch (e: Exception) {
-                safeReject(promise, "DOWNLOAD_ERROR", "Failed to start download: ${e.message}", e)
+                SafePromise(promise, NAME).reject("DOWNLOAD_ERROR", "Failed to start download: ${e.message}", e)
             }
-        }
-    }
-
-    /**
-     * Attempts to start a download via WorkManager. Returns true on success (promise resolved),
-     * false if it fails (caller should fall back to the legacy DownloadManager path).
-     */
-    private fun tryStartWorkerDownload(
-        url: String,
-        fileName: String,
-        modelId: String,
-        title: String,
-        description: String,
-        totalBytes: Long,
-        promise: Promise,
-    ): Boolean {
-        return try {
-            val downloadId = System.currentTimeMillis()
-            val downloadInfo = JSONObject().apply {
-                put("downloadId", downloadId)
-                put("url", url)
-                put("fileName", fileName)
-                put("modelId", modelId)
-                put("title", title)
-                put("description", description)
-                put("totalBytes", totalBytes)
-                put("bytesDownloaded", 0)
-                put("status", WorkerDownloadStore.STATUS_PENDING)
-                put("startedAt", System.currentTimeMillis())
-                put("backend", "worker")
-                put("localUri", Uri.fromFile(File(
-                    reactApplicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-                    fileName
-                )).toString())
-            }
-            WorkerDownloadStore.put(reactApplicationContext, downloadInfo)
-            DownloadEventBridge.log("I", "[Module] startDownload routed to worker id=$downloadId file=$fileName model=$modelId")
-            WorkerDownload.enqueue(
-                reactApplicationContext,
-                downloadId,
-                url,
-                fileName,
-                modelId,
-                title,
-                totalBytes,
-            )
-            val result = Arguments.createMap().apply {
-                putDouble("downloadId", downloadId.toDouble())
-                putString("fileName", fileName)
-                putString("modelId", modelId)
-            }
-            safeResolve(promise, result)
-            true
-        } catch (e: Exception) {
-            DownloadEventBridge.log("E", "[Module] worker start failed, falling back to legacy: ${e.message}")
-            false
         }
     }
 
     @ReactMethod
     fun cancelDownload(downloadId: Double, promise: Promise) {
-        try {
-            val id = downloadId.toLong()
-            val workerInfo = WorkerDownloadStore.get(reactApplicationContext, id)
-            if (workerInfo != null) {
-                DownloadEventBridge.log("W", "[Module] Cancelling worker download id=$id")
+        scope.launch {
+            try {
+                val id = downloadId.toLong()
+                withContext(Dispatchers.IO) {
+                    val download = downloadDao.getDownload(id)
+                    if (download != null) {
+                        downloadDao.updateStatus(id, DownloadStatus.CANCELLED, "Download cancelled by user")
+                        val file = File(download.destination)
+                        if (file.exists()) file.delete()
+                    }
+                }
                 WorkerDownload.cancel(reactApplicationContext, id)
-                workerInfo.optString("fileName")?.let { fileName ->
-                    val file = File(
-                        reactApplicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-                        fileName
-                    )
-                    if (file.exists()) file.delete()
-                }
-                WorkerDownloadStore.remove(reactApplicationContext, id)
-                WorkerDownloadStore.stopForegroundServiceIfIdle(reactApplicationContext, "worker cancelled")
-                safeResolve(promise, true)
-                return
+                workManager.pruneWork()
+                removeWorkObserver(id)
+                DownloadEventBridge.log("I", "[Module] cancelDownload id=$id")
+                SafePromise(promise, NAME).resolve(true)
+            } catch (e: Exception) {
+                SafePromise(promise, NAME).reject("CANCEL_ERROR", "Failed to cancel download: ${e.message}", e)
             }
-            android.util.Log.d("DownloadService", "Cancelling download - id: $id")
+        }
+    }
 
-            // Get download info BEFORE removing from SharedPreferences
-            val downloadInfo = getDownloadInfo(id)
-
-            downloadManager.remove(id)
-            removeDownload(id)
-            handler.post { downloadBytesTracker.remove(id) }
-
-            // Clean up partial file
-            downloadInfo?.optString("fileName")?.let { fileName ->
-                val file = File(
-                    reactApplicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-                    fileName
-                )
-                if (file.exists()) {
-                    file.delete()
+    @ReactMethod
+    fun pauseDownload(downloadId: Double, promise: Promise) {
+        scope.launch {
+            try {
+                val id = downloadId.toLong()
+                withContext(Dispatchers.IO) {
+                    downloadDao.updateStatus(id, DownloadStatus.PAUSED)
                 }
+                DownloadEventBridge.log("I", "[Module] pauseDownload id=$id")
+                SafePromise(promise, NAME).resolve(true)
+            } catch (e: Exception) {
+                SafePromise(promise, NAME).reject("PAUSE_ERROR", "Failed to pause download: ${e.message}", e)
             }
+        }
+    }
 
-            stopForegroundServiceIfIdle("cancelled")
-            safeResolve(promise, true)
-        } catch (e: Exception) {
-            safeReject(promise, "CANCEL_ERROR", "Failed to cancel download: ${e.message}", e)
+    @ReactMethod
+    fun resumeDownload(downloadId: Double, promise: Promise) {
+        scope.launch {
+            try {
+                val id = downloadId.toLong()
+                withContext(Dispatchers.IO) {
+                    val download = downloadDao.getDownload(id) ?: return@withContext
+                    downloadDao.updateStatus(id, DownloadStatus.QUEUED)
+                    // Only re-enqueue if WorkManager has no live work for this id
+                    val workName = WorkerDownload.workName(id)
+                    val workInfo = workManager.getWorkInfosForUniqueWork(workName).get().firstOrNull()
+                    if (workInfo == null || workInfo.state.isFinished) {
+                        WorkerDownload.enqueue(reactApplicationContext, id)
+                    }
+                }
+                registerObserver(id)
+                DownloadEventBridge.log("I", "[Module] resumeDownload id=$id")
+                SafePromise(promise, NAME).resolve(true)
+            } catch (e: Exception) {
+                SafePromise(promise, NAME).reject("RESUME_ERROR", "Failed to resume download: ${e.message}", e)
+            }
         }
     }
 
     @ReactMethod
     fun getActiveDownloads(promise: Promise) {
-        try {
-            val result = Arguments.createArray()
-            val workerDownloads = WorkerDownloadStore.all(reactApplicationContext)
-
-            for (i in 0 until workerDownloads.length()) {
-                val download = workerDownloads.getJSONObject(i)
-                result.pushMap(Arguments.createMap().apply {
-                    putDouble("downloadId", download.optLong("downloadId").toDouble())
-                    putString("fileName", download.optString("fileName"))
-                    putString("modelId", download.optString("modelId"))
-                    putString("title", download.optString("title"))
-                    putDouble("totalBytes", download.optDouble("totalBytes", 0.0))
-                    putString("status", download.optString("status", WorkerDownloadStore.STATUS_UNKNOWN))
-                    putDouble("bytesDownloaded", download.optDouble("bytesDownloaded", 0.0))
-                    putString("localUri", download.optString("localUri"))
-                    putDouble("startedAt", download.optDouble("startedAt", 0.0))
-                })
-            }
-
-            val downloads = getAllPersistedDownloads()
-
-            for (i in 0 until downloads.length()) {
-                val download = downloads.getJSONObject(i)
-                val downloadId = download.getLong("downloadId")
-
-                // Get current status from DownloadManager
-                val statusInfo = queryDownloadStatus(downloadId)
-
-                val map = Arguments.createMap().apply {
-                    putDouble("downloadId", downloadId.toDouble())
-                    putString("fileName", download.optString("fileName"))
-                    putString("modelId", download.optString("modelId"))
-                    putString("title", download.optString("title"))
-                    putDouble("totalBytes", download.optDouble("totalBytes", 0.0))
-                    putString("status", statusInfo.getString("status"))
-                    putDouble("bytesDownloaded", statusInfo.getDouble("bytesDownloaded"))
-                    putString("localUri", statusInfo.getString("localUri"))
-                    putDouble("startedAt", download.optDouble("startedAt", 0.0))
+        scope.launch {
+            try {
+                val downloads = withContext(Dispatchers.IO) {
+                    downloadDao.getAllDownloads().first().filter {
+                        it.status == DownloadStatus.QUEUED ||
+                        it.status == DownloadStatus.RUNNING ||
+                        it.status == DownloadStatus.PAUSED
+                    }
                 }
-                result.pushMap(map)
+                val result = Arguments.createArray()
+                downloads.forEach { d ->
+                    result.pushMap(Arguments.createMap().apply {
+                        putDouble("downloadId", d.id.toDouble())
+                        putString("fileName", d.fileName)
+                        putString("modelId", d.modelId)
+                        putString("title", d.title)
+                        putDouble("totalBytes", d.totalBytes.toDouble())
+                        putDouble("bytesDownloaded", d.downloadedBytes.toDouble())
+                        putString("status", d.status.name.lowercase())
+                        putString("localUri", Uri.fromFile(File(d.destination)).toString())
+                        putDouble("startedAt", d.createdAt.toDouble())
+                    })
+                }
+                SafePromise(promise, NAME).resolve(result)
+            } catch (e: Exception) {
+                SafePromise(promise, NAME).reject("QUERY_ERROR", "Failed to get active downloads: ${e.message}", e)
             }
-
-            safeResolve(promise, result)
-        } catch (e: Exception) {
-            safeReject(promise, "QUERY_ERROR", "Failed to get active downloads: ${e.message}", e)
         }
     }
 
     @ReactMethod
     fun getDownloadProgress(downloadId: Double, promise: Promise) {
-        try {
-            val id = downloadId.toLong()
-            val workerInfo = WorkerDownloadStore.get(reactApplicationContext, id)
-            if (workerInfo != null) {
-                val result = Arguments.createMap().apply {
-                    putDouble("downloadId", id.toDouble())
-                    putDouble("bytesDownloaded", workerInfo.optDouble("bytesDownloaded", 0.0))
-                    putDouble("totalBytes", workerInfo.optDouble("totalBytes", 0.0))
-                    putString("status", workerInfo.optString("status", WorkerDownloadStore.STATUS_UNKNOWN))
-                    putString("localUri", workerInfo.optString("localUri"))
-                    putString("reason", workerInfo.optString("reason"))
+        scope.launch {
+            try {
+                val id = downloadId.toLong()
+                val d = withContext(Dispatchers.IO) { downloadDao.getDownload(id) }
+                if (d == null) {
+                    SafePromise(promise, NAME).reject("QUERY_ERROR", "Download not found")
+                    return@launch
                 }
-                safeResolve(promise, result)
-                return
+                val result = Arguments.createMap().apply {
+                    putDouble("downloadId", d.id.toDouble())
+                    putDouble("bytesDownloaded", d.downloadedBytes.toDouble())
+                    putDouble("totalBytes", d.totalBytes.toDouble())
+                    putString("status", d.status.name.lowercase())
+                    putString("localUri", Uri.fromFile(File(d.destination)).toString())
+                    putString("reason", d.error ?: "")
+                }
+                SafePromise(promise, NAME).resolve(result)
+            } catch (e: Exception) {
+                SafePromise(promise, NAME).reject("PROGRESS_ERROR", "Failed to get progress: ${e.message}", e)
             }
-            val statusInfo = queryDownloadStatus(id)
-            val downloadInfo = getDownloadInfo(id)
-
-            val result = Arguments.createMap().apply {
-                putDouble("downloadId", id.toDouble())
-                putDouble("bytesDownloaded", statusInfo.getDouble("bytesDownloaded"))
-                putDouble("totalBytes", statusInfo.getDouble("totalBytes").takeIf { it > 0 }
-                    ?: downloadInfo?.optDouble("totalBytes", 0.0) ?: 0.0)
-                putString("status", statusInfo.getString("status"))
-                putString("localUri", statusInfo.getString("localUri"))
-                putString("reason", statusInfo.getString("reason"))
-            }
-            safeResolve(promise, result)
-        } catch (e: Exception) {
-            safeReject(promise, "PROGRESS_ERROR", "Failed to get download progress: ${e.message}", e)
         }
     }
 
     @ReactMethod
     fun moveCompletedDownload(downloadId: Double, targetPath: String, promise: Promise) {
-        try {
-            val id = downloadId.toLong()
+        scope.launch {
+            try {
+                val id = downloadId.toLong()
 
-            // Validate target path against app sandbox directories to prevent path traversal.
-            // Skip validation only when targetPath is empty (cleanup-only mode).
-            if (targetPath.isNotEmpty()) {
-                val targetFile = File(targetPath)
-                val allowedDirs = listOfNotNull(
-                    reactApplicationContext.filesDir?.canonicalPath,
-                    reactApplicationContext.cacheDir?.canonicalPath,
-                    reactApplicationContext.getExternalFilesDir(null)?.canonicalPath,
-                )
-                if (allowedDirs.none { targetFile.canonicalPath.startsWith(it) }) {
-                    safeReject(promise, "MOVE_ERROR", "Target path is outside the app sandbox.")
-                    return
+                // Validate target path against app sandbox directories to prevent path traversal.
+                if (targetPath.isNotEmpty()) {
+                    val targetFile = File(targetPath)
+                    val allowedDirs = listOfNotNull(
+                        reactApplicationContext.filesDir?.canonicalPath,
+                        reactApplicationContext.cacheDir?.canonicalPath,
+                        reactApplicationContext.getExternalFilesDir(null)?.canonicalPath,
+                    )
+                    if (allowedDirs.none { targetFile.canonicalPath.startsWith(it) }) {
+                        SafePromise(promise, NAME).reject("MOVE_ERROR", "Target path is outside the app sandbox.")
+                        return@launch
+                    }
                 }
-            }
 
-            val workerInfo = WorkerDownloadStore.get(reactApplicationContext, id)
-            if (workerInfo != null) {
-                val fileName = workerInfo.optString("fileName")
-                val sourceFile = File(
-                    reactApplicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-                    fileName
-                )
-                if (!sourceFile.exists()) {
-                    throw IllegalArgumentException("Worker download file not found: ${sourceFile.absolutePath}")
-                }
+                val d = withContext(Dispatchers.IO) { downloadDao.getDownload(id) }
+                    ?: run {
+                        SafePromise(promise, NAME).reject("MOVE_ERROR", "Download info not found")
+                        return@launch
+                    }
+
+                val sourceFile = File(d.destination)
+
                 if (targetPath.isEmpty()) {
-                    DownloadEventBridge.log("I", "[Module] moveCompletedDownload cleanup-only for worker id=$id file=${sourceFile.absolutePath}")
-                    WorkerDownloadStore.remove(reactApplicationContext, id)
-                    WorkerDownloadStore.stopForegroundServiceIfIdle(reactApplicationContext, "worker cleanup")
-                    safeResolve(promise, sourceFile.absolutePath)
-                    return
+                    // Cleanup-only — delete DB entry, no move needed
+                    withContext(Dispatchers.IO) { downloadDao.deleteDownload(d) }
+                    DownloadForegroundService.stop(reactApplicationContext, "cleanup")
+                    SafePromise(promise, NAME).resolve(sourceFile.absolutePath)
+                    return@launch
                 }
+
+                if (!sourceFile.exists()) {
+                    SafePromise(promise, NAME).reject("MOVE_ERROR", "Downloaded file not found: ${sourceFile.absolutePath}")
+                    return@launch
+                }
+
                 val targetFile = File(targetPath)
                 targetFile.parentFile?.mkdirs()
-                val moved = if (sourceFile.renameTo(targetFile)) {
-                    targetFile
-                } else {
-                    sourceFile.copyTo(targetFile, overwrite = true)
-                    sourceFile.delete()
-                    targetFile
-                }
-                DownloadEventBridge.log("I", "[Module] Worker file moved id=$id from=${sourceFile.absolutePath} to=${moved.absolutePath}")
-                WorkerDownloadStore.remove(reactApplicationContext, id)
-                WorkerDownloadStore.stopForegroundServiceIfIdle(reactApplicationContext, "worker moved")
-                safeResolve(promise, moved.absolutePath)
-                return
-            }
-            val downloadInfo = getDownloadInfo(id)
-            val fileName = downloadInfo?.optString("fileName")
-                ?: throw IllegalArgumentException("Download info not found")
 
-            // First try to get the actual file path from DownloadManager (handles auto-renamed files)
-            var sourceFile: File? = null
-            val statusInfo = queryDownloadStatus(id)
-            val localUri = statusInfo.getString("localUri")
-            if (!localUri.isNullOrEmpty()) {
-                try {
-                    val uri = Uri.parse(localUri)
-                    val path = uri.path
-                    if (path != null) {
-                        val uriFile = File(path)
-                        if (uriFile.exists()) {
-                            sourceFile = uriFile
-                            android.util.Log.d("DownloadService", "Using DownloadManager localUri: ${uriFile.absolutePath}")
-                        }
+                val movedPath = withContext(Dispatchers.IO) {
+                    if (sourceFile.renameTo(targetFile)) {
+                        targetFile.absolutePath
+                    } else {
+                        sourceFile.copyTo(targetFile, overwrite = true)
+                        sourceFile.delete()
+                        targetFile.absolutePath
                     }
-                } catch (e: Exception) {
-                    android.util.Log.w("DownloadService", "Failed to resolve localUri: $localUri", e)
                 }
-            }
 
-            // Fallback to persisted fileName
-            if (sourceFile == null) {
-                sourceFile = File(
-                    reactApplicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-                    fileName
-                )
-                android.util.Log.d("DownloadService", "Using persisted fileName: ${sourceFile.absolutePath}")
+                withContext(Dispatchers.IO) { downloadDao.deleteDownload(d) }
+                DownloadForegroundService.stop(reactApplicationContext, "moved")
+                DownloadEventBridge.log("I", "[Module] moveCompleted id=$id -> $movedPath")
+                SafePromise(promise, NAME).resolve(movedPath)
+            } catch (e: Exception) {
+                SafePromise(promise, NAME).reject("MOVE_ERROR", "Failed to move completed download: ${e.message}", e)
             }
-
-            if (!sourceFile.exists()) {
-                throw IllegalArgumentException("Downloaded file not found: ${sourceFile.absolutePath}")
-            }
-
-            val targetFile = File(targetPath)
-            targetFile.parentFile?.mkdirs()
-
-            // Move the file
-            if (sourceFile.renameTo(targetFile)) {
-                markMoveCompleted(id)
-                safeResolve(promise, targetFile.absolutePath)
-            } else {
-                // If rename fails (different filesystem), copy then delete
-                sourceFile.copyTo(targetFile, overwrite = true)
-                if (!sourceFile.delete()) {
-                    android.util.Log.w("DownloadService", "Failed to delete source file: ${sourceFile.absolutePath}")
-                }
-                markMoveCompleted(id)
-                safeResolve(promise, targetFile.absolutePath)
-            }
-        } catch (e: Exception) {
-            safeReject(promise, "MOVE_ERROR", "Failed to move completed download: ${e.message}", e)
         }
     }
 
+    /**
+     * Re-attaches WorkInfo LiveData observers for any downloads still active in the DB.
+     * Called by JS on app resume — covers the case where the app was killed while a
+     * download was running and WorkManager continued in the background.
+     */
     @ReactMethod
     fun startProgressPolling() {
-        if (!isPolling) {
-            DownloadEventBridge.log("I", "[Module] startProgressPolling")
-            isPolling = true
-            handler.post(pollRunnable)
-            watchdogHandler.postDelayed(watchdogRunnable, WATCHDOG_INTERVAL_MS)
-            registerNetworkCallback()
+        scope.launch {
+            val active = withContext(Dispatchers.IO) {
+                downloadDao.getAllDownloads().first().filter {
+                    it.status == DownloadStatus.QUEUED ||
+                    it.status == DownloadStatus.RUNNING ||
+                    it.status == DownloadStatus.PAUSED
+                }
+            }
+            active.forEach { registerObserver(it.id) }
+            DownloadEventBridge.log("I", "[Module] startProgressPolling — re-attached ${active.size} observer(s)")
         }
     }
 
     @ReactMethod
     fun stopProgressPolling() {
-        DownloadEventBridge.log("I", "[Module] stopProgressPolling")
-        isPolling = false
-        handler.removeCallbacks(pollRunnable)
-        watchdogHandler.removeCallbacks(watchdogRunnable)
-        unregisterNetworkCallback()
+        workObservers.keys.toList().forEach { removeWorkObserver(it) }
+        workObservers.clear()
+        DownloadEventBridge.log("I", "[Module] stopProgressPolling — all observers removed")
     }
 
     @ReactMethod
-    fun addListener(eventName: String) {
-        // Required for RN event emitter
-    }
+    fun addListener(eventName: String) { /* required for RN event emitter */ }
 
     @ReactMethod
-    fun removeListeners(count: Int) {
-        // Required for RN event emitter
-    }
+    fun removeListeners(count: Int) { /* required for RN event emitter */ }
 
     /**
-     * Returns true if the app is already excluded from battery optimization.
-     * On Android < M this always returns true (feature doesn't exist).
+     * Returns true if the app is already excluded from battery optimisation.
+     * Always returns true on Android < M.
      */
     @ReactMethod
     fun isBatteryOptimizationIgnored(promise: Promise) {
@@ -697,17 +340,14 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
                 return
             }
             val pm = reactApplicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
-            val ignored = pm.isIgnoringBatteryOptimizations(reactApplicationContext.packageName)
-            android.util.Log.d("DownloadService", "Battery optimization ignored: $ignored")
-            promise.resolve(ignored)
+            promise.resolve(pm.isIgnoringBatteryOptimizations(reactApplicationContext.packageName))
         } catch (e: Exception) {
-            android.util.Log.w("DownloadService", "Failed to check battery optimization: ${e.message}")
             promise.resolve(true) // fail open — don't block downloads
         }
     }
 
     /**
-     * Opens the system dialog asking the user to exempt this app from battery optimization.
+     * Opens the system dialog asking the user to exempt this app from battery optimisation.
      * No-op on Android < M.
      */
     @ReactMethod
@@ -719,562 +359,89 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
             reactApplicationContext.startActivity(intent)
-            android.util.Log.d("DownloadService", "Opened battery optimization settings")
         } catch (e: Exception) {
-            android.util.Log.w("DownloadService", "Failed to open battery optimization settings: ${e.message}")
+            DownloadEventBridge.log("W", "[Module] Failed to open battery optimization settings: ${e.message}")
         }
     }
 
     // -------------------------------------------------------------------------
-    // Network connectivity
+    // WorkInfo observer management — mirrors PocketPal's pattern exactly
     // -------------------------------------------------------------------------
 
-    private fun registerNetworkCallback() {
-        if (networkCallbackRegistered) return
-        try {
-            val cm = reactApplicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-            val request = NetworkRequest.Builder()
-                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                .build()
-            cm.registerNetworkCallback(request, networkCallback)
-            networkCallbackRegistered = true
-            android.util.Log.d("DownloadService", "Network callback registered")
-        } catch (e: Exception) {
-            android.util.Log.w("DownloadService", "Failed to register network callback: ${e.message}")
+    private fun registerObserver(downloadId: Long) {
+        // Remove stale observer if present
+        workObservers[downloadId]?.let { old ->
+            workManager.getWorkInfosForUniqueWorkLiveData(WorkerDownload.workName(downloadId))
+                .removeObserver(old)
         }
-    }
 
-    private fun unregisterNetworkCallback() {
-        if (!networkCallbackRegistered) return
-        try {
-            val cm = reactApplicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-            cm.unregisterNetworkCallback(networkCallback)
-            networkCallbackRegistered = false
-            android.util.Log.d("DownloadService", "Network callback unregistered")
-        } catch (e: Exception) {
-            android.util.Log.w("DownloadService", "Failed to unregister network callback: ${e.message}")
-        }
-    }
-
-    private fun checkNetworkRestored() {
-        val downloads = getAllPersistedDownloads()
-        for (i in 0 until downloads.length()) {
-            val download = downloads.getJSONObject(i)
-            val downloadId = download.getLong("downloadId")
-            val statusInfo = queryDownloadStatus(downloadId)
-            val status = statusInfo.getString("status") ?: STATUS_UNKNOWN
-            val reason = statusInfo.getString("reason") ?: ""
-            android.util.Log.d("DownloadService", "Download status: ${status.uppercase()} - reason: $reason - id: $downloadId")
-            if (status == STATUS_PAUSED) {
-                android.util.Log.d("DownloadService", "Download $downloadId paused - DownloadManager will auto-resume")
-            }
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // Stuck-download watchdog
-    // -------------------------------------------------------------------------
-
-    private fun checkForStuckDownloads() {
-        val downloads = getAllPersistedDownloads()
-        for (i in 0 until downloads.length()) {
-            val download = downloads.getJSONObject(i)
-            val downloadId = download.getLong("downloadId")
-
-            val statusInfo = queryDownloadStatus(downloadId)
-            val status = statusInfo.getString("status") ?: STATUS_UNKNOWN
-            val reason = statusInfo.getString("reason") ?: ""
-
-            android.util.Log.d("DownloadService", "Download status: ${status.uppercase()} - reason: $reason - id: $downloadId")
-
-            if (status != STATUS_RUNNING) {
-                downloadBytesTracker.remove(downloadId)
-                continue
-            }
-
-            val bytesDownloaded = statusInfo.getDouble("bytesDownloaded").toLong()
-            val totalBytes = (statusInfo.getDouble("totalBytes").takeIf { it > 0 }
-                ?: download.optDouble("totalBytes", 0.0)).toLong()
-            val percent = if (totalBytes > 0) (bytesDownloaded * 100 / totalBytes) else 0
-
-            android.util.Log.d("DownloadService", "Progress - id: $downloadId | bytes: $bytesDownloaded / $totalBytes | percent: $percent%")
-
-            val track = downloadBytesTracker[downloadId]
-            if (track == null) {
-                downloadBytesTracker[downloadId] = BytesTrack(bytesDownloaded, 0)
-                continue
-            }
-
-            when (val action = evaluateStuckProgress(track, bytesDownloaded)) {
-                is StuckAction.ResetCounter -> {
-                    downloadBytesTracker[downloadId] = action.newTrack
-                }
-                is StuckAction.IncrementCounter -> {
-                    val elapsedSeconds = action.newTrack.unchangedCount * WATCHDOG_INTERVAL_MS / 1000
-                    if (action.newTrack.lastBytes == 0L) {
-                        android.util.Log.d("DownloadService", "Waiting for first byte on download $downloadId (${elapsedSeconds}s elapsed, timeout: ${STARTUP_TIMEOUT_POLLS * WATCHDOG_INTERVAL_MS / 1000}s)")
-                    } else {
-                        android.util.Log.w("DownloadService", "No progress for ${elapsedSeconds}s on download $downloadId (${action.newTrack.unchangedCount}/$STUCK_THRESHOLD checks)")
+        val observer = Observer<List<WorkInfo>> { workInfos ->
+            val info = workInfos.firstOrNull() ?: return@Observer
+            when (info.state) {
+                WorkInfo.State.RUNNING -> {
+                    val bytes = info.progress.getLong(WorkerDownload.KEY_PROGRESS, 0L)
+                    val total = info.progress.getLong(WorkerDownload.KEY_TOTAL, 0L)
+                    scope.launch {
+                        val d = withContext(Dispatchers.IO) { downloadDao.getDownload(downloadId) }
+                            ?: return@launch
+                        DownloadEventBridge.progress(
+                            downloadId, d.fileName, d.modelId, bytes, total,
+                            DownloadStatus.RUNNING.name.lowercase(),
+                        )
                     }
-                    downloadBytesTracker[downloadId] = action.newTrack
                 }
-                is StuckAction.Retry -> {
-                    val stuckSeconds = STUCK_THRESHOLD * WATCHDOG_INTERVAL_MS / 1000
-                    android.util.Log.w("DownloadService", "Download $downloadId stuck for ${stuckSeconds}s — retrying (attempt ${action.retryCount}/$MAX_RETRY_ATTEMPTS)")
-                    downloadBytesTracker.remove(downloadId)
-                    handleStuckDownload(downloadId, bytesDownloaded, download, action.retryCount)
-                }
-                is StuckAction.GiveUp -> {
-                    android.util.Log.e("DownloadService", "Download $downloadId gave up after ${track.retryCount} retries")
-                    downloadBytesTracker.remove(downloadId)
-                    sendEvent("DownloadError", buildEventParams(downloadId, download, queryDownloadStatus(downloadId), STATUS_FAILED).also {
-                        it.putString("reason", "Download stuck after ${track.retryCount} retries")
-                    })
-                    downloadManager.remove(downloadId)
-                    removeDownload(downloadId)
-                    stopForegroundServiceIfIdle("failed")
-                    return
-                }
-                is StuckAction.StartupTimeout -> {
-                    android.util.Log.e("DownloadService", "Download $downloadId failed to start after ${STARTUP_TIMEOUT_POLLS * WATCHDOG_INTERVAL_MS / 1000}s — no bytes received")
-                    downloadBytesTracker.remove(downloadId)
-                    sendEvent("DownloadError", buildEventParams(downloadId, download, queryDownloadStatus(downloadId), STATUS_FAILED).also {
-                        it.putString("reason", "Download failed to start — please check your connection and try again")
-                    })
-                    downloadManager.remove(downloadId)
-                    removeDownload(downloadId)
-                    stopForegroundServiceIfIdle("failed")
-                    return
-                }
-            }
-        }
-    }
-
-    private fun handleStuckDownload(downloadId: Long, bytesDownloaded: Long, downloadInfo: JSONObject, retryCount: Int = 1) {
-        android.util.Log.w("DownloadService", "Restarting stuck download - id: $downloadId (attempt $retryCount/$MAX_RETRY_ATTEMPTS)")
-
-        val url = downloadInfo.optString("url", "")
-        val fileName = downloadInfo.optString("fileName", "")
-        val title = downloadInfo.optString("title", fileName)
-        val modelId = downloadInfo.optString("modelId", "")
-        val totalBytes = downloadInfo.optLong("totalBytes", 0L)
-
-        // Step 1: resolve URL and delete partial file on background executor (network/IO)
-        executor.execute {
-            try {
-                val resolvedUrl = resolveRedirects(url)
-
-                val partialFile = File(
-                    reactApplicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-                    fileName
-                )
-                if (partialFile.exists()) {
-                    android.util.Log.d("DownloadService", "Deleting partial file (${partialFile.length()}B): ${partialFile.name}")
-                    partialFile.delete()
-                }
-
-                // Step 2: backoff using postDelayed — does NOT block the executor thread
-                val backoffMs = retryCount * 30_000L
-                android.util.Log.d("DownloadService", "Backoff ${backoffMs / 1000}s before re-enqueue (retry $retryCount/$MAX_RETRY_ATTEMPTS)")
-
-                watchdogHandler.postDelayed({
-                    // Guard: if download was cancelled during backoff, do not resurrect it
-                    if (getDownloadInfo(downloadId) == null) {
-                        android.util.Log.d("DownloadService", "Download $downloadId was cancelled during backoff — skipping re-enqueue")
-                        return@postDelayed
-                    }
-                    // enqueue and persist on executor to avoid disk/network IO on main thread
-                    executor.execute {
-                        try {
-                            val request = DownloadManager.Request(Uri.parse(resolvedUrl))
-                                .setTitle(title)
-                                .setDescription("Downloading model...")
-                                .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-                                .setDestinationInExternalFilesDir(
-                                    reactApplicationContext,
-                                    Environment.DIRECTORY_DOWNLOADS,
-                                    fileName
-                                )
-                                .setAllowedOverMetered(true)
-                                .setAllowedOverRoaming(true)
-
-                            val newDownloadId = downloadManager.enqueue(request)
-
-                            // Persist new entry first, then remove old — avoids a gap where
-                            // SharedPreferences is empty and the poll loop stops the foreground service
-                            val newInfo = JSONObject().apply {
-                                put("downloadId", newDownloadId)
-                                put("url", url)
-                                put("fileName", fileName)
-                                put("modelId", modelId)
-                                put("title", title)
-                                put("totalBytes", totalBytes)
-                                put("status", STATUS_PENDING)
-                                put("startedAt", System.currentTimeMillis())
-                            }
-                            persistDownload(newDownloadId, newInfo)
-                            downloadManager.remove(downloadId)
-                            removeDownload(downloadId)
-
-                            handler.post { downloadBytesTracker[newDownloadId] = BytesTrack(0L, 0, retryCount) }
-                            android.util.Log.d("DownloadService", "Re-enqueued - new id: $newDownloadId (replaced: $downloadId, retry $retryCount/$MAX_RETRY_ATTEMPTS)")
-                        } catch (e: Exception) {
-                            android.util.Log.e("DownloadService", "Failed to re-enqueue stuck download $downloadId: ${e.message}")
+                WorkInfo.State.SUCCEEDED -> {
+                    scope.launch {
+                        val d = withContext(Dispatchers.IO) { downloadDao.getDownload(downloadId) }
+                        if (d != null) {
+                            DownloadEventBridge.complete(
+                                downloadId, d.fileName, d.modelId,
+                                Uri.fromFile(File(d.destination)).toString(),
+                                d.downloadedBytes, d.totalBytes,
+                            )
                         }
+                        DownloadForegroundService.stop(reactApplicationContext, "completed")
+                        removeWorkObserver(downloadId)
                     }
-                }, backoffMs)
-
-            } catch (e: Exception) {
-                android.util.Log.e("DownloadService", "Failed to prepare retry for stuck download $downloadId: ${e.message}")
-            }
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // URL redirect resolution
-    // -------------------------------------------------------------------------
-
-    private fun isHostAllowed(host: String?): Boolean {
-        if (host == null) return false
-        return allowedDownloadHosts.any { host == it || host.endsWith(".$it") }
-    }
-
-    private fun followOneRedirect(currentUrl: String): String? {
-        val connection = URL(currentUrl).openConnection() as HttpURLConnection
-        try {
-            connection.instanceFollowRedirects = false
-            connection.requestMethod = "HEAD"
-            connection.connectTimeout = 10_000
-            connection.readTimeout = 10_000
-            val responseCode = connection.responseCode
-            if (responseCode !in 300..399) return null
-
-            val location = connection.getHeaderField("Location")
-            if (location.isNullOrEmpty()) return null
-
-            val nextUrl = if (location.startsWith("http")) location
-                else URL(URL(currentUrl), location).toString()
-
-            val nextHost = try { URL(nextUrl).host } catch (_: Exception) { null }
-            if (!isHostAllowed(nextHost)) {
-                android.util.Log.w("DownloadService", "Redirect to unauthorized host blocked: $nextHost")
-                return null
-            }
-            return nextUrl
-        } finally {
-            connection.disconnect()
-        }
-    }
-
-    /**
-     * Follow HTTP redirects manually and return the final URL.
-     * Some OEM DownloadManager implementations silently fail on 302 redirects
-     * to long signed CDN URLs (e.g. HuggingFace → xethub.hf.co).
-     * By pre-resolving, DownloadManager gets the direct URL with no redirects.
-     * Falls back to the original URL on any error so downloads aren't blocked.
-     */
-    internal fun resolveRedirects(originalUrl: String, maxRedirects: Int = 5): String {
-        var currentUrl = originalUrl
-        for (i in 0 until maxRedirects) {
-            try {
-                val nextUrl = followOneRedirect(currentUrl) ?: return currentUrl
-                currentUrl = nextUrl
-            } catch (e: Exception) {
-                android.util.Log.w("DownloadService", "Redirect resolution failed, using original URL", e)
-                return originalUrl
-            }
-        }
-        android.util.Log.w("DownloadService", "Redirect resolution exceeded max redirects ($maxRedirects), using original URL")
-        return originalUrl
-    }
-
-    // -------------------------------------------------------------------------
-    // Progress polling helpers
-    // -------------------------------------------------------------------------
-
-    private fun buildEventParams(
-        downloadId: Long, download: JSONObject, statusInfo: ReadableMap, status: String,
-    ): WritableMap = Arguments.createMap().apply {
-        putDouble("downloadId", downloadId.toDouble())
-        putString("fileName", download.optString("fileName"))
-        putString("modelId", download.optString("modelId"))
-        putDouble("bytesDownloaded", statusInfo.getDouble("bytesDownloaded"))
-        putDouble("totalBytes", statusInfo.getDouble("totalBytes").takeIf { it > 0 }
-            ?: download.optDouble("totalBytes", 0.0))
-        putString("status", status)
-        putString("reason", statusInfo.getString("reason") ?: "")
-    }
-
-    private fun handlePollCompleted(
-        downloadId: Long, eventParams: WritableMap, statusInfo: ReadableMap, completedEventSent: Boolean,
-    ) {
-        eventParams.putString("localUri", statusInfo.getString("localUri"))
-        if (!completedEventSent) {
-            android.util.Log.d("DownloadService", "Sending DownloadComplete event for $downloadId")
-            sendEvent("DownloadComplete", eventParams)
-            updateDownloadStatus(downloadId, STATUS_COMPLETED, statusInfo.getString("localUri"))
-            stopForegroundServiceIfIdle("completed")
-        }
-    }
-
-    private fun handlePollUnknown(downloadId: Long, eventParams: WritableMap, completedEventSent: Boolean) {
-        android.util.Log.w("DownloadService", "Download $downloadId has unknown status - may have completed or been removed")
-        val downloadInfo = getDownloadInfo(downloadId)
-        val fileName = downloadInfo?.optString("fileName")
-        if (fileName == null) {
-            android.util.Log.d("DownloadService", "No info for unknown download $downloadId, removing stale entry")
-            removeDownload(downloadId)
-            downloadBytesTracker.remove(downloadId)
-            stopForegroundServiceIfIdle("unknown")
-            return
-        }
-        val file = java.io.File(
-            reactApplicationContext.getExternalFilesDir(android.os.Environment.DIRECTORY_DOWNLOADS), fileName
-        )
-        if (file.exists() && file.length() > 0) {
-            android.util.Log.d("DownloadService", "File exists, treating as completed: ${file.absolutePath}")
-            eventParams.putString("localUri", file.toURI().toString())
-            if (!completedEventSent) sendEvent("DownloadComplete", eventParams)
-            updateDownloadStatus(downloadId, STATUS_COMPLETED, file.toURI().toString())
-        } else {
-            android.util.Log.d("DownloadService", "No file found for unknown download $downloadId, removing stale entry")
-            removeDownload(downloadId)
-            downloadBytesTracker.remove(downloadId)
-        }
-        stopForegroundServiceIfIdle("completed")
-    }
-
-    private fun pollAllDownloads() {
-        val downloads = getAllPersistedDownloads()
-
-        for (i in 0 until downloads.length()) {
-            val download = downloads.getJSONObject(i)
-            val downloadId = download.getLong("downloadId")
-
-            val statusInfo = queryDownloadStatus(downloadId)
-            val status = statusInfo.getString("status") ?: STATUS_UNKNOWN
-            val eventParams = buildEventParams(downloadId, download, statusInfo, status)
-            val completedEventSent = download.optBoolean("completedEventSent", false)
-
-            when (status) {
-                STATUS_COMPLETED -> handlePollCompleted(downloadId, eventParams, statusInfo, completedEventSent)
-                STATUS_FAILED -> {
-                    eventParams.putString("reason", statusInfo.getString("reason"))
-                    sendEvent("DownloadError", eventParams)
-                    removeDownload(downloadId)
-                    downloadBytesTracker.remove(downloadId)
-                    stopForegroundServiceIfIdle("failed")
                 }
-                STATUS_PAUSED -> {
-                    eventParams.putString("reason", statusInfo.getString("reason"))
-                    sendEvent("DownloadProgress", eventParams)
+                WorkInfo.State.FAILED -> {
+                    scope.launch {
+                        val d = withContext(Dispatchers.IO) { downloadDao.getDownload(downloadId) }
+                        DownloadEventBridge.error(
+                            downloadId,
+                            d?.fileName ?: "",
+                            d?.modelId ?: "",
+                            d?.error ?: "Unknown error",
+                        )
+                        DownloadForegroundService.stop(reactApplicationContext, "failed")
+                        removeWorkObserver(downloadId)
+                    }
                 }
-                STATUS_RUNNING, STATUS_PENDING -> sendEvent("DownloadProgress", eventParams)
-                STATUS_UNKNOWN -> handlePollUnknown(downloadId, eventParams, completedEventSent)
+                WorkInfo.State.CANCELLED -> {
+                    scope.launch {
+                        DownloadForegroundService.stop(reactApplicationContext, "cancelled")
+                        removeWorkObserver(downloadId)
+                    }
+                }
+                else -> Unit
             }
+        }
+
+        workObservers[downloadId] = observer
+        workManager.getWorkInfosForUniqueWorkLiveData(WorkerDownload.workName(downloadId))
+            .observeForever(observer)
+    }
+
+    private fun removeWorkObserver(downloadId: Long) {
+        workObservers.remove(downloadId)?.let { observer ->
+            workManager.getWorkInfosForUniqueWorkLiveData(WorkerDownload.workName(downloadId))
+                .removeObserver(observer)
         }
     }
 
     // -------------------------------------------------------------------------
-    // DownloadManager query helpers
-    // -------------------------------------------------------------------------
 
-    private fun buildUnknownStatusMap(reason: String): WritableMap = Arguments.createMap().apply {
-        putDouble("bytesDownloaded", 0.0)
-        putDouble("totalBytes", 0.0)
-        putString("localUri", "")
-        putString("status", STATUS_UNKNOWN)
-        putString("reason", reason)
-    }
-
-    private fun buildStatusFromCursor(cursor: Cursor): WritableMap {
-        val bytesDownloadedIdx = cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)
-        val totalBytesIdx = cursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES)
-        val statusIdx = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)
-        val reasonIdx = cursor.getColumnIndex(DownloadManager.COLUMN_REASON)
-        val localUriIdx = cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI)
-
-        val bytesDownloaded = if (bytesDownloadedIdx >= 0) cursor.getLong(bytesDownloadedIdx) else 0L
-        val totalBytes = if (totalBytesIdx >= 0) cursor.getLong(totalBytesIdx) else 0L
-        val status = if (statusIdx >= 0) cursor.getInt(statusIdx) else DownloadManager.STATUS_PENDING
-        val reason = if (reasonIdx >= 0) cursor.getInt(reasonIdx) else 0
-        val localUri = if (localUriIdx >= 0) cursor.getString(localUriIdx) else null
-
-        return Arguments.createMap().apply {
-            putDouble("bytesDownloaded", bytesDownloaded.toDouble())
-            putDouble("totalBytes", totalBytes.toDouble())
-            putString("localUri", localUri ?: "")
-            putString("status", statusToString(status))
-            putString("reason", reasonToString(status, reason))
-        }
-    }
-
-    private fun queryDownloadStatus(downloadId: Long): ReadableMap {
-        val query = DownloadManager.Query().setFilterById(downloadId)
-        val cursor: Cursor? = downloadManager.query(query)
-
-        cursor?.use {
-            return if (it.moveToFirst()) buildStatusFromCursor(it)
-                else buildUnknownStatusMap("Download not found")
-        }
-
-        return buildUnknownStatusMap("Query failed")
-    }
-
-    private fun sendEvent(eventName: String, params: WritableMap) {
-        reactApplicationContext
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-            .emit(eventName, params)
-    }
-
-    private fun pollWorkerDownloads() {
-        val downloads = WorkerDownloadStore.all(reactApplicationContext)
-        for (i in 0 until downloads.length()) {
-            val download = downloads.getJSONObject(i)
-            val status = download.optString("status", WorkerDownloadStore.STATUS_UNKNOWN)
-            if (status != WorkerDownloadStore.STATUS_RUNNING && status != WorkerDownloadStore.STATUS_PENDING) continue
-            val downloadId = download.optLong("downloadId")
-            DownloadEventBridge.progress(
-                downloadId,
-                download.optString("fileName"),
-                download.optString("modelId"),
-                download.optLong("bytesDownloaded"),
-                download.optLong("totalBytes"),
-                status,
-                download.optString("reason").ifEmpty { null },
-            )
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // SharedPreferences persistence
-    // -------------------------------------------------------------------------
-
-    private fun persistDownload(downloadId: Long, info: JSONObject) {
-        val downloads = getAllPersistedDownloads()
-
-        // Update or add the download
-        var found = false
-        for (i in 0 until downloads.length()) {
-            val existing = downloads.getJSONObject(i)
-            if (existing.getLong("downloadId") == downloadId) {
-                downloads.put(i, info)
-                found = true
-                break
-            }
-        }
-        if (!found) {
-            downloads.put(info)
-        }
-
-        sharedPrefs.edit().putString(DOWNLOADS_KEY, downloads.toString()).apply()
-    }
-
-    private fun updateDownloadStatus(downloadId: Long, status: String, localUri: String?) {
-        val info = getDownloadInfo(downloadId)
-        if (info != null) {
-            info.put("status", status)
-            if (localUri != null) {
-                info.put("localUri", localUri)
-            }
-            if (status == STATUS_COMPLETED) {
-                info.put("completedAt", System.currentTimeMillis())
-                info.put("completedEventSent", true)
-            }
-            persistDownload(downloadId, info)
-        }
-    }
-
-    private fun markMoveCompleted(downloadId: Long) {
-        val info = getDownloadInfo(downloadId)
-        if (info != null) {
-            info.put("moveCompleted", true)
-            persistDownload(downloadId, info)
-        } else {
-            // Info already cleaned up — nothing to mark
-        }
-    }
-
-    private fun removeDownload(downloadId: Long) {
-        val downloads = getAllPersistedDownloads()
-        val newDownloads = JSONArray()
-
-        for (i in 0 until downloads.length()) {
-            val download = downloads.getJSONObject(i)
-            if (download.getLong("downloadId") != downloadId) {
-                newDownloads.put(download)
-            }
-        }
-
-        sharedPrefs.edit().putString(DOWNLOADS_KEY, newDownloads.toString()).apply()
-    }
-
-    private fun getDownloadInfo(downloadId: Long): JSONObject? {
-        val downloads = getAllPersistedDownloads()
-        for (i in 0 until downloads.length()) {
-            val download = downloads.getJSONObject(i)
-            if (download.getLong("downloadId") == downloadId) {
-                return download
-            }
-        }
-        return null
-    }
-
-    /**
-     * Clean up stale download entries from SharedPreferences.
-     * Removes entries where DownloadManager no longer has the download (status=unknown)
-     * or entries that have been moved to their final location by moveCompletedDownload.
-     */
-    private fun cleanupStaleDownloads() {
-        val downloads = getAllPersistedDownloads()
-        val cleanedDownloads = JSONArray()
-        var removedCount = 0
-
-        for (i in 0 until downloads.length()) {
-            val download = downloads.getJSONObject(i)
-            val downloadId = download.getLong("downloadId")
-            val statusInfo = queryDownloadStatus(downloadId)
-            val status = statusInfo.getString("status")
-            val previousStatus = download.optString("status", STATUS_PENDING)
-
-            if (shouldRemoveDownload(download, status ?: STATUS_UNKNOWN)) {
-                android.util.Log.d("DownloadService", "Cleanup: removing download $downloadId (liveStatus=$status, storedStatus=$previousStatus)")
-                removedCount++
-                continue
-            }
-
-            if (previousStatus == STATUS_COMPLETED && download.optLong("completedAt", 0L) > 0 && !download.optBoolean("completedEventSent", false)) {
-                android.util.Log.w("DownloadService", "Cleanup: found completed download $downloadId without event sent - will retry in polling")
-            }
-
-            cleanedDownloads.put(download)
-        }
-
-        if (removedCount > 0) {
-            android.util.Log.d("DownloadService", "Cleanup: removed $removedCount stale entries")
-            sharedPrefs.edit().putString(DOWNLOADS_KEY, cleanedDownloads.toString()).apply()
-        }
-    }
-
-    private fun getAllPersistedDownloads(): JSONArray {
-        val json = sharedPrefs.getString(DOWNLOADS_KEY, "[]") ?: "[]"
-        return try {
-            JSONArray(json)
-        } catch (e: Exception) {
-            JSONArray()
-        }
-    }
-
-    /**
-     * Stop the foreground service if no downloads are still active
-     * (pending, running, or paused).
-     */
-    private fun stopForegroundServiceIfIdle(reason: String = "completed") {
-        if (!hasNoActiveDownloads(getAllPersistedDownloads())) return
-        try {
-            DownloadForegroundService.stop(reactApplicationContext, reason)
-        } catch (e: Exception) {
-            android.util.Log.w("DownloadService", "Failed to stop foreground service (non-fatal): ${e.message}", e)
-        }
+    companion object {
+        const val NAME = "DownloadManagerModule"
     }
 }

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -30,6 +30,10 @@ import java.util.concurrent.Executors
 class DownloadManagerModule(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext) {
 
+    init {
+        DownloadEventBridge.attach(reactContext)
+    }
+
     private fun safeReject(promise: Promise, code: String, message: String, throwable: Throwable? = null) =
         SafePromise(promise, NAME).reject(code, message, throwable)
 
@@ -200,6 +204,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     private val pollRunnable = object : Runnable {
         override fun run() {
             if (isPolling) {
+                pollWorkerDownloads()
                 pollAllDownloads()
                 handler.postDelayed(this, POLL_INTERVAL_MS)
             }
@@ -224,6 +229,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     // --- Network connectivity ---
     @Volatile private var networkAvailable = true
     private var networkCallbackRegistered = false
+    private val useWorkerDownloader = true
 
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
@@ -272,6 +278,49 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
         if (parsedHost == null || !allowedDownloadHosts.any { parsedHost == it || parsedHost.endsWith(".$it") }) {
             safeReject(promise, "DOWNLOAD_ERROR", "Download URL host not allowed: $parsedHost")
             return
+        }
+
+        if (useWorkerDownloader) {
+            try {
+                val downloadId = System.currentTimeMillis()
+                val downloadInfo = JSONObject().apply {
+                    put("downloadId", downloadId)
+                    put("url", url)
+                    put("fileName", fileName)
+                    put("modelId", modelId)
+                    put("title", title)
+                    put("description", description)
+                    put("totalBytes", totalBytes)
+                    put("bytesDownloaded", 0)
+                    put("status", WorkerDownloadStore.STATUS_PENDING)
+                    put("startedAt", System.currentTimeMillis())
+                    put("backend", "worker")
+                    put("localUri", Uri.fromFile(File(
+                        reactApplicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
+                        fileName
+                    )).toString())
+                }
+                WorkerDownloadStore.put(reactApplicationContext, downloadInfo)
+                DownloadEventBridge.log("I", "[Module] startDownload routed to worker id=$downloadId file=$fileName model=$modelId")
+                WorkerDownload.enqueue(
+                    reactApplicationContext,
+                    downloadId,
+                    url,
+                    fileName,
+                    modelId,
+                    title,
+                    totalBytes,
+                )
+                val result = Arguments.createMap().apply {
+                    putDouble("downloadId", downloadId.toDouble())
+                    putString("fileName", fileName)
+                    putString("modelId", modelId)
+                }
+                safeResolve(promise, result)
+                return
+            } catch (e: Exception) {
+                DownloadEventBridge.log("E", "[Module] worker start failed, falling back to legacy: ${e.message}")
+            }
         }
 
         // Resolve redirects on a background thread (network I/O)
@@ -351,6 +400,22 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     fun cancelDownload(downloadId: Double, promise: Promise) {
         try {
             val id = downloadId.toLong()
+            val workerInfo = WorkerDownloadStore.get(reactApplicationContext, id)
+            if (workerInfo != null) {
+                DownloadEventBridge.log("W", "[Module] Cancelling worker download id=$id")
+                WorkerDownload.cancel(reactApplicationContext, id)
+                workerInfo.optString("fileName")?.let { fileName ->
+                    val file = File(
+                        reactApplicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
+                        fileName
+                    )
+                    if (file.exists()) file.delete()
+                }
+                WorkerDownloadStore.remove(reactApplicationContext, id)
+                WorkerDownloadStore.stopForegroundServiceIfIdle(reactApplicationContext, "worker cancelled")
+                safeResolve(promise, true)
+                return
+            }
             android.util.Log.d("DownloadService", "Cancelling download - id: $id")
 
             // Get download info BEFORE removing from SharedPreferences
@@ -381,8 +446,25 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     @ReactMethod
     fun getActiveDownloads(promise: Promise) {
         try {
-            val downloads = getAllPersistedDownloads()
             val result = Arguments.createArray()
+            val workerDownloads = WorkerDownloadStore.all(reactApplicationContext)
+
+            for (i in 0 until workerDownloads.length()) {
+                val download = workerDownloads.getJSONObject(i)
+                result.pushMap(Arguments.createMap().apply {
+                    putDouble("downloadId", download.optLong("downloadId").toDouble())
+                    putString("fileName", download.optString("fileName"))
+                    putString("modelId", download.optString("modelId"))
+                    putString("title", download.optString("title"))
+                    putDouble("totalBytes", download.optDouble("totalBytes", 0.0))
+                    putString("status", download.optString("status", WorkerDownloadStore.STATUS_UNKNOWN))
+                    putDouble("bytesDownloaded", download.optDouble("bytesDownloaded", 0.0))
+                    putString("localUri", download.optString("localUri"))
+                    putDouble("startedAt", download.optDouble("startedAt", 0.0))
+                })
+            }
+
+            val downloads = getAllPersistedDownloads()
 
             for (i in 0 until downloads.length()) {
                 val download = downloads.getJSONObject(i)
@@ -415,6 +497,19 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     fun getDownloadProgress(downloadId: Double, promise: Promise) {
         try {
             val id = downloadId.toLong()
+            val workerInfo = WorkerDownloadStore.get(reactApplicationContext, id)
+            if (workerInfo != null) {
+                val result = Arguments.createMap().apply {
+                    putDouble("downloadId", id.toDouble())
+                    putDouble("bytesDownloaded", workerInfo.optDouble("bytesDownloaded", 0.0))
+                    putDouble("totalBytes", workerInfo.optDouble("totalBytes", 0.0))
+                    putString("status", workerInfo.optString("status", WorkerDownloadStore.STATUS_UNKNOWN))
+                    putString("localUri", workerInfo.optString("localUri"))
+                    putString("reason", workerInfo.optString("reason"))
+                }
+                safeResolve(promise, result)
+                return
+            }
             val statusInfo = queryDownloadStatus(id)
             val downloadInfo = getDownloadInfo(id)
 
@@ -437,6 +532,38 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     fun moveCompletedDownload(downloadId: Double, targetPath: String, promise: Promise) {
         try {
             val id = downloadId.toLong()
+            val workerInfo = WorkerDownloadStore.get(reactApplicationContext, id)
+            if (workerInfo != null) {
+                val fileName = workerInfo.optString("fileName")
+                val sourceFile = File(
+                    reactApplicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
+                    fileName
+                )
+                if (!sourceFile.exists()) {
+                    throw IllegalArgumentException("Worker download file not found: ${sourceFile.absolutePath}")
+                }
+                if (targetPath.isEmpty()) {
+                    DownloadEventBridge.log("I", "[Module] moveCompletedDownload cleanup-only for worker id=$id file=${sourceFile.absolutePath}")
+                    WorkerDownloadStore.remove(reactApplicationContext, id)
+                    WorkerDownloadStore.stopForegroundServiceIfIdle(reactApplicationContext, "worker cleanup")
+                    safeResolve(promise, sourceFile.absolutePath)
+                    return
+                }
+                val targetFile = File(targetPath)
+                targetFile.parentFile?.mkdirs()
+                val moved = if (sourceFile.renameTo(targetFile)) {
+                    targetFile
+                } else {
+                    sourceFile.copyTo(targetFile, overwrite = true)
+                    sourceFile.delete()
+                    targetFile
+                }
+                DownloadEventBridge.log("I", "[Module] Worker file moved id=$id from=${sourceFile.absolutePath} to=${moved.absolutePath}")
+                WorkerDownloadStore.remove(reactApplicationContext, id)
+                WorkerDownloadStore.stopForegroundServiceIfIdle(reactApplicationContext, "worker moved")
+                safeResolve(promise, moved.absolutePath)
+                return
+            }
             val downloadInfo = getDownloadInfo(id)
             val fileName = downloadInfo?.optString("fileName")
                 ?: throw IllegalArgumentException("Download info not found")
@@ -498,6 +625,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     @ReactMethod
     fun startProgressPolling() {
         if (!isPolling) {
+            DownloadEventBridge.log("I", "[Module] startProgressPolling")
             isPolling = true
             handler.post(pollRunnable)
             watchdogHandler.postDelayed(watchdogRunnable, WATCHDOG_INTERVAL_MS)
@@ -507,6 +635,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun stopProgressPolling() {
+        DownloadEventBridge.log("I", "[Module] stopProgressPolling")
         isPolling = false
         handler.removeCallbacks(pollRunnable)
         watchdogHandler.removeCallbacks(watchdogRunnable)
@@ -963,6 +1092,25 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
         reactApplicationContext
             .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
             .emit(eventName, params)
+    }
+
+    private fun pollWorkerDownloads() {
+        val downloads = WorkerDownloadStore.all(reactApplicationContext)
+        for (i in 0 until downloads.length()) {
+            val download = downloads.getJSONObject(i)
+            val status = download.optString("status", WorkerDownloadStore.STATUS_UNKNOWN)
+            if (status != WorkerDownloadStore.STATUS_RUNNING && status != WorkerDownloadStore.STATUS_PENDING) continue
+            val downloadId = download.optLong("downloadId")
+            DownloadEventBridge.progress(
+                downloadId,
+                download.optString("fileName"),
+                download.optString("modelId"),
+                download.optLong("bytesDownloaded"),
+                download.optLong("totalBytes"),
+                status,
+                download.optString("reason").ifEmpty { null },
+            )
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -157,7 +157,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
             try {
                 val id = downloadId.toLong()
                 withContext(Dispatchers.IO) {
-                    val download = downloadDao.getDownload(id) ?: return@withContext
+                    downloadDao.getDownload(id) ?: return@withContext
                     downloadDao.updateStatus(id, DownloadStatus.QUEUED)
                     // KEEP policy: leave running work untouched, restart only if finished/missing
                     WorkerDownload.enqueueResume(reactApplicationContext, id)

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -33,7 +33,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     private val downloadDao = DownloadDatabase.getInstance(reactContext).downloadDao()
     private val workManager = WorkManager.getInstance(reactContext)
 
-    // LiveData observers keyed by downloadId — same pattern as PocketPal
+    // LiveData observers keyed by downloadId
     private val workObservers = mutableMapOf<Long, Observer<List<WorkInfo>>>()
 
     init {
@@ -70,6 +70,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
                 val modelId = params.getString("modelId") ?: ""
                 val title = params.getString("title") ?: fileName
                 val totalBytes = if (params.hasKey("totalBytes")) params.getDouble("totalBytes").toLong() else 0L
+                val expectedSha256 = params.getString("sha256")?.lowercase()?.takeIf { it.length == 64 }
 
                 val downloadId = System.currentTimeMillis()
                 val destination = File(
@@ -88,6 +89,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
                     downloadedBytes = 0L,
                     status = DownloadStatus.QUEUED,
                     createdAt = System.currentTimeMillis(),
+                    expectedSha256 = expectedSha256,
                 )
 
                 withContext(Dispatchers.IO) {
@@ -121,7 +123,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
                     if (download != null) {
                         downloadDao.updateStatus(id, DownloadStatus.CANCELLED, "Download cancelled by user")
                         val file = File(download.destination)
-                        if (file.exists()) file.delete()
+                        if (file.exists() && !file.delete()) DownloadEventBridge.log("W", "[Module] Could not delete partial file on cancel id=$id")
                     }
                 }
                 WorkerDownload.cancel(reactApplicationContext, id)
@@ -364,7 +366,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     }
 
     // -------------------------------------------------------------------------
-    // WorkInfo observer management — mirrors PocketPal's pattern exactly
+    // WorkInfo observer management
     // -------------------------------------------------------------------------
 
     private fun registerObserver(downloadId: Long) {

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
+import ai.offgridmobile.SafePromise
 
 class DownloadManagerModule(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext) {
@@ -158,17 +159,8 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
                 withContext(Dispatchers.IO) {
                     val download = downloadDao.getDownload(id) ?: return@withContext
                     downloadDao.updateStatus(id, DownloadStatus.QUEUED)
-                    // Only re-enqueue if WorkManager has no live work for this id
-                    val workName = WorkerDownload.workName(id)
-                    val workInfos = try {
-                        workManager.getWorkInfosForUniqueWork(workName).get()
-                    } catch (_: Exception) {
-                        null
-                    }
-                    val workInfo = workInfos?.firstOrNull()
-                    if (workInfo == null || workInfo.state.isFinished) {
-                        WorkerDownload.enqueue(reactApplicationContext, id)
-                    }
+                    // KEEP policy: leave running work untouched, restart only if finished/missing
+                    WorkerDownload.enqueueResume(reactApplicationContext, id)
                 }
                 registerObserver(id)
                 DownloadEventBridge.log("I", "[Module] resumeDownload id=$id")

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -33,7 +33,9 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     private val downloadDao = DownloadDatabase.getInstance(reactContext).downloadDao()
     private val workManager = WorkManager.getInstance(reactContext)
 
-    // LiveData observers keyed by downloadId
+    // LiveData observers keyed by downloadId — enables real-time progress tracking
+    // Future: integrate with device connectivity service to enforce WiFi-only downloads
+    // when requested, allowing models to resume over cellular if necessary.
     private val workObservers = mutableMapOf<Long, Observer<List<WorkInfo>>>()
 
     init {

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -280,47 +280,8 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
             return
         }
 
-        if (useWorkerDownloader) {
-            try {
-                val downloadId = System.currentTimeMillis()
-                val downloadInfo = JSONObject().apply {
-                    put("downloadId", downloadId)
-                    put("url", url)
-                    put("fileName", fileName)
-                    put("modelId", modelId)
-                    put("title", title)
-                    put("description", description)
-                    put("totalBytes", totalBytes)
-                    put("bytesDownloaded", 0)
-                    put("status", WorkerDownloadStore.STATUS_PENDING)
-                    put("startedAt", System.currentTimeMillis())
-                    put("backend", "worker")
-                    put("localUri", Uri.fromFile(File(
-                        reactApplicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-                        fileName
-                    )).toString())
-                }
-                WorkerDownloadStore.put(reactApplicationContext, downloadInfo)
-                DownloadEventBridge.log("I", "[Module] startDownload routed to worker id=$downloadId file=$fileName model=$modelId")
-                WorkerDownload.enqueue(
-                    reactApplicationContext,
-                    downloadId,
-                    url,
-                    fileName,
-                    modelId,
-                    title,
-                    totalBytes,
-                )
-                val result = Arguments.createMap().apply {
-                    putDouble("downloadId", downloadId.toDouble())
-                    putString("fileName", fileName)
-                    putString("modelId", modelId)
-                }
-                safeResolve(promise, result)
-                return
-            } catch (e: Exception) {
-                DownloadEventBridge.log("E", "[Module] worker start failed, falling back to legacy: ${e.message}")
-            }
+        if (useWorkerDownloader && tryStartWorkerDownload(url, fileName, modelId, title, description, totalBytes, promise)) {
+            return
         }
 
         // Resolve redirects on a background thread (network I/O)
@@ -393,6 +354,62 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
             } catch (e: Exception) {
                 safeReject(promise, "DOWNLOAD_ERROR", "Failed to start download: ${e.message}", e)
             }
+        }
+    }
+
+    /**
+     * Attempts to start a download via WorkManager. Returns true on success (promise resolved),
+     * false if it fails (caller should fall back to the legacy DownloadManager path).
+     */
+    private fun tryStartWorkerDownload(
+        url: String,
+        fileName: String,
+        modelId: String,
+        title: String,
+        description: String,
+        totalBytes: Long,
+        promise: Promise,
+    ): Boolean {
+        return try {
+            val downloadId = System.currentTimeMillis()
+            val downloadInfo = JSONObject().apply {
+                put("downloadId", downloadId)
+                put("url", url)
+                put("fileName", fileName)
+                put("modelId", modelId)
+                put("title", title)
+                put("description", description)
+                put("totalBytes", totalBytes)
+                put("bytesDownloaded", 0)
+                put("status", WorkerDownloadStore.STATUS_PENDING)
+                put("startedAt", System.currentTimeMillis())
+                put("backend", "worker")
+                put("localUri", Uri.fromFile(File(
+                    reactApplicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
+                    fileName
+                )).toString())
+            }
+            WorkerDownloadStore.put(reactApplicationContext, downloadInfo)
+            DownloadEventBridge.log("I", "[Module] startDownload routed to worker id=$downloadId file=$fileName model=$modelId")
+            WorkerDownload.enqueue(
+                reactApplicationContext,
+                downloadId,
+                url,
+                fileName,
+                modelId,
+                title,
+                totalBytes,
+            )
+            val result = Arguments.createMap().apply {
+                putDouble("downloadId", downloadId.toDouble())
+                putString("fileName", fileName)
+                putString("modelId", modelId)
+            }
+            safeResolve(promise, result)
+            true
+        } catch (e: Exception) {
+            DownloadEventBridge.log("E", "[Module] worker start failed, falling back to legacy: ${e.message}")
+            false
         }
     }
 
@@ -532,6 +549,22 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     fun moveCompletedDownload(downloadId: Double, targetPath: String, promise: Promise) {
         try {
             val id = downloadId.toLong()
+
+            // Validate target path against app sandbox directories to prevent path traversal.
+            // Skip validation only when targetPath is empty (cleanup-only mode).
+            if (targetPath.isNotEmpty()) {
+                val targetFile = File(targetPath)
+                val allowedDirs = listOfNotNull(
+                    reactApplicationContext.filesDir?.canonicalPath,
+                    reactApplicationContext.cacheDir?.canonicalPath,
+                    reactApplicationContext.getExternalFilesDir(null)?.canonicalPath,
+                )
+                if (allowedDirs.none { targetFile.canonicalPath.startsWith(it) }) {
+                    safeReject(promise, "MOVE_ERROR", "Target path is outside the app sandbox.")
+                    return
+                }
+            }
+
             val workerInfo = WorkerDownloadStore.get(reactApplicationContext, id)
             if (workerInfo != null) {
                 val fileName = workerInfo.optString("fileName")

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -191,7 +191,9 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
                         putString("title", d.title)
                         putDouble("totalBytes", d.totalBytes.toDouble())
                         putDouble("bytesDownloaded", d.downloadedBytes.toDouble())
-                        putString("status", d.status.name.lowercase())
+                        // QUEUED = WorkManager backoff retry — surface as "pending" to JS
+                        // so the download stays visible in the active list during retry.
+                        putString("status", if (d.status == DownloadStatus.QUEUED) "pending" else d.status.name.lowercase())
                         putString("localUri", Uri.fromFile(File(d.destination)).toString())
                         putDouble("startedAt", d.createdAt.toDouble())
                     })
@@ -217,7 +219,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
                     putDouble("downloadId", d.id.toDouble())
                     putDouble("bytesDownloaded", d.downloadedBytes.toDouble())
                     putDouble("totalBytes", d.totalBytes.toDouble())
-                    putString("status", d.status.name.lowercase())
+                    putString("status", if (d.status == DownloadStatus.QUEUED) "pending" else d.status.name.lowercase())
                     putString("localUri", Uri.fromFile(File(d.destination)).toString())
                     putString("reason", d.error ?: "")
                 }
@@ -374,6 +376,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
 
         val observer = Observer<List<WorkInfo>> { workInfos ->
             val info = workInfos.firstOrNull() ?: return@Observer
+            DownloadEventBridge.log("D", "[Observer] id=$downloadId WorkInfo.state=${info.state}")
             when (info.state) {
                 WorkInfo.State.RUNNING -> {
                     val bytes = info.progress.getLong(WorkerDownload.KEY_PROGRESS, 0L)

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.Uri
 import android.os.Environment
 import androidx.work.BackoffPolicy
-import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
@@ -18,159 +17,155 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
 import java.io.FileOutputStream
+import java.net.URL
 import java.util.concurrent.TimeUnit
-import kotlin.math.max
 
 class WorkerDownload(
     context: Context,
     params: WorkerParameters,
 ) : CoroutineWorker(context, params) {
 
+    private val downloadDao = DownloadDatabase.getInstance(context).downloadDao()
     private val client = httpClient
 
     override suspend fun doWork(): Result {
         val downloadId = inputData.getLong(KEY_DOWNLOAD_ID, -1L)
-        val url = inputData.getString(KEY_URL) ?: return Result.failure()
-        val fileName = inputData.getString(KEY_FILE_NAME) ?: return Result.failure()
-        val modelId = inputData.getString(KEY_MODEL_ID) ?: ""
-        val title = inputData.getString(KEY_TITLE) ?: fileName
-        val expectedTotalBytes = inputData.getLong(KEY_TOTAL_BYTES, 0L)
-        val targetFile = File(
-            applicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-            fileName
-        )
-        val tempDir = targetFile.parentFile
-        tempDir?.mkdirs()
-        DownloadEventBridge.log(
-            "I",
-            "[Worker] doWork start id=$downloadId attempt=$runAttemptCount file=$fileName model=$modelId"
-        )
-        DownloadForegroundService.start(applicationContext, title, downloadId)
-        WorkerDownloadStore.update(applicationContext, downloadId) {
-            it.put("status", WorkerDownloadStore.STATUS_RUNNING)
-            it.put("localUri", Uri.fromFile(targetFile).toString())
+        if (downloadId == -1L) return Result.failure()
+
+        val progressInterval = inputData.getLong(KEY_PROGRESS_INTERVAL, DEFAULT_PROGRESS_INTERVAL)
+
+        val download = downloadDao.getDownload(downloadId) ?: return Result.failure()
+        DownloadEventBridge.log("I", "[Worker] doWork start id=$downloadId attempt=$runAttemptCount file=${download.fileName}")
+
+        if (isStopped) {
+            downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, "Download cancelled")
+            return Result.failure()
         }
 
-        try {
-            val existingBytes = if (targetFile.exists()) targetFile.length() else 0L
-            val requestBuilder = Request.Builder().url(url)
-            if (existingBytes > 0L) {
-                requestBuilder.addHeader("Range", "bytes=$existingBytes-")
-            }
+        if (download.status == DownloadStatus.PAUSED) {
+            DownloadEventBridge.log("I", "[Worker] Paused — returning retry id=$downloadId")
+            return Result.retry()
+        }
 
-            val request = requestBuilder.build()
+        DownloadForegroundService.start(applicationContext, download.title, downloadId)
 
-            client.newCall(request).execute().use { response ->
+        val targetFile = File(download.destination)
+        targetFile.parentFile?.mkdirs()
+
+        // Sync file size with DB if they diverged (e.g. partial file from prior run)
+        if (targetFile.exists() && targetFile.length() != download.downloadedBytes) {
+            downloadDao.updateProgress(downloadId, targetFile.length(), download.totalBytes, DownloadStatus.RUNNING)
+        }
+
+        val requestBuilder = Request.Builder().url(download.url)
+        val existingBytes = if (targetFile.exists()) targetFile.length() else 0L
+        if (existingBytes > 0L) {
+            DownloadEventBridge.log("I", "[Worker] Resuming from byte $existingBytes id=$downloadId")
+            requestBuilder.addHeader("Range", "bytes=$existingBytes-")
+        }
+
+        downloadDao.updateStatus(downloadId, DownloadStatus.RUNNING)
+
+        return try {
+            client.newCall(requestBuilder.build()).execute().use { response ->
                 val code = response.code
                 DownloadEventBridge.log("I", "[Worker] Response id=$downloadId code=$code")
-                if (existingBytes > 0L && code == 200) {
-                    DownloadEventBridge.log("W", "[Worker] Server ignored range for id=$downloadId, restarting from zero")
-                    targetFile.delete()
-                } else if (code == 416) {
-                    DownloadEventBridge.log("E", "[Worker] Range invalid for id=$downloadId, deleting partial file")
-                    targetFile.delete()
-                    val reason = "Server rejected resume request (416)"
-                    fail(downloadId, fileName, modelId, reason)
-                    return Result.failure()
-                } else if (!response.isSuccessful) {
-                    val reason = "HTTP ${response.code}"
-                    DownloadEventBridge.log("E", "[Worker] Request failed id=$downloadId reason=$reason")
-                    fail(downloadId, fileName, modelId, reason)
-                    return if (response.code in 500..599) Result.retry() else Result.failure()
+
+                when {
+                    existingBytes > 0L && code == 200 -> {
+                        // Server ignored Range — restart from zero
+                        DownloadEventBridge.log("W", "[Worker] Server ignored Range, restarting id=$downloadId")
+                        targetFile.delete()
+                    }
+                    code == 416 -> {
+                        DownloadEventBridge.log("E", "[Worker] Range invalid id=$downloadId, deleting partial")
+                        targetFile.delete()
+                        downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, "Server rejected resume (416)")
+                        DownloadEventBridge.error(downloadId, download.fileName, download.modelId, "Server rejected resume (416)")
+                        WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker 416")
+                        return Result.failure()
+                    }
+                    !response.isSuccessful -> {
+                        val reason = "HTTP ${response.code}"
+                        DownloadEventBridge.log("E", "[Worker] Request failed id=$downloadId reason=$reason")
+                        downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, reason)
+                        DownloadEventBridge.error(downloadId, download.fileName, download.modelId, reason)
+                        WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker http error")
+                        return if (code in 500..599) Result.retry() else Result.failure()
+                    }
                 }
 
                 val body = response.body ?: run {
                     val reason = "Empty response body"
-                    DownloadEventBridge.log("E", "[Worker] No response body id=$downloadId")
-                    fail(downloadId, fileName, modelId, reason)
+                    downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, reason)
+                    DownloadEventBridge.error(downloadId, download.fileName, download.modelId, reason)
+                    WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker no body")
                     return Result.failure()
                 }
 
-                val currentFileBytes = if (targetFile.exists() && response.code == 206) targetFile.length() else 0L
+                val currentFileBytes = if (targetFile.exists() && code == 206) targetFile.length() else 0L
                 val contentLength = body.contentLength()
-                val totalBytes = when (response.code) {
+                val totalBytes = when (code) {
                     206 -> currentFileBytes + contentLength
                     200 -> contentLength
-                    else -> maxOf(expectedTotalBytes, contentLength)
-                }.coerceAtLeast(expectedTotalBytes)
+                    else -> maxOf(download.totalBytes, contentLength)
+                }.coerceAtLeast(download.totalBytes)
+
                 DownloadEventBridge.log("I", "[Worker] Transfer plan id=$downloadId existing=$currentFileBytes body=$contentLength total=$totalBytes")
+                downloadDao.updateProgress(downloadId, currentFileBytes, totalBytes, DownloadStatus.RUNNING)
 
                 var bytesWritten = currentFileBytes
                 var lastProgressAt = 0L
-                val appendMode = targetFile.exists() && response.code == 206
+                val appendMode = targetFile.exists() && code == 206
+
                 FileOutputStream(targetFile, appendMode).buffered().use { output ->
                     body.byteStream().buffered().use { input ->
                         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
                         var read = input.read(buffer)
                         while (read >= 0) {
                             if (isStopped) {
-                                val reason = "Worker stopped"
-                                DownloadEventBridge.log("W", "[Worker] Stopped mid-transfer id=$downloadId bytes=$bytesWritten")
-                                fail(downloadId, fileName, modelId, reason, WorkerDownloadStore.STATUS_CANCELLED)
+                                downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, "Download cancelled")
+                                DownloadEventBridge.error(downloadId, download.fileName, download.modelId, "Download cancelled", "cancelled")
+                                WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker stopped")
                                 return Result.failure()
                             }
+
+                            // Mid-loop pause check — same as PocketPal
+                            val current = downloadDao.getDownload(downloadId)
+                            if (current?.status == DownloadStatus.PAUSED) {
+                                DownloadEventBridge.log("I", "[Worker] Paused mid-transfer id=$downloadId bytes=$bytesWritten")
+                                return Result.retry()
+                            }
+
                             output.write(buffer, 0, read)
                             bytesWritten += read
+
                             val now = System.currentTimeMillis()
-                            if (now - lastProgressAt >= PROGRESS_INTERVAL_MS) {
-                                persistProgress(downloadId, bytesWritten, totalBytes)
-                                DownloadEventBridge.progress(downloadId, fileName, modelId, bytesWritten, totalBytes, WorkerDownloadStore.STATUS_RUNNING)
+                            if (now - lastProgressAt >= progressInterval) {
+                                setProgress(workDataOf(KEY_PROGRESS to bytesWritten, KEY_TOTAL to totalBytes))
+                                downloadDao.updateProgress(downloadId, bytesWritten, totalBytes, DownloadStatus.RUNNING)
                                 lastProgressAt = now
-                                setProgress(workDataOf(KEY_PROGRESS to bytesWritten, KEY_TOTAL_BYTES to totalBytes))
                             }
+
                             read = input.read(buffer)
                         }
                     }
                 }
 
-                persistProgress(downloadId, bytesWritten, totalBytes)
-                WorkerDownloadStore.update(applicationContext, downloadId) {
-                    it.put("status", WorkerDownloadStore.STATUS_COMPLETED)
-                    it.put("bytesDownloaded", bytesWritten)
-                    it.put("totalBytes", totalBytes)
-                    it.put("completedAt", System.currentTimeMillis())
-                    it.put("localUri", Uri.fromFile(targetFile).toString())
-                }
-                DownloadEventBridge.complete(
-                    downloadId,
-                    fileName,
-                    modelId,
-                    Uri.fromFile(targetFile).toString(),
-                    bytesWritten,
-                    totalBytes,
-                )
+                downloadDao.updateProgress(downloadId, bytesWritten, totalBytes, DownloadStatus.COMPLETED)
+                val localUri = Uri.fromFile(targetFile).toString()
                 DownloadEventBridge.log("I", "[Worker] Completed id=$downloadId bytes=$bytesWritten")
                 WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker completed")
-                return Result.success()
+                Result.success()
             }
         } catch (e: Exception) {
             val reason = e.message ?: e.javaClass.simpleName
-            DownloadEventBridge.log(
-                "E",
-                "[Worker] Exception id=$downloadId attempt=$runAttemptCount reason=$reason"
-            )
-            fail(downloadId, fileName, modelId, reason)
-            return Result.retry()
+            DownloadEventBridge.log("E", "[Worker] Exception id=$downloadId attempt=$runAttemptCount reason=$reason")
+            downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, reason)
+            DownloadEventBridge.error(downloadId, download.fileName, download.modelId, reason)
+            WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker exception")
+            Result.retry()
         }
-    }
-
-    private fun persistProgress(downloadId: Long, bytesWritten: Long, totalBytes: Long) {
-        WorkerDownloadStore.update(applicationContext, downloadId) {
-            it.put("status", WorkerDownloadStore.STATUS_RUNNING)
-            it.put("bytesDownloaded", bytesWritten)
-            it.put("totalBytes", totalBytes)
-            it.put("updatedAt", System.currentTimeMillis())
-        }
-    }
-
-    private fun fail(downloadId: Long, fileName: String, modelId: String, reason: String, status: String = WorkerDownloadStore.STATUS_FAILED) {
-        WorkerDownloadStore.update(applicationContext, downloadId) {
-            it.put("status", status)
-            it.put("reason", reason)
-            it.put("updatedAt", System.currentTimeMillis())
-        }
-        DownloadEventBridge.error(downloadId, fileName, modelId, reason, status)
-        WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker terminal status=$status")
     }
 
     companion object {
@@ -181,56 +176,74 @@ class WorkerDownload(
             .followSslRedirects(true)
             .build()
 
-        private const val PROGRESS_INTERVAL_MS = 750L
+        const val DEFAULT_PROGRESS_INTERVAL = 1000L
         const val KEY_DOWNLOAD_ID = "download_id"
-        const val KEY_URL = "url"
-        const val KEY_FILE_NAME = "file_name"
-        const val KEY_MODEL_ID = "model_id"
-        const val KEY_TITLE = "title"
-        const val KEY_TOTAL_BYTES = "total_bytes"
         const val KEY_PROGRESS = "progress"
+        const val KEY_TOTAL = "total"
+        const val KEY_PROGRESS_INTERVAL = "progress_interval"
+
+        private val allowedDownloadHosts = setOf(
+            "huggingface.co",
+            "cdn-lfs.huggingface.co",
+            "cas-bridge.xethub.hf.co",
+        )
+
+        fun isHostAllowed(url: String): Boolean {
+            val host = try { URL(url).host } catch (_: Exception) { return false }
+            return allowedDownloadHosts.any { host == it || host.endsWith(".$it") }
+        }
 
         fun enqueue(
             context: Context,
             downloadId: Long,
-            url: String,
-            fileName: String,
-            modelId: String,
-            title: String,
-            totalBytes: Long,
+            progressInterval: Long = DEFAULT_PROGRESS_INTERVAL,
         ): OneTimeWorkRequest {
             val request = OneTimeWorkRequestBuilder<WorkerDownload>()
                 .setConstraints(
-                    Constraints.Builder()
+                    androidx.work.Constraints.Builder()
                         .setRequiredNetworkType(NetworkType.CONNECTED)
                         .build()
                 )
                 .setBackoffCriteria(
                     BackoffPolicy.EXPONENTIAL,
                     WorkRequest.MIN_BACKOFF_MILLIS,
-                    TimeUnit.MILLISECONDS
+                    TimeUnit.MILLISECONDS,
                 )
                 .setInputData(
                     workDataOf(
                         KEY_DOWNLOAD_ID to downloadId,
-                        KEY_URL to url,
-                        KEY_FILE_NAME to fileName,
-                        KEY_MODEL_ID to modelId,
-                        KEY_TITLE to title,
-                        KEY_TOTAL_BYTES to totalBytes,
+                        KEY_PROGRESS_INTERVAL to progressInterval,
                     )
                 )
                 .build()
             WorkManager.getInstance(context).enqueueUniqueWork(
-                "worker_download_$downloadId",
+                workName(downloadId),
                 ExistingWorkPolicy.REPLACE,
-                request
+                request,
             )
             return request
         }
 
         fun cancel(context: Context, downloadId: Long) {
-            WorkManager.getInstance(context).cancelUniqueWork("worker_download_$downloadId")
+            WorkManager.getInstance(context).cancelUniqueWork(workName(downloadId))
         }
+
+        fun workName(downloadId: Long) = "download_$downloadId"
+    }
+}
+
+/**
+ * Thin shim so WorkerDownload can call stopForegroundServiceIfIdle without depending
+ * on the old WorkerDownloadStore. Checks both Room and legacy SharedPrefs are idle.
+ * Legacy path is empty now that DownloadManagerModule no longer uses SharedPrefs.
+ */
+private object WorkerDownloadStore {
+    fun stopForegroundServiceIfIdle(context: Context, reason: String) {
+        // With Room as the single source of truth the foreground service is stopped
+        // by the module's LiveData observer on COMPLETED/FAILED/CANCELLED.
+        // The worker calls this as a belt-and-suspenders stop when the app is backgrounded
+        // and the module observer may not be alive.
+        DownloadEventBridge.log("I", "[WorkerStore] stopForegroundServiceIfIdle: $reason")
+        DownloadForegroundService.stop(context, reason)
     }
 }

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -1,0 +1,233 @@
+package ai.offgridmobile.download
+
+import android.content.Context
+import android.net.Uri
+import android.os.Environment
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkRequest
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.TimeUnit
+import kotlin.math.max
+
+class WorkerDownload(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    private val client = OkHttpClient.Builder()
+        .retryOnConnectionFailure(true)
+        .followRedirects(true)
+        .followSslRedirects(true)
+        .build()
+
+    override suspend fun doWork(): Result {
+        val downloadId = inputData.getLong(KEY_DOWNLOAD_ID, -1L)
+        val url = inputData.getString(KEY_URL) ?: return Result.failure()
+        val fileName = inputData.getString(KEY_FILE_NAME) ?: return Result.failure()
+        val modelId = inputData.getString(KEY_MODEL_ID) ?: ""
+        val title = inputData.getString(KEY_TITLE) ?: fileName
+        val expectedTotalBytes = inputData.getLong(KEY_TOTAL_BYTES, 0L)
+        val targetFile = File(
+            applicationContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
+            fileName
+        )
+        val tempDir = targetFile.parentFile
+        tempDir?.mkdirs()
+        DownloadEventBridge.log(
+            "I",
+            "[Worker] doWork start id=$downloadId attempt=$runAttemptCount file=$fileName model=$modelId"
+        )
+        DownloadForegroundService.start(applicationContext, title, downloadId)
+        WorkerDownloadStore.update(applicationContext, downloadId) {
+            it.put("status", WorkerDownloadStore.STATUS_RUNNING)
+            it.put("localUri", Uri.fromFile(targetFile).toString())
+        }
+
+        try {
+            val existingBytes = if (targetFile.exists()) targetFile.length() else 0L
+            val requestBuilder = Request.Builder().url(url)
+            if (existingBytes > 0L) {
+                requestBuilder.addHeader("Range", "bytes=$existingBytes-")
+            }
+
+            val request = requestBuilder.build()
+
+            client.newCall(request).execute().use { response ->
+                val code = response.code
+                DownloadEventBridge.log("I", "[Worker] Response id=$downloadId code=$code")
+                if (existingBytes > 0L && code == 200) {
+                    DownloadEventBridge.log("W", "[Worker] Server ignored range for id=$downloadId, restarting from zero")
+                    targetFile.delete()
+                } else if (code == 416) {
+                    DownloadEventBridge.log("E", "[Worker] Range invalid for id=$downloadId, deleting partial file")
+                    targetFile.delete()
+                    val reason = "Server rejected resume request (416)"
+                    fail(downloadId, fileName, modelId, reason)
+                    return Result.failure()
+                } else if (!response.isSuccessful) {
+                    val reason = "HTTP ${response.code}"
+                    DownloadEventBridge.log("E", "[Worker] Request failed id=$downloadId reason=$reason")
+                    fail(downloadId, fileName, modelId, reason)
+                    return if (response.code in 500..599) Result.retry() else Result.failure()
+                }
+
+                val body = response.body ?: run {
+                    val reason = "Empty response body"
+                    DownloadEventBridge.log("E", "[Worker] No response body id=$downloadId")
+                    fail(downloadId, fileName, modelId, reason)
+                    return Result.failure()
+                }
+
+                val currentFileBytes = if (targetFile.exists() && response.code == 206) targetFile.length() else 0L
+                val contentLength = body.contentLength()
+                val totalBytes = when (response.code) {
+                    206 -> currentFileBytes + contentLength
+                    200 -> contentLength
+                    else -> maxOf(expectedTotalBytes, contentLength)
+                }.coerceAtLeast(expectedTotalBytes)
+                DownloadEventBridge.log("I", "[Worker] Transfer plan id=$downloadId existing=$currentFileBytes body=$contentLength total=$totalBytes")
+
+                var bytesWritten = currentFileBytes
+                var lastProgressAt = 0L
+                val appendMode = targetFile.exists() && response.code == 206
+                FileOutputStream(targetFile, appendMode).buffered().use { output ->
+                    body.byteStream().buffered().use { input ->
+                        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                        var read = input.read(buffer)
+                        while (read >= 0) {
+                            if (isStopped) {
+                                val reason = "Worker stopped"
+                                DownloadEventBridge.log("W", "[Worker] Stopped mid-transfer id=$downloadId bytes=$bytesWritten")
+                                fail(downloadId, fileName, modelId, reason, WorkerDownloadStore.STATUS_CANCELLED)
+                                return Result.failure()
+                            }
+                            output.write(buffer, 0, read)
+                            bytesWritten += read
+                            val now = System.currentTimeMillis()
+                            if (now - lastProgressAt >= PROGRESS_INTERVAL_MS) {
+                                persistProgress(downloadId, bytesWritten, totalBytes)
+                                DownloadEventBridge.progress(downloadId, fileName, modelId, bytesWritten, totalBytes, WorkerDownloadStore.STATUS_RUNNING)
+                                lastProgressAt = now
+                                setProgress(workDataOf(KEY_PROGRESS to bytesWritten, KEY_TOTAL_BYTES to totalBytes))
+                            }
+                            read = input.read(buffer)
+                        }
+                    }
+                }
+
+                persistProgress(downloadId, bytesWritten, totalBytes)
+                WorkerDownloadStore.update(applicationContext, downloadId) {
+                    it.put("status", WorkerDownloadStore.STATUS_COMPLETED)
+                    it.put("bytesDownloaded", bytesWritten)
+                    it.put("totalBytes", totalBytes)
+                    it.put("completedAt", System.currentTimeMillis())
+                    it.put("localUri", Uri.fromFile(targetFile).toString())
+                }
+                DownloadEventBridge.complete(
+                    downloadId,
+                    fileName,
+                    modelId,
+                    Uri.fromFile(targetFile).toString(),
+                    bytesWritten,
+                    totalBytes,
+                )
+                DownloadEventBridge.log("I", "[Worker] Completed id=$downloadId bytes=$bytesWritten")
+                WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker completed")
+                return Result.success()
+            }
+        } catch (e: Exception) {
+            val reason = e.message ?: e.javaClass.simpleName
+            DownloadEventBridge.log(
+                "E",
+                "[Worker] Exception id=$downloadId attempt=$runAttemptCount reason=$reason"
+            )
+            fail(downloadId, fileName, modelId, reason)
+            return Result.retry()
+        }
+    }
+
+    private fun persistProgress(downloadId: Long, bytesWritten: Long, totalBytes: Long) {
+        WorkerDownloadStore.update(applicationContext, downloadId) {
+            it.put("status", WorkerDownloadStore.STATUS_RUNNING)
+            it.put("bytesDownloaded", bytesWritten)
+            it.put("totalBytes", totalBytes)
+            it.put("updatedAt", System.currentTimeMillis())
+        }
+    }
+
+    private fun fail(downloadId: Long, fileName: String, modelId: String, reason: String, status: String = WorkerDownloadStore.STATUS_FAILED) {
+        WorkerDownloadStore.update(applicationContext, downloadId) {
+            it.put("status", status)
+            it.put("reason", reason)
+            it.put("updatedAt", System.currentTimeMillis())
+        }
+        DownloadEventBridge.error(downloadId, fileName, modelId, reason, status)
+        WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker terminal status=$status")
+    }
+
+    companion object {
+        private const val PROGRESS_INTERVAL_MS = 750L
+        const val KEY_DOWNLOAD_ID = "download_id"
+        const val KEY_URL = "url"
+        const val KEY_FILE_NAME = "file_name"
+        const val KEY_MODEL_ID = "model_id"
+        const val KEY_TITLE = "title"
+        const val KEY_TOTAL_BYTES = "total_bytes"
+        const val KEY_PROGRESS = "progress"
+
+        fun enqueue(
+            context: Context,
+            downloadId: Long,
+            url: String,
+            fileName: String,
+            modelId: String,
+            title: String,
+            totalBytes: Long,
+        ): OneTimeWorkRequest {
+            val request = OneTimeWorkRequestBuilder<WorkerDownload>()
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .setBackoffCriteria(
+                    BackoffPolicy.EXPONENTIAL,
+                    WorkRequest.MIN_BACKOFF_MILLIS,
+                    TimeUnit.MILLISECONDS
+                )
+                .setInputData(
+                    workDataOf(
+                        KEY_DOWNLOAD_ID to downloadId,
+                        KEY_URL to url,
+                        KEY_FILE_NAME to fileName,
+                        KEY_MODEL_ID to modelId,
+                        KEY_TITLE to title,
+                        KEY_TOTAL_BYTES to totalBytes,
+                    )
+                )
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                "worker_download_$downloadId",
+                ExistingWorkPolicy.REPLACE,
+                request
+            )
+            return request
+        }
+
+        fun cancel(context: Context, downloadId: Long) {
+            WorkManager.getInstance(context).cancelUniqueWork("worker_download_$downloadId")
+        }
+    }
+}

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -232,18 +232,3 @@ class WorkerDownload(
     }
 }
 
-/**
- * Thin shim so WorkerDownload can call stopForegroundServiceIfIdle without depending
- * on the old WorkerDownloadStore. Checks both Room and legacy SharedPrefs are idle.
- * Legacy path is empty now that DownloadManagerModule no longer uses SharedPrefs.
- */
-private object WorkerDownloadStore {
-    fun stopForegroundServiceIfIdle(context: Context, reason: String) {
-        // With Room as the single source of truth the foreground service is stopped
-        // by the module's LiveData observer on COMPLETED/FAILED/CANCELLED.
-        // The worker calls this as a belt-and-suspenders stop when the app is backgrounded
-        // and the module observer may not be alive.
-        DownloadEventBridge.log("I", "[WorkerStore] stopForegroundServiceIfIdle: $reason")
-        DownloadForegroundService.stop(context, reason)
-    }
-}

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -277,6 +277,20 @@ class WorkerDownload(
             return request
         }
 
+        /** Re-enqueue with KEEP policy — leaves running work untouched, restarts finished work. */
+        fun enqueueResume(context: Context, downloadId: Long, progressInterval: Long = DEFAULT_PROGRESS_INTERVAL) {
+            val request = OneTimeWorkRequestBuilder<WorkerDownload>()
+                .setConstraints(
+                    androidx.work.Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, WorkRequest.MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
+                .setInputData(workDataOf(KEY_DOWNLOAD_ID to downloadId, KEY_PROGRESS_INTERVAL to progressInterval))
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(workName(downloadId), ExistingWorkPolicy.KEEP, request)
+        }
+
         fun cancel(context: Context, downloadId: Long) {
             WorkManager.getInstance(context).cancelUniqueWork(workName(downloadId))
         }

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -1,7 +1,6 @@
 package ai.offgridmobile.download
 
 import android.content.Context
-import android.net.Uri
 import android.os.Environment
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
@@ -15,6 +14,7 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URL
@@ -33,7 +33,6 @@ class WorkerDownload(
         if (downloadId == -1L) return Result.failure()
 
         val progressInterval = inputData.getLong(KEY_PROGRESS_INTERVAL, DEFAULT_PROGRESS_INTERVAL)
-
         val download = downloadDao.getDownload(downloadId) ?: return Result.failure()
         DownloadEventBridge.log("I", "[Worker] doWork start id=$downloadId attempt=$runAttemptCount file=${download.fileName}")
 
@@ -41,7 +40,6 @@ class WorkerDownload(
             downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, "Download cancelled")
             return Result.failure()
         }
-
         if (download.status == DownloadStatus.PAUSED) {
             DownloadEventBridge.log("I", "[Worker] Paused — returning retry id=$downloadId")
             return Result.retry()
@@ -52,111 +50,14 @@ class WorkerDownload(
         val targetFile = File(download.destination)
         targetFile.parentFile?.mkdirs()
 
-        // Sync file size with DB if they diverged (e.g. partial file from prior run)
-        if (targetFile.exists() && targetFile.length() != download.downloadedBytes) {
-            downloadDao.updateProgress(downloadId, targetFile.length(), download.totalBytes, DownloadStatus.RUNNING)
-        }
+        syncFileSizeWithDb(downloadId, targetFile, download)
 
-        val requestBuilder = Request.Builder().url(download.url)
         val existingBytes = if (targetFile.exists()) targetFile.length() else 0L
-        if (existingBytes > 0L) {
-            DownloadEventBridge.log("I", "[Worker] Resuming from byte $existingBytes id=$downloadId")
-            requestBuilder.addHeader("Range", "bytes=$existingBytes-")
-        }
-
         downloadDao.updateStatus(downloadId, DownloadStatus.RUNNING)
 
         return try {
-            client.newCall(requestBuilder.build()).execute().use { response ->
-                val code = response.code
-                DownloadEventBridge.log("I", "[Worker] Response id=$downloadId code=$code")
-
-                when {
-                    existingBytes > 0L && code == 200 -> {
-                        // Server ignored Range — restart from zero
-                        DownloadEventBridge.log("W", "[Worker] Server ignored Range, restarting id=$downloadId")
-                        targetFile.delete()
-                    }
-                    code == 416 -> {
-                        DownloadEventBridge.log("E", "[Worker] Range invalid id=$downloadId, deleting partial")
-                        targetFile.delete()
-                        downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, "Server rejected resume (416)")
-                        DownloadEventBridge.error(downloadId, download.fileName, download.modelId, "Server rejected resume (416)")
-                        WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker 416")
-                        return Result.failure()
-                    }
-                    !response.isSuccessful -> {
-                        val reason = "HTTP ${response.code}"
-                        DownloadEventBridge.log("E", "[Worker] Request failed id=$downloadId reason=$reason")
-                        downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, reason)
-                        DownloadEventBridge.error(downloadId, download.fileName, download.modelId, reason)
-                        WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker http error")
-                        return if (code in 500..599) Result.retry() else Result.failure()
-                    }
-                }
-
-                val body = response.body ?: run {
-                    val reason = "Empty response body"
-                    downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, reason)
-                    DownloadEventBridge.error(downloadId, download.fileName, download.modelId, reason)
-                    WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker no body")
-                    return Result.failure()
-                }
-
-                val currentFileBytes = if (targetFile.exists() && code == 206) targetFile.length() else 0L
-                val contentLength = body.contentLength()
-                val totalBytes = when (code) {
-                    206 -> currentFileBytes + contentLength
-                    200 -> contentLength
-                    else -> maxOf(download.totalBytes, contentLength)
-                }.coerceAtLeast(download.totalBytes)
-
-                DownloadEventBridge.log("I", "[Worker] Transfer plan id=$downloadId existing=$currentFileBytes body=$contentLength total=$totalBytes")
-                downloadDao.updateProgress(downloadId, currentFileBytes, totalBytes, DownloadStatus.RUNNING)
-
-                var bytesWritten = currentFileBytes
-                var lastProgressAt = 0L
-                val appendMode = targetFile.exists() && code == 206
-
-                FileOutputStream(targetFile, appendMode).buffered().use { output ->
-                    body.byteStream().buffered().use { input ->
-                        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                        var read = input.read(buffer)
-                        while (read >= 0) {
-                            if (isStopped) {
-                                downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, "Download cancelled")
-                                DownloadEventBridge.error(downloadId, download.fileName, download.modelId, "Download cancelled", "cancelled")
-                                WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker stopped")
-                                return Result.failure()
-                            }
-
-                            // Mid-loop pause check — same as PocketPal
-                            val current = downloadDao.getDownload(downloadId)
-                            if (current?.status == DownloadStatus.PAUSED) {
-                                DownloadEventBridge.log("I", "[Worker] Paused mid-transfer id=$downloadId bytes=$bytesWritten")
-                                return Result.retry()
-                            }
-
-                            output.write(buffer, 0, read)
-                            bytesWritten += read
-
-                            val now = System.currentTimeMillis()
-                            if (now - lastProgressAt >= progressInterval) {
-                                setProgress(workDataOf(KEY_PROGRESS to bytesWritten, KEY_TOTAL to totalBytes))
-                                downloadDao.updateProgress(downloadId, bytesWritten, totalBytes, DownloadStatus.RUNNING)
-                                lastProgressAt = now
-                            }
-
-                            read = input.read(buffer)
-                        }
-                    }
-                }
-
-                downloadDao.updateProgress(downloadId, bytesWritten, totalBytes, DownloadStatus.COMPLETED)
-                val localUri = Uri.fromFile(targetFile).toString()
-                DownloadEventBridge.log("I", "[Worker] Completed id=$downloadId bytes=$bytesWritten")
-                WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker completed")
-                Result.success()
+            client.newCall(buildRequest(download.url, existingBytes)).execute().use { response ->
+                handleResponse(response, existingBytes, download, downloadId, targetFile, progressInterval)
             }
         } catch (e: Exception) {
             val reason = e.message ?: e.javaClass.simpleName
@@ -167,6 +68,158 @@ class WorkerDownload(
             Result.retry()
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Private helpers — each handles one concern to keep cognitive complexity low
+    // -------------------------------------------------------------------------
+
+    private suspend fun syncFileSizeWithDb(downloadId: Long, targetFile: File, download: DownloadEntity) {
+        if (targetFile.exists() && targetFile.length() != download.downloadedBytes) {
+            downloadDao.updateProgress(downloadId, targetFile.length(), download.totalBytes, DownloadStatus.RUNNING)
+        }
+    }
+
+    private fun buildRequest(url: String, existingBytes: Long): Request {
+        val builder = Request.Builder().url(url)
+        if (existingBytes > 0L) {
+            DownloadEventBridge.log("I", "[Worker] Resuming from byte $existingBytes")
+            builder.addHeader("Range", "bytes=$existingBytes-")
+        }
+        return builder.build()
+    }
+
+    private suspend fun handleResponse(
+        response: Response,
+        existingBytes: Long,
+        download: DownloadEntity,
+        downloadId: Long,
+        targetFile: File,
+        progressInterval: Long,
+    ): Result {
+        val code = response.code
+        DownloadEventBridge.log("I", "[Worker] Response id=$downloadId code=$code")
+
+        val earlyResult = handleResponseCode(response, code, existingBytes, download, downloadId, targetFile)
+        if (earlyResult != null) return earlyResult
+
+        val body = response.body ?: return failDownload(downloadId, download, "Empty response body", "worker no body")
+
+        val currentFileBytes = if (targetFile.exists() && code == 206) targetFile.length() else 0L
+        val contentLength = body.contentLength()
+        val totalBytes = calculateTotalBytes(code, currentFileBytes, contentLength, download.totalBytes)
+
+        DownloadEventBridge.log("I", "[Worker] Transfer plan id=$downloadId existing=$currentFileBytes body=$contentLength total=$totalBytes")
+        downloadDao.updateProgress(downloadId, currentFileBytes, totalBytes, DownloadStatus.RUNNING)
+
+        return streamToFile(body.byteStream().buffered(), targetFile, code, download, downloadId, currentFileBytes, totalBytes, progressInterval)
+    }
+
+    /** Returns a non-null Result to exit early, or null to continue processing. */
+    private suspend fun handleResponseCode(
+        response: Response,
+        code: Int,
+        existingBytes: Long,
+        download: DownloadEntity,
+        downloadId: Long,
+        targetFile: File,
+    ): Result? {
+        return when {
+            existingBytes > 0L && code == 200 -> {
+                DownloadEventBridge.log("W", "[Worker] Server ignored Range, restarting id=$downloadId")
+                targetFile.delete()
+                null
+            }
+            code == 416 -> {
+                DownloadEventBridge.log("E", "[Worker] Range invalid id=$downloadId, deleting partial")
+                targetFile.delete()
+                failDownload(downloadId, download, "Server rejected resume (416)", "worker 416")
+            }
+            !response.isSuccessful -> {
+                val reason = "HTTP $code"
+                DownloadEventBridge.log("E", "[Worker] Request failed id=$downloadId reason=$reason")
+                downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, reason)
+                DownloadEventBridge.error(downloadId, download.fileName, download.modelId, reason)
+                WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker http error")
+                if (code in 500..599) Result.retry() else Result.failure()
+            }
+            else -> null
+        }
+    }
+
+    private fun calculateTotalBytes(code: Int, currentFileBytes: Long, contentLength: Long, existingTotal: Long): Long {
+        return when (code) {
+            206 -> currentFileBytes + contentLength
+            200 -> contentLength
+            else -> maxOf(existingTotal, contentLength)
+        }.coerceAtLeast(existingTotal)
+    }
+
+    private suspend fun streamToFile(
+        input: java.io.InputStream,
+        targetFile: File,
+        code: Int,
+        download: DownloadEntity,
+        downloadId: Long,
+        currentFileBytes: Long,
+        totalBytes: Long,
+        progressInterval: Long,
+    ): Result {
+        val appendMode = targetFile.exists() && code == 206
+        var bytesWritten = currentFileBytes
+        var lastProgressAt = 0L
+
+        FileOutputStream(targetFile, appendMode).buffered().use { output ->
+            input.use { src ->
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                var read = src.read(buffer)
+                while (read >= 0) {
+                    val checkResult = checkCancellationOrPause(downloadId, download, bytesWritten)
+                    if (checkResult != null) return checkResult
+
+                    output.write(buffer, 0, read)
+                    bytesWritten += read
+
+                    val now = System.currentTimeMillis()
+                    if (now - lastProgressAt >= progressInterval) {
+                        setProgress(workDataOf(KEY_PROGRESS to bytesWritten, KEY_TOTAL to totalBytes))
+                        downloadDao.updateProgress(downloadId, bytesWritten, totalBytes, DownloadStatus.RUNNING)
+                        lastProgressAt = now
+                    }
+                    read = src.read(buffer)
+                }
+            }
+        }
+
+        downloadDao.updateProgress(downloadId, bytesWritten, totalBytes, DownloadStatus.COMPLETED)
+        DownloadEventBridge.log("I", "[Worker] Completed id=$downloadId bytes=$bytesWritten")
+        WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker completed")
+        return Result.success()
+    }
+
+    /** Returns a non-null Result if the loop should stop, null to continue. */
+    private suspend fun checkCancellationOrPause(downloadId: Long, download: DownloadEntity, bytesWritten: Long): Result? {
+        if (isStopped) {
+            downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, "Download cancelled")
+            DownloadEventBridge.error(downloadId, download.fileName, download.modelId, "Download cancelled", "cancelled")
+            WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker stopped")
+            return Result.failure()
+        }
+        val current = downloadDao.getDownload(downloadId)
+        if (current?.status == DownloadStatus.PAUSED) {
+            DownloadEventBridge.log("I", "[Worker] Paused mid-transfer id=$downloadId bytes=$bytesWritten")
+            return Result.retry()
+        }
+        return null
+    }
+
+    private suspend fun failDownload(downloadId: Long, download: DownloadEntity, reason: String, serviceReason: String): Result {
+        downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, reason)
+        DownloadEventBridge.error(downloadId, download.fileName, download.modelId, reason)
+        WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, serviceReason)
+        return Result.failure()
+    }
+
+    // -------------------------------------------------------------------------
 
     companion object {
         // Shared across all WorkerDownload instances — reuses connection and thread pools.
@@ -231,4 +284,3 @@ class WorkerDownload(
         fun workName(downloadId: Long) = "download_$downloadId"
     }
 }
-

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -2,6 +2,7 @@ package ai.offgridmobile.download
 
 import android.content.Context
 import android.os.Environment
+import android.os.StatFs
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingWorkPolicy
@@ -18,7 +19,10 @@ import okhttp3.Response
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
+import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
+import kotlin.math.abs
+import kotlinx.coroutines.Job
 
 class WorkerDownload(
     context: Context,
@@ -56,30 +60,69 @@ class WorkerDownload(
 
         val existingBytes = if (targetFile.exists()) targetFile.length() else 0L
         DownloadEventBridge.log("I", "[Worker] Resume offset=${existingBytes}B file=${targetFile.absolutePath}")
+
+        // Disk space check — fail fast rather than filling the disk mid-download
+        if (download.totalBytes > 0L) {
+            val needed = download.totalBytes - existingBytes
+            val available = StatFs(targetFile.parentFile?.absolutePath ?: download.destination).availableBytes
+            DownloadEventBridge.log("I", "[Worker] Disk space id=$downloadId need=${needed / 1024 / 1024}MB available=${available / 1024 / 1024}MB")
+            if (available < needed) {
+                val reason = "Not enough disk space (need ${needed / 1024 / 1024}MB, have ${available / 1024 / 1024}MB)"
+                return failDownload(downloadId, download, reason, "worker disk space")
+            }
+        }
+
         downloadDao.updateStatus(downloadId, DownloadStatus.RUNNING)
 
         val requestStartMs = System.currentTimeMillis()
+        val call = client.newCall(buildRequest(download.url, existingBytes))
+        // Cancel the OkHttp socket immediately when WorkManager stops this worker.
+        // CoroutineWorker.onStopped() is final — it cancels the coroutine Job.
+        // invokeOnCompletion fires on cancellation, closing the socket before the next buffer read.
+        val cancelHandle = coroutineContext[Job]?.invokeOnCompletion { call.cancel() }
         return try {
-            client.newCall(buildRequest(download.url, existingBytes)).execute().use { response ->
+            call.execute().use { response ->
                 val ttfbMs = System.currentTimeMillis() - requestStartMs
                 DownloadEventBridge.log("I", "[Worker] TTFB id=$downloadId: ${ttfbMs}ms (time to first byte / server response)")
                 handleResponse(response, existingBytes, download, downloadId, targetFile, progressInterval)
             }
         } catch (e: Exception) {
-            val elapsed = System.currentTimeMillis() - requestStartMs
-            val reason = e.message ?: e.javaClass.simpleName
-            DownloadEventBridge.log("E", "[Worker] Exception id=$downloadId attempt=$runAttemptCount elapsed=${elapsed}ms reason=$reason")
-            DownloadEventBridge.log("E", "[Worker] Stack: ${e.stackTraceToString().take(400)}")
-            downloadDao.updateStatus(downloadId, DownloadStatus.QUEUED, reason)
-            DownloadEventBridge.retrying(downloadId, download.fileName, download.modelId, reason, runAttemptCount)
-            WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker exception")
-            Result.retry()
+            if (isStopped) {
+                // call.cancel() caused the IOException — treat as user cancellation, not a network error
+                val partial = File(download.destination)
+                if (partial.exists() && !partial.delete()) DownloadEventBridge.log("W", "[Worker] Could not delete partial on cancel id=$downloadId")
+                downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, MSG_DOWNLOAD_CANCELLED)
+                WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker cancelled")
+                Result.failure()
+            } else {
+                val elapsed = System.currentTimeMillis() - requestStartMs
+                val reason = e.message ?: e.javaClass.simpleName
+                DownloadEventBridge.log("E", "[Worker] Exception id=$downloadId attempt=$runAttemptCount elapsed=${elapsed}ms reason=$reason")
+                DownloadEventBridge.log("E", "[Worker] Stack: ${e.stackTraceToString().take(400)}")
+                downloadDao.updateStatus(downloadId, DownloadStatus.QUEUED, reason)
+                DownloadEventBridge.retrying(downloadId, download.fileName, download.modelId, reason, runAttemptCount)
+                WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker exception")
+                Result.retry()
+            }
+        } finally {
+            cancelHandle?.dispose()
         }
     }
 
     // -------------------------------------------------------------------------
     // Private helpers — each handles one concern to keep cognitive complexity low
     // -------------------------------------------------------------------------
+
+    private data class StreamParams(
+        val input: java.io.InputStream,
+        val targetFile: File,
+        val code: Int,
+        val download: DownloadEntity,
+        val downloadId: Long,
+        val currentFileBytes: Long,
+        val totalBytes: Long,
+        val progressInterval: Long,
+    )
 
     private suspend fun syncFileSizeWithDb(downloadId: Long, targetFile: File, download: DownloadEntity) {
         if (targetFile.exists() && targetFile.length() != download.downloadedBytes) {
@@ -122,7 +165,7 @@ class WorkerDownload(
         DownloadEventBridge.log("I", "[Worker] Transfer plan id=$downloadId existing=$currentFileBytes body=$contentLength total=$totalBytes")
         downloadDao.updateProgress(downloadId, currentFileBytes, totalBytes, DownloadStatus.RUNNING)
 
-        return streamToFile(body.byteStream().buffered(), targetFile, code, download, downloadId, currentFileBytes, totalBytes, progressInterval)
+        return streamToFile(StreamParams(body.byteStream().buffered(), targetFile, code, download, downloadId, currentFileBytes, totalBytes, progressInterval))
     }
 
     /** Returns a non-null Result to exit early, or null to continue processing. */
@@ -165,16 +208,8 @@ class WorkerDownload(
         }.coerceAtLeast(existingTotal)
     }
 
-    private suspend fun streamToFile(
-        input: java.io.InputStream,
-        targetFile: File,
-        code: Int,
-        download: DownloadEntity,
-        downloadId: Long,
-        currentFileBytes: Long,
-        totalBytes: Long,
-        progressInterval: Long,
-    ): Result {
+    private suspend fun streamToFile(params: StreamParams): Result {
+        val (input, targetFile, code, download, downloadId, currentFileBytes, totalBytes, progressInterval) = params
         val appendMode = targetFile.exists() && code == 206
         var bytesWritten = currentFileBytes
         var lastProgressAt = 0L
@@ -209,8 +244,32 @@ class WorkerDownload(
 
         val totalElapsedMs = (System.currentTimeMillis() - transferStartMs).coerceAtLeast(1L)
         val avgSpeedKBps = (bytesWritten - currentFileBytes) * 1000L / totalElapsedMs / 1024L
+        DownloadEventBridge.log("I", "[Worker] Stream done id=$downloadId bytes=$bytesWritten elapsed=${totalElapsedMs}ms avgSpeed=${avgSpeedKBps}KB/s")
+
+        // SHA256 integrity check — only if file size doesn't match (avoid expensive hash computation on mobile)
+        // Most downloads will match size exactly, so this rarely runs.
+        // Only check hash if size is off by > 0.1%, indicating truncation or corruption.
+        val expectedSha256 = download.expectedSha256
+        if (!expectedSha256.isNullOrEmpty() && download.totalBytes > 0L) {
+            val sizeDiffPercent = abs(bytesWritten - download.totalBytes).toDouble() / download.totalBytes
+            if (sizeDiffPercent > 0.001) {
+                // File size mismatch > 0.1% — verify integrity with SHA256 before failing
+                DownloadEventBridge.log("I", "[Worker] Size mismatch (${(sizeDiffPercent * 100).toInt()}%) — verifying SHA256 id=$downloadId")
+                val actual = computeFileSha256(targetFile)
+                if (!actual.equals(expectedSha256, ignoreCase = true)) {
+                    DownloadEventBridge.log("E", "[Worker] SHA256 mismatch id=$downloadId expected=$expectedSha256 actual=$actual")
+                    if (!targetFile.delete()) DownloadEventBridge.log("W", "[Worker] Could not delete corrupt file id=$downloadId")
+                    return failDownload(downloadId, download, "File corrupted (size mismatch + hash failure)", "worker sha256 mismatch")
+                }
+                DownloadEventBridge.log("I", "[Worker] SHA256 matches despite size mismatch (server quirk?) id=$downloadId")
+            } else {
+                // File size matches within tolerance — skip expensive hash computation, assume valid
+                DownloadEventBridge.log("I", "[Worker] File size matches expected (within 0.1%) — skipping SHA256 check id=$downloadId")
+            }
+        }
+
         downloadDao.updateProgress(downloadId, bytesWritten, totalBytes, DownloadStatus.COMPLETED)
-        DownloadEventBridge.log("I", "[Worker] Completed id=$downloadId bytes=$bytesWritten elapsed=${totalElapsedMs}ms avgSpeed=${avgSpeedKBps}KB/s")
+        DownloadEventBridge.log("I", "[Worker] Completed id=$downloadId")
         WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker completed")
         return Result.success()
     }
@@ -273,6 +332,20 @@ class WorkerDownload(
         const val KEY_PROGRESS = "progress"
         const val KEY_TOTAL = "total"
         const val KEY_PROGRESS_INTERVAL = "progress_interval"
+
+        /** Computes the lowercase hex SHA-256 digest of [file]. Internal for testability. */
+        internal fun computeFileSha256(file: File): String {
+            val digest = MessageDigest.getInstance("SHA-256")
+            file.inputStream().buffered().use { input ->
+                val buf = ByteArray(DEFAULT_BUFFER_SIZE)
+                var n = input.read(buf)
+                while (n >= 0) {
+                    digest.update(buf, 0, n)
+                    n = input.read(buf)
+                }
+            }
+            return digest.digest().joinToString("") { "%02x".format(it) }
+        }
 
         private val allowedDownloadHosts = setOf(
             "huggingface.co",

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -195,15 +195,9 @@ class WorkerDownload(
 
                     val now = System.currentTimeMillis()
                     if (now - lastProgressAt >= progressInterval) {
-                        val intervalMs = (now - lastSpeedTs).coerceAtLeast(1L)
-                        val speedKBps = (bytesWritten - lastSpeedBytes) * 1000L / intervalMs / 1024L
-                        val pct = if (totalBytes > 0) (bytesWritten * 100L / totalBytes) else 0L
-                        DownloadEventBridge.log("I", "[Worker] Progress id=$downloadId ${pct}% ${bytesWritten / 1024 / 1024}MB/${totalBytes / 1024 / 1024}MB speed=${speedKBps}KB/s")
+                        emitProgressUpdate(downloadId, bytesWritten, totalBytes, lastSpeedBytes, lastSpeedTs, now)
                         lastSpeedBytes = bytesWritten
                         lastSpeedTs = now
-
-                        setProgress(workDataOf(KEY_PROGRESS to bytesWritten, KEY_TOTAL to totalBytes))
-                        downloadDao.updateProgress(downloadId, bytesWritten, totalBytes, DownloadStatus.RUNNING)
                         lastProgressAt = now
                     }
                     read = src.read(buffer)
@@ -233,6 +227,22 @@ class WorkerDownload(
             return Result.retry()
         }
         return null
+    }
+
+    private suspend fun emitProgressUpdate(
+        downloadId: Long,
+        bytesWritten: Long,
+        totalBytes: Long,
+        lastSpeedBytes: Long,
+        lastSpeedTs: Long,
+        now: Long,
+    ) {
+        val intervalMs = (now - lastSpeedTs).coerceAtLeast(1L)
+        val speedKBps = (bytesWritten - lastSpeedBytes) * 1000L / intervalMs / 1024L
+        val pct = if (totalBytes > 0) bytesWritten * 100L / totalBytes else 0L
+        DownloadEventBridge.log("I", "[Worker] Progress id=$downloadId ${pct}% ${bytesWritten / 1024 / 1024}MB/${totalBytes / 1024 / 1024}MB speed=${speedKBps}KB/s")
+        setProgress(workDataOf(KEY_PROGRESS to bytesWritten, KEY_TOTAL to totalBytes))
+        downloadDao.updateProgress(downloadId, bytesWritten, totalBytes, DownloadStatus.RUNNING)
     }
 
     private suspend fun failDownload(downloadId: Long, download: DownloadEntity, reason: String, serviceReason: String): Result {

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -26,11 +26,7 @@ class WorkerDownload(
     params: WorkerParameters,
 ) : CoroutineWorker(context, params) {
 
-    private val client = OkHttpClient.Builder()
-        .retryOnConnectionFailure(true)
-        .followRedirects(true)
-        .followSslRedirects(true)
-        .build()
+    private val client = httpClient
 
     override suspend fun doWork(): Result {
         val downloadId = inputData.getLong(KEY_DOWNLOAD_ID, -1L)
@@ -178,6 +174,13 @@ class WorkerDownload(
     }
 
     companion object {
+        // Shared across all WorkerDownload instances — reuses connection and thread pools.
+        val httpClient: OkHttpClient = OkHttpClient.Builder()
+            .retryOnConnectionFailure(true)
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .build()
+
         private const val PROGRESS_INTERVAL_MS = 750L
         const val KEY_DOWNLOAD_ID = "download_id"
         const val KEY_URL = "url"

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -17,7 +17,7 @@ import okhttp3.Request
 import okhttp3.Response
 import java.io.File
 import java.io.FileOutputStream
-import java.net.URL
+import java.net.URI
 import java.util.concurrent.TimeUnit
 
 class WorkerDownload(
@@ -37,6 +37,8 @@ class WorkerDownload(
         DownloadEventBridge.log("I", "[Worker] doWork start id=$downloadId attempt=$runAttemptCount file=${download.fileName}")
 
         if (isStopped) {
+            val partial = File(download.destination)
+            if (partial.exists() && !partial.delete()) DownloadEventBridge.log("W", "[Worker] Could not delete partial on early cancel id=$downloadId")
             downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, MSG_DOWNLOAD_CANCELLED)
             return Result.failure()
         }
@@ -135,12 +137,12 @@ class WorkerDownload(
         return when {
             existingBytes > 0L && code == 200 -> {
                 DownloadEventBridge.log("W", "[Worker] Server returned 200 despite Range header — resume not supported, restarting from 0. id=$downloadId existingBytes=$existingBytes")
-                targetFile.delete()
+                if (!targetFile.delete()) DownloadEventBridge.log("W", "[Worker] Could not delete partial file for restart id=$downloadId")
                 null
             }
             code == 416 -> {
                 DownloadEventBridge.log("E", "[Worker] Range invalid id=$downloadId, deleting partial")
-                targetFile.delete()
+                if (!targetFile.delete()) DownloadEventBridge.log("W", "[Worker] Could not delete partial file on 416 id=$downloadId")
                 failDownload(downloadId, download, "Server rejected resume (416)", "worker 416")
             }
             !response.isSuccessful -> {
@@ -216,6 +218,8 @@ class WorkerDownload(
     /** Returns a non-null Result if the loop should stop, null to continue. */
     private suspend fun checkCancellationOrPause(downloadId: Long, download: DownloadEntity, bytesWritten: Long): Result? {
         if (isStopped) {
+            val partial = File(download.destination)
+            if (partial.exists() && !partial.delete()) DownloadEventBridge.log("W", "[Worker] Could not delete partial on cancel id=$downloadId bytes=$bytesWritten")
             downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, MSG_DOWNLOAD_CANCELLED)
             DownloadEventBridge.error(downloadId, download.fileName, download.modelId, MSG_DOWNLOAD_CANCELLED, "cancelled")
             WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker stopped")
@@ -277,7 +281,8 @@ class WorkerDownload(
         )
 
         fun isHostAllowed(url: String): Boolean {
-            val host = try { URL(url).host } catch (_: Exception) { return false }
+            val host = try { URI(url).host } catch (_: Exception) { return false }
+            if (host == null) return false
             return allowedDownloadHosts.any { host == it || host.endsWith(".$it") }
         }
 

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -245,7 +245,7 @@ class WorkerDownload(
     // -------------------------------------------------------------------------
 
     companion object {
-        const val MSG_DOWNLOAD_CANCELLED = MSG_DOWNLOAD_CANCELLED
+        const val MSG_DOWNLOAD_CANCELLED = "Download cancelled"
 
         // Shared across all WorkerDownload instances — reuses connection and thread pools.
         val httpClient: OkHttpClient = OkHttpClient.Builder()

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -40,16 +40,9 @@ class WorkerDownload(
         val download = downloadDao.getDownload(downloadId) ?: return Result.failure()
         DownloadEventBridge.log("I", "[Worker] doWork start id=$downloadId attempt=$runAttemptCount file=${download.fileName}")
 
-        if (isStopped) {
-            val partial = File(download.destination)
-            if (partial.exists() && !partial.delete()) DownloadEventBridge.log("W", "[Worker] Could not delete partial on early cancel id=$downloadId")
-            downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, MSG_DOWNLOAD_CANCELLED)
-            return Result.failure()
-        }
-        if (download.status == DownloadStatus.PAUSED) {
-            DownloadEventBridge.log("I", "[Worker] Paused on start — will retry when resumed id=$downloadId")
-            return Result.retry()
-        }
+        // Handle early stops and pauses
+        val earlyCheckResult = handleEarlyStopOrPause(downloadId, download)
+        if (earlyCheckResult != null) return earlyCheckResult
 
         DownloadForegroundService.start(applicationContext, download.title, downloadId)
 
@@ -62,23 +55,13 @@ class WorkerDownload(
         DownloadEventBridge.log("I", "[Worker] Resume offset=${existingBytes}B file=${targetFile.absolutePath}")
 
         // Disk space check — fail fast rather than filling the disk mid-download
-        if (download.totalBytes > 0L) {
-            val needed = download.totalBytes - existingBytes
-            val available = StatFs(targetFile.parentFile?.absolutePath ?: download.destination).availableBytes
-            DownloadEventBridge.log("I", "[Worker] Disk space id=$downloadId need=${needed / 1024 / 1024}MB available=${available / 1024 / 1024}MB")
-            if (available < needed) {
-                val reason = "Not enough disk space (need ${needed / 1024 / 1024}MB, have ${available / 1024 / 1024}MB)"
-                return failDownload(downloadId, download, reason, "worker disk space")
-            }
-        }
+        val diskCheckResult = checkDiskSpace(downloadId, download, targetFile, existingBytes)
+        if (diskCheckResult != null) return diskCheckResult
 
         downloadDao.updateStatus(downloadId, DownloadStatus.RUNNING)
 
         val requestStartMs = System.currentTimeMillis()
         val call = client.newCall(buildRequest(download.url, existingBytes))
-        // Cancel the OkHttp socket immediately when WorkManager stops this worker.
-        // CoroutineWorker.onStopped() is final — it cancels the coroutine Job.
-        // invokeOnCompletion fires on cancellation, closing the socket before the next buffer read.
         val cancelHandle = coroutineContext[Job]?.invokeOnCompletion { call.cancel() }
         return try {
             call.execute().use { response ->
@@ -87,26 +70,57 @@ class WorkerDownload(
                 handleResponse(response, existingBytes, download, downloadId, targetFile, progressInterval)
             }
         } catch (e: Exception) {
-            if (isStopped) {
-                // call.cancel() caused the IOException — treat as user cancellation, not a network error
-                val partial = File(download.destination)
-                if (partial.exists() && !partial.delete()) DownloadEventBridge.log("W", "[Worker] Could not delete partial on cancel id=$downloadId")
-                downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, MSG_DOWNLOAD_CANCELLED)
-                WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker cancelled")
-                Result.failure()
-            } else {
-                val elapsed = System.currentTimeMillis() - requestStartMs
-                val reason = e.message ?: e.javaClass.simpleName
-                DownloadEventBridge.log("E", "[Worker] Exception id=$downloadId attempt=$runAttemptCount elapsed=${elapsed}ms reason=$reason")
-                DownloadEventBridge.log("E", "[Worker] Stack: ${e.stackTraceToString().take(400)}")
-                downloadDao.updateStatus(downloadId, DownloadStatus.QUEUED, reason)
-                DownloadEventBridge.retrying(downloadId, download.fileName, download.modelId, reason, runAttemptCount)
-                WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker exception")
-                Result.retry()
-            }
+            handleDownloadException(e, downloadId, download, requestStartMs)
         } finally {
             cancelHandle?.dispose()
         }
+    }
+
+    /** Returns non-null Result if should exit early, null to continue. */
+    private suspend fun handleEarlyStopOrPause(downloadId: Long, download: DownloadEntity): Result? {
+        if (isStopped) {
+            val partial = File(download.destination)
+            if (partial.exists() && !partial.delete()) DownloadEventBridge.log("W", "[Worker] Could not delete partial on early cancel id=$downloadId")
+            downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, MSG_DOWNLOAD_CANCELLED)
+            return Result.failure()
+        }
+        if (download.status == DownloadStatus.PAUSED) {
+            DownloadEventBridge.log("I", "[Worker] Paused on start — will retry when resumed id=$downloadId")
+            return Result.retry()
+        }
+        return null
+    }
+
+    /** Returns non-null Result if disk space check fails, null to continue. */
+    private suspend fun checkDiskSpace(downloadId: Long, download: DownloadEntity, targetFile: File, existingBytes: Long): Result? {
+        if (download.totalBytes <= 0L) return null
+        val needed = download.totalBytes - existingBytes
+        val available = StatFs(targetFile.parentFile?.absolutePath ?: download.destination).availableBytes
+        DownloadEventBridge.log("I", "[Worker] Disk space id=$downloadId need=${needed / 1024 / 1024}MB available=${available / 1024 / 1024}MB")
+        if (available < needed) {
+            val reason = "Not enough disk space (need ${needed / 1024 / 1024}MB, have ${available / 1024 / 1024}MB)"
+            return failDownload(downloadId, download, reason, "worker disk space")
+        }
+        return null
+    }
+
+    /** Handles exceptions during download. */
+    private suspend fun handleDownloadException(e: Exception, downloadId: Long, download: DownloadEntity, requestStartMs: Long): Result {
+        if (isStopped) {
+            val partial = File(download.destination)
+            if (partial.exists() && !partial.delete()) DownloadEventBridge.log("W", "[Worker] Could not delete partial on cancel id=$downloadId")
+            downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, MSG_DOWNLOAD_CANCELLED)
+            WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker cancelled")
+            return Result.failure()
+        }
+        val elapsed = System.currentTimeMillis() - requestStartMs
+        val reason = e.message ?: e.javaClass.simpleName
+        DownloadEventBridge.log("E", "[Worker] Exception id=$downloadId attempt=$runAttemptCount elapsed=${elapsed}ms reason=$reason")
+        DownloadEventBridge.log("E", "[Worker] Stack: ${e.stackTraceToString().take(400)}")
+        downloadDao.updateStatus(downloadId, DownloadStatus.QUEUED, reason)
+        DownloadEventBridge.retrying(downloadId, download.fileName, download.modelId, reason, runAttemptCount)
+        WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker exception")
+        return Result.retry()
     }
 
     // -------------------------------------------------------------------------
@@ -256,7 +270,7 @@ class WorkerDownload(
                 // File size mismatch > 0.1% — verify integrity with SHA256 before failing
                 DownloadEventBridge.log("I", "[Worker] Size mismatch (${(sizeDiffPercent * 100).toInt()}%) — verifying SHA256 id=$downloadId")
                 val actual = computeFileSha256(targetFile)
-                if (!actual.equals(expectedSha256, ignoreCase = true)) {
+                if (actual.lowercase() != expectedSha256.lowercase()) {
                     DownloadEventBridge.log("E", "[Worker] SHA256 mismatch id=$downloadId expected=$expectedSha256 actual=$actual")
                     if (!targetFile.delete()) DownloadEventBridge.log("W", "[Worker] Could not delete corrupt file id=$downloadId")
                     return failDownload(downloadId, download, "File corrupted (size mismatch + hash failure)", "worker sha256 mismatch")

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -37,11 +37,11 @@ class WorkerDownload(
         DownloadEventBridge.log("I", "[Worker] doWork start id=$downloadId attempt=$runAttemptCount file=${download.fileName}")
 
         if (isStopped) {
-            downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, "Download cancelled")
+            downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, MSG_DOWNLOAD_CANCELLED)
             return Result.failure()
         }
         if (download.status == DownloadStatus.PAUSED) {
-            DownloadEventBridge.log("I", "[Worker] Paused — returning retry id=$downloadId")
+            DownloadEventBridge.log("I", "[Worker] Paused on start — will retry when resumed id=$downloadId")
             return Result.retry()
         }
 
@@ -53,17 +53,23 @@ class WorkerDownload(
         syncFileSizeWithDb(downloadId, targetFile, download)
 
         val existingBytes = if (targetFile.exists()) targetFile.length() else 0L
+        DownloadEventBridge.log("I", "[Worker] Resume offset=${existingBytes}B file=${targetFile.absolutePath}")
         downloadDao.updateStatus(downloadId, DownloadStatus.RUNNING)
 
+        val requestStartMs = System.currentTimeMillis()
         return try {
             client.newCall(buildRequest(download.url, existingBytes)).execute().use { response ->
+                val ttfbMs = System.currentTimeMillis() - requestStartMs
+                DownloadEventBridge.log("I", "[Worker] TTFB id=$downloadId: ${ttfbMs}ms (time to first byte / server response)")
                 handleResponse(response, existingBytes, download, downloadId, targetFile, progressInterval)
             }
         } catch (e: Exception) {
+            val elapsed = System.currentTimeMillis() - requestStartMs
             val reason = e.message ?: e.javaClass.simpleName
-            DownloadEventBridge.log("E", "[Worker] Exception id=$downloadId attempt=$runAttemptCount reason=$reason")
-            downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, reason)
-            DownloadEventBridge.error(downloadId, download.fileName, download.modelId, reason)
+            DownloadEventBridge.log("E", "[Worker] Exception id=$downloadId attempt=$runAttemptCount elapsed=${elapsed}ms reason=$reason")
+            DownloadEventBridge.log("E", "[Worker] Stack: ${e.stackTraceToString().take(400)}")
+            downloadDao.updateStatus(downloadId, DownloadStatus.QUEUED, reason)
+            DownloadEventBridge.retrying(downloadId, download.fileName, download.modelId, reason, runAttemptCount)
             WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker exception")
             Result.retry()
         }
@@ -97,7 +103,10 @@ class WorkerDownload(
         progressInterval: Long,
     ): Result {
         val code = response.code
-        DownloadEventBridge.log("I", "[Worker] Response id=$downloadId code=$code")
+        val acceptRanges = response.header("Accept-Ranges") ?: "not-set"
+        val contentLengthHeader = response.header("Content-Length") ?: "unknown"
+        val contentRange = response.header("Content-Range") ?: ""
+        DownloadEventBridge.log("I", "[Worker] Response id=$downloadId code=$code Accept-Ranges=$acceptRanges Content-Length=$contentLengthHeader${if (contentRange.isNotEmpty()) " Content-Range=$contentRange" else ""}")
 
         val earlyResult = handleResponseCode(response, code, existingBytes, download, downloadId, targetFile)
         if (earlyResult != null) return earlyResult
@@ -125,7 +134,7 @@ class WorkerDownload(
     ): Result? {
         return when {
             existingBytes > 0L && code == 200 -> {
-                DownloadEventBridge.log("W", "[Worker] Server ignored Range, restarting id=$downloadId")
+                DownloadEventBridge.log("W", "[Worker] Server returned 200 despite Range header — resume not supported, restarting from 0. id=$downloadId existingBytes=$existingBytes")
                 targetFile.delete()
                 null
             }
@@ -167,6 +176,11 @@ class WorkerDownload(
         val appendMode = targetFile.exists() && code == 206
         var bytesWritten = currentFileBytes
         var lastProgressAt = 0L
+        var lastSpeedBytes = currentFileBytes
+        var lastSpeedTs = System.currentTimeMillis()
+        val transferStartMs = lastSpeedTs
+
+        DownloadEventBridge.log("I", "[Worker] Stream start id=$downloadId append=$appendMode offset=${currentFileBytes}B total=${totalBytes}B")
 
         FileOutputStream(targetFile, appendMode).buffered().use { output ->
             input.use { src ->
@@ -181,6 +195,13 @@ class WorkerDownload(
 
                     val now = System.currentTimeMillis()
                     if (now - lastProgressAt >= progressInterval) {
+                        val intervalMs = (now - lastSpeedTs).coerceAtLeast(1L)
+                        val speedKBps = (bytesWritten - lastSpeedBytes) * 1000L / intervalMs / 1024L
+                        val pct = if (totalBytes > 0) (bytesWritten * 100L / totalBytes) else 0L
+                        DownloadEventBridge.log("I", "[Worker] Progress id=$downloadId ${pct}% ${bytesWritten / 1024 / 1024}MB/${totalBytes / 1024 / 1024}MB speed=${speedKBps}KB/s")
+                        lastSpeedBytes = bytesWritten
+                        lastSpeedTs = now
+
                         setProgress(workDataOf(KEY_PROGRESS to bytesWritten, KEY_TOTAL to totalBytes))
                         downloadDao.updateProgress(downloadId, bytesWritten, totalBytes, DownloadStatus.RUNNING)
                         lastProgressAt = now
@@ -190,8 +211,10 @@ class WorkerDownload(
             }
         }
 
+        val totalElapsedMs = (System.currentTimeMillis() - transferStartMs).coerceAtLeast(1L)
+        val avgSpeedKBps = (bytesWritten - currentFileBytes) * 1000L / totalElapsedMs / 1024L
         downloadDao.updateProgress(downloadId, bytesWritten, totalBytes, DownloadStatus.COMPLETED)
-        DownloadEventBridge.log("I", "[Worker] Completed id=$downloadId bytes=$bytesWritten")
+        DownloadEventBridge.log("I", "[Worker] Completed id=$downloadId bytes=$bytesWritten elapsed=${totalElapsedMs}ms avgSpeed=${avgSpeedKBps}KB/s")
         WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker completed")
         return Result.success()
     }
@@ -199,8 +222,8 @@ class WorkerDownload(
     /** Returns a non-null Result if the loop should stop, null to continue. */
     private suspend fun checkCancellationOrPause(downloadId: Long, download: DownloadEntity, bytesWritten: Long): Result? {
         if (isStopped) {
-            downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, "Download cancelled")
-            DownloadEventBridge.error(downloadId, download.fileName, download.modelId, "Download cancelled", "cancelled")
+            downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, MSG_DOWNLOAD_CANCELLED)
+            DownloadEventBridge.error(downloadId, download.fileName, download.modelId, MSG_DOWNLOAD_CANCELLED, "cancelled")
             WorkerDownloadStore.stopForegroundServiceIfIdle(applicationContext, "worker stopped")
             return Result.failure()
         }
@@ -222,6 +245,8 @@ class WorkerDownload(
     // -------------------------------------------------------------------------
 
     companion object {
+        const val MSG_DOWNLOAD_CANCELLED = MSG_DOWNLOAD_CANCELLED
+
         // Shared across all WorkerDownload instances — reuses connection and thread pools.
         val httpClient: OkHttpClient = OkHttpClient.Builder()
             .retryOnConnectionFailure(true)

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownloadStore.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownloadStore.kt
@@ -1,0 +1,116 @@
+package ai.offgridmobile.download
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+object WorkerDownloadStore {
+    private const val PREFS_NAME = "OffgridWorkerDownloads"
+    private const val DOWNLOADS_KEY = "downloads"
+
+    const val STATUS_PENDING = "pending"
+    const val STATUS_RUNNING = "running"
+    const val STATUS_PAUSED = "paused"
+    const val STATUS_COMPLETED = "completed"
+    const val STATUS_FAILED = "failed"
+    const val STATUS_CANCELLED = "cancelled"
+    const val STATUS_UNKNOWN = "unknown"
+
+    private val ACTIVE_STATUSES = setOf(STATUS_PENDING, STATUS_RUNNING, STATUS_PAUSED)
+
+    private fun prefs(context: Context) = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    @Synchronized
+    fun all(context: Context): JSONArray {
+        val raw = prefs(context).getString(DOWNLOADS_KEY, "[]") ?: "[]"
+        return try { JSONArray(raw) } catch (_: Exception) { JSONArray() }
+    }
+
+    @Synchronized
+    fun saveAll(context: Context, downloads: JSONArray) {
+        prefs(context).edit().putString(DOWNLOADS_KEY, downloads.toString()).apply()
+    }
+
+    @Synchronized
+    fun put(context: Context, info: JSONObject) {
+        val downloads = all(context)
+        var replaced = false
+        for (i in 0 until downloads.length()) {
+            if (downloads.getJSONObject(i).optLong("downloadId") == info.optLong("downloadId")) {
+                downloads.put(i, info)
+                replaced = true
+                break
+            }
+        }
+        if (!replaced) downloads.put(info)
+        saveAll(context, downloads)
+    }
+
+    @Synchronized
+    fun get(context: Context, downloadId: Long): JSONObject? {
+        val downloads = all(context)
+        for (i in 0 until downloads.length()) {
+            val item = downloads.getJSONObject(i)
+            if (item.optLong("downloadId") == downloadId) return item
+        }
+        return null
+    }
+
+    @Synchronized
+    fun update(context: Context, downloadId: Long, mutate: (JSONObject) -> Unit): JSONObject? {
+        val downloads = all(context)
+        for (i in 0 until downloads.length()) {
+            val item = downloads.getJSONObject(i)
+            if (item.optLong("downloadId") == downloadId) {
+                mutate(item)
+                downloads.put(i, item)
+                saveAll(context, downloads)
+                return item
+            }
+        }
+        return null
+    }
+
+    @Synchronized
+    fun remove(context: Context, downloadId: Long) {
+        val downloads = all(context)
+        val updated = JSONArray()
+        for (i in 0 until downloads.length()) {
+            val item = downloads.getJSONObject(i)
+            if (item.optLong("downloadId") != downloadId) updated.put(item)
+        }
+        saveAll(context, updated)
+    }
+
+    @Synchronized
+    fun hasActiveWorkerDownloads(context: Context): Boolean {
+        val downloads = all(context)
+        for (i in 0 until downloads.length()) {
+            if (downloads.getJSONObject(i).optString("status") in ACTIVE_STATUSES) return true
+        }
+        return false
+    }
+
+    @Synchronized
+    fun hasActiveLegacyDownloads(context: Context): Boolean {
+        val raw = context.getSharedPreferences(
+            DownloadManagerModule.PREFS_NAME,
+            Context.MODE_PRIVATE
+        ).getString(DownloadManagerModule.DOWNLOADS_KEY, "[]") ?: "[]"
+        val downloads = try { JSONArray(raw) } catch (_: Exception) { JSONArray() }
+        for (i in 0 until downloads.length()) {
+            val status = downloads.getJSONObject(i).optString("status", DownloadManagerModule.STATUS_PENDING)
+            if (status == DownloadManagerModule.STATUS_PENDING ||
+                status == DownloadManagerModule.STATUS_RUNNING ||
+                status == DownloadManagerModule.STATUS_PAUSED) return true
+        }
+        return false
+    }
+
+    fun stopForegroundServiceIfIdle(context: Context, reason: String) {
+        if (!hasActiveWorkerDownloads(context) && !hasActiveLegacyDownloads(context)) {
+            DownloadEventBridge.log("I", "[WorkerStore] Stopping foreground service: $reason")
+            DownloadForegroundService.stop(context, reason)
+        }
+    }
+}

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownloadStore.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownloadStore.kt
@@ -74,12 +74,13 @@ object WorkerDownloadStore {
     @Synchronized
     fun remove(context: Context, downloadId: Long) {
         val downloads = all(context)
-        val updated = JSONArray()
         for (i in 0 until downloads.length()) {
-            val item = downloads.getJSONObject(i)
-            if (item.optLong("downloadId") != downloadId) updated.put(item)
+            if (downloads.getJSONObject(i).optLong("downloadId") == downloadId) {
+                downloads.remove(i)
+                saveAll(context, downloads)
+                return
+            }
         }
-        saveAll(context, updated)
     }
 
     @Synchronized
@@ -98,11 +99,14 @@ object WorkerDownloadStore {
             Context.MODE_PRIVATE
         ).getString(DownloadManagerModule.DOWNLOADS_KEY, "[]") ?: "[]"
         val downloads = try { JSONArray(raw) } catch (_: Exception) { JSONArray() }
+        val activeLegacyStatuses = setOf(
+            DownloadManagerModule.STATUS_PENDING,
+            DownloadManagerModule.STATUS_RUNNING,
+            DownloadManagerModule.STATUS_PAUSED,
+        )
         for (i in 0 until downloads.length()) {
             val status = downloads.getJSONObject(i).optString("status", DownloadManagerModule.STATUS_PENDING)
-            if (status == DownloadManagerModule.STATUS_PENDING ||
-                status == DownloadManagerModule.STATUS_RUNNING ||
-                status == DownloadManagerModule.STATUS_PAUSED) return true
+            if (status in activeLegacyStatuses) return true
         }
         return false
     }

--- a/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
+++ b/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
@@ -210,7 +210,7 @@ class DownloadManagerModuleTest {
             tmp.writeBytes("hello".toByteArray(Charsets.UTF_8))
             val hash = WorkerDownload.computeFileSha256(tmp)
             // Our function always returns lowercase; verify it equals the uppercase version ignoreCase
-            assertTrue(hash.equals(hash.uppercase(), ignoreCase = true))
+            assertTrue(hash == hash.lowercase())
         } finally {
             tmp.delete()
         }

--- a/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
+++ b/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
@@ -170,4 +170,49 @@ class DownloadManagerModuleTest {
     fun keyTotalConstantIsDefined() {
         assertEquals("total", WorkerDownload.KEY_TOTAL)
     }
+
+    // ── WorkerDownload.computeFileSha256 ──────────────────────────────────────
+
+    @Test
+    fun computeFileSha256MatchesKnownHash() {
+        // echo -n "hello" | sha256sum = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+        val tmp = createTempFile("sha256test", ".bin")
+        try {
+            tmp.writeBytes("hello".toByteArray(Charsets.UTF_8))
+            assertEquals(
+                "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                WorkerDownload.computeFileSha256(tmp),
+            )
+        } finally {
+            tmp.delete()
+        }
+    }
+
+    @Test
+    fun computeFileSha256EmptyFileReturnsKnownHash() {
+        // sha256 of empty input = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        val tmp = createTempFile("sha256empty", ".bin")
+        try {
+            tmp.writeBytes(ByteArray(0))
+            assertEquals(
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                WorkerDownload.computeFileSha256(tmp),
+            )
+        } finally {
+            tmp.delete()
+        }
+    }
+
+    @Test
+    fun computeFileSha256IsCaseInsensitiveCompatible() {
+        val tmp = createTempFile("sha256case", ".bin")
+        try {
+            tmp.writeBytes("hello".toByteArray(Charsets.UTF_8))
+            val hash = WorkerDownload.computeFileSha256(tmp)
+            // Our function always returns lowercase; verify it equals the uppercase version ignoreCase
+            assertTrue(hash.equals(hash.uppercase(), ignoreCase = true))
+        } finally {
+            tmp.delete()
+        }
+    }
 }

--- a/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
+++ b/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
@@ -24,57 +24,57 @@ class DownloadManagerModuleTest {
     // ── WorkerDownload.isHostAllowed ──────────────────────────────────────────
 
     @Test
-    fun `isHostAllowed accepts huggingface co`() {
+    fun isHostAllowedAcceptsHuggingfaceCo() {
         assertTrue(WorkerDownload.isHostAllowed("https://huggingface.co/model.gguf"))
     }
 
     @Test
-    fun `isHostAllowed accepts cdn-lfs subdomain`() {
+    fun isHostAllowedAcceptsCdnLfsSubdomain() {
         assertTrue(WorkerDownload.isHostAllowed("https://cdn-lfs.huggingface.co/path/to/model"))
     }
 
     @Test
-    fun `isHostAllowed accepts cas-bridge subdomain`() {
+    fun isHostAllowedAcceptsCasBridgeSubdomain() {
         assertTrue(WorkerDownload.isHostAllowed("https://cas-bridge.xethub.hf.co/file"))
     }
 
     @Test
-    fun `isHostAllowed accepts nested subdomain of allowed host`() {
+    fun isHostAllowedAcceptsNestedSubdomainOfAllowedHost() {
         assertTrue(WorkerDownload.isHostAllowed("https://foo.cdn-lfs.huggingface.co/file"))
     }
 
     @Test
-    fun `isHostAllowed accepts nested subdomain of huggingface co`() {
+    fun isHostAllowedAcceptsNestedSubdomainOfHuggingfaceCo() {
         assertTrue(WorkerDownload.isHostAllowed("https://subdomain.huggingface.co/model"))
     }
 
     @Test
-    fun `isHostAllowed rejects unknown host`() {
+    fun isHostAllowedRejectsUnknownHost() {
         assertFalse(WorkerDownload.isHostAllowed("https://evil.com/malware.gguf"))
     }
 
     @Test
-    fun `isHostAllowed rejects look-alike domain without dot separator`() {
+    fun isHostAllowedRejectsLookAlikeDomainWithoutDotSeparator() {
         assertFalse(WorkerDownload.isHostAllowed("https://nothuggingface.co/model.gguf"))
     }
 
     @Test
-    fun `isHostAllowed rejects subdomain of look-alike host`() {
+    fun isHostAllowedRejectsSubdomainOfLookAlikeHost() {
         assertFalse(WorkerDownload.isHostAllowed("https://cdn.evil-huggingface.co/model.gguf"))
     }
 
     @Test
-    fun `isHostAllowed rejects invalid URL`() {
+    fun isHostAllowedRejectsInvalidUrl() {
         assertFalse(WorkerDownload.isHostAllowed("not a url"))
     }
 
     @Test
-    fun `isHostAllowed rejects empty string`() {
+    fun isHostAllowedRejectsEmptyString() {
         assertFalse(WorkerDownload.isHostAllowed(""))
     }
 
     @Test
-    fun `isHostAllowed rejects http scheme on allowed host`() {
+    fun isHostAllowedAllowsHttpSchemeOnAllowedHost() {
         // The allowlist checks the host, not the scheme — http is still allowed by this
         // function; network security config handles transport-level enforcement.
         assertTrue(WorkerDownload.isHostAllowed("http://huggingface.co/model.gguf"))
@@ -83,22 +83,22 @@ class DownloadManagerModuleTest {
     // ── WorkerDownload.workName ───────────────────────────────────────────────
 
     @Test
-    fun `workName returns download underscore id`() {
+    fun workNameReturnsDownloadUnderscoreId() {
         assertEquals("download_42", WorkerDownload.workName(42L))
     }
 
     @Test
-    fun `workName handles zero id`() {
+    fun workNameHandlesZeroId() {
         assertEquals("download_0", WorkerDownload.workName(0L))
     }
 
     @Test
-    fun `workName handles large timestamp id`() {
+    fun workNameHandlesLargeTimestampId() {
         assertEquals("download_1712345678901", WorkerDownload.workName(1712345678901L))
     }
 
     @Test
-    fun `workName is unique per id`() {
+    fun workNameIsUniquePerDownloadId() {
         val name1 = WorkerDownload.workName(1L)
         val name2 = WorkerDownload.workName(2L)
         assertTrue(name1 != name2)
@@ -107,8 +107,8 @@ class DownloadManagerModuleTest {
     // ── DownloadStatus enum ───────────────────────────────────────────────────
 
     @Test
-    fun `DownloadStatus contains all required values`() {
-        val values = DownloadStatus.values().map { it.name }
+    fun downloadStatusContainsAllRequiredValues() {
+        val values = DownloadStatus.entries.map { it.name }
         assertTrue(values.contains("QUEUED"))
         assertTrue(values.contains("RUNNING"))
         assertTrue(values.contains("PAUSED"))
@@ -118,29 +118,29 @@ class DownloadManagerModuleTest {
     }
 
     @Test
-    fun `DownloadStatus RUNNING lowercased matches legacy constant`() {
+    fun downloadStatusRunningLowercasedMatchesLegacyConstant() {
         assertEquals(DownloadManagerModule.STATUS_RUNNING, DownloadStatus.RUNNING.name.lowercase())
     }
 
     @Test
-    fun `DownloadStatus PAUSED lowercased matches legacy constant`() {
+    fun downloadStatusPausedLowercasedMatchesLegacyConstant() {
         assertEquals(DownloadManagerModule.STATUS_PAUSED, DownloadStatus.PAUSED.name.lowercase())
     }
 
     @Test
-    fun `DownloadStatus COMPLETED lowercased matches legacy constant`() {
+    fun downloadStatusCompletedLowercasedMatchesLegacyConstant() {
         assertEquals(DownloadManagerModule.STATUS_COMPLETED, DownloadStatus.COMPLETED.name.lowercase())
     }
 
     @Test
-    fun `DownloadStatus FAILED lowercased matches legacy constant`() {
+    fun downloadStatusFailedLowercasedMatchesLegacyConstant() {
         assertEquals(DownloadManagerModule.STATUS_FAILED, DownloadStatus.FAILED.name.lowercase())
     }
 
     // ── DownloadManagerModule legacy constants ────────────────────────────────
 
     @Test
-    fun `legacy status constants have correct string values`() {
+    fun legacyStatusConstantsHaveCorrectStringValues() {
         assertEquals("pending", DownloadManagerModule.STATUS_PENDING)
         assertEquals("running", DownloadManagerModule.STATUS_RUNNING)
         assertEquals("paused", DownloadManagerModule.STATUS_PAUSED)
@@ -152,22 +152,22 @@ class DownloadManagerModuleTest {
     // ── WorkerDownload constants ──────────────────────────────────────────────
 
     @Test
-    fun `DEFAULT_PROGRESS_INTERVAL is 1 second`() {
+    fun defaultProgressIntervalIsOneSecond() {
         assertEquals(1_000L, WorkerDownload.DEFAULT_PROGRESS_INTERVAL)
     }
 
     @Test
-    fun `KEY_DOWNLOAD_ID constant is defined`() {
+    fun keyDownloadIdConstantIsDefined() {
         assertEquals("download_id", WorkerDownload.KEY_DOWNLOAD_ID)
     }
 
     @Test
-    fun `KEY_PROGRESS constant is defined`() {
+    fun keyProgressConstantIsDefined() {
         assertEquals("progress", WorkerDownload.KEY_PROGRESS)
     }
 
     @Test
-    fun `KEY_TOTAL constant is defined`() {
+    fun keyTotalConstantIsDefined() {
         assertEquals("total", WorkerDownload.KEY_TOTAL)
     }
 }

--- a/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
+++ b/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
@@ -1,8 +1,6 @@
 package ai.offgridmobile.download
 
 import android.app.Application
-import android.app.DownloadManager
-import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -12,557 +10,164 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Tests for the pure helper functions in DownloadManagerModule.
- * These functions contain complex branching logic and all branches must be covered.
+ * Tests for the pure helper functions in the new WorkManager-based download layer.
+ *
+ * The old DownloadManager/SharedPrefs layer (statusToString, reasonToString,
+ * hasNoActiveDownloads, shouldRemoveDownload, BytesTrack, evaluateStuckProgress)
+ * has been replaced by Room + WorkManager. These tests cover the pure functions
+ * that remain in the new architecture.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = Application::class)
 class DownloadManagerModuleTest {
 
-    // ── statusToString ────────────────────────────────────────────────────────
+    // ── WorkerDownload.isHostAllowed ──────────────────────────────────────────
 
     @Test
-    fun `statusToString maps STATUS_PENDING to pending`() {
-        assertEquals("pending", DownloadManagerModule.statusToString(DownloadManager.STATUS_PENDING))
+    fun `isHostAllowed accepts huggingface co`() {
+        assertTrue(WorkerDownload.isHostAllowed("https://huggingface.co/model.gguf"))
     }
 
     @Test
-    fun `statusToString maps STATUS_RUNNING to running`() {
-        assertEquals("running", DownloadManagerModule.statusToString(DownloadManager.STATUS_RUNNING))
+    fun `isHostAllowed accepts cdn-lfs subdomain`() {
+        assertTrue(WorkerDownload.isHostAllowed("https://cdn-lfs.huggingface.co/path/to/model"))
     }
 
     @Test
-    fun `statusToString maps STATUS_PAUSED to paused`() {
-        assertEquals("paused", DownloadManagerModule.statusToString(DownloadManager.STATUS_PAUSED))
+    fun `isHostAllowed accepts cas-bridge subdomain`() {
+        assertTrue(WorkerDownload.isHostAllowed("https://cas-bridge.xethub.hf.co/file"))
     }
 
     @Test
-    fun `statusToString maps STATUS_SUCCESSFUL to completed`() {
-        assertEquals("completed", DownloadManagerModule.statusToString(DownloadManager.STATUS_SUCCESSFUL))
+    fun `isHostAllowed accepts nested subdomain of allowed host`() {
+        assertTrue(WorkerDownload.isHostAllowed("https://foo.cdn-lfs.huggingface.co/file"))
     }
 
     @Test
-    fun `statusToString maps STATUS_FAILED to failed`() {
-        assertEquals("failed", DownloadManagerModule.statusToString(DownloadManager.STATUS_FAILED))
+    fun `isHostAllowed accepts nested subdomain of huggingface co`() {
+        assertTrue(WorkerDownload.isHostAllowed("https://subdomain.huggingface.co/model"))
     }
 
     @Test
-    fun `statusToString returns unknown for unrecognized status`() {
-        assertEquals("unknown", DownloadManagerModule.statusToString(-99))
-        assertEquals("unknown", DownloadManagerModule.statusToString(0))
+    fun `isHostAllowed rejects unknown host`() {
+        assertFalse(WorkerDownload.isHostAllowed("https://evil.com/malware.gguf"))
     }
 
-    // ── reasonToString — paused ───────────────────────────────────────────────
-
-    @Test
-    fun `reasonToString maps PAUSED_QUEUED_FOR_WIFI when status is paused`() {
-        assertEquals(
-            "Waiting for WiFi",
-            DownloadManagerModule.reasonToString(
-                DownloadManager.STATUS_PAUSED,
-                DownloadManager.PAUSED_QUEUED_FOR_WIFI,
-            ),
-        )
-    }
-
-    @Test
-    fun `reasonToString maps PAUSED_WAITING_FOR_NETWORK when status is paused`() {
-        assertEquals(
-            "Waiting for network",
-            DownloadManagerModule.reasonToString(
-                DownloadManager.STATUS_PAUSED,
-                DownloadManager.PAUSED_WAITING_FOR_NETWORK,
-            ),
-        )
-    }
-
-    @Test
-    fun `reasonToString maps PAUSED_WAITING_TO_RETRY when status is paused`() {
-        assertEquals(
-            "Waiting to retry",
-            DownloadManagerModule.reasonToString(
-                DownloadManager.STATUS_PAUSED,
-                DownloadManager.PAUSED_WAITING_TO_RETRY,
-            ),
-        )
-    }
-
-    @Test
-    fun `reasonToString returns generic Paused for unknown pause reason`() {
-        assertEquals(
-            "Paused",
-            DownloadManagerModule.reasonToString(DownloadManager.STATUS_PAUSED, -99),
-        )
-    }
-
-    // ── reasonToString — failed ───────────────────────────────────────────────
-
-    @Test
-    fun `reasonToString maps ERROR_CANNOT_RESUME when status is failed`() {
-        assertEquals(
-            "Cannot resume",
-            DownloadManagerModule.reasonToString(
-                DownloadManager.STATUS_FAILED,
-                DownloadManager.ERROR_CANNOT_RESUME,
-            ),
-        )
-    }
-
-    @Test
-    fun `reasonToString maps ERROR_DEVICE_NOT_FOUND when status is failed`() {
-        assertEquals(
-            "Device not found",
-            DownloadManagerModule.reasonToString(
-                DownloadManager.STATUS_FAILED,
-                DownloadManager.ERROR_DEVICE_NOT_FOUND,
-            ),
-        )
-    }
-
-    @Test
-    fun `reasonToString maps ERROR_FILE_ALREADY_EXISTS when status is failed`() {
-        assertEquals(
-            "File already exists",
-            DownloadManagerModule.reasonToString(
-                DownloadManager.STATUS_FAILED,
-                DownloadManager.ERROR_FILE_ALREADY_EXISTS,
-            ),
-        )
-    }
-
-    @Test
-    fun `reasonToString maps ERROR_FILE_ERROR when status is failed`() {
-        assertEquals(
-            "File error",
-            DownloadManagerModule.reasonToString(
-                DownloadManager.STATUS_FAILED,
-                DownloadManager.ERROR_FILE_ERROR,
-            ),
-        )
-    }
-
-    @Test
-    fun `reasonToString maps ERROR_HTTP_DATA_ERROR when status is failed`() {
-        assertEquals(
-            "HTTP data error",
-            DownloadManagerModule.reasonToString(
-                DownloadManager.STATUS_FAILED,
-                DownloadManager.ERROR_HTTP_DATA_ERROR,
-            ),
-        )
-    }
-
-    @Test
-    fun `reasonToString maps ERROR_INSUFFICIENT_SPACE when status is failed`() {
-        assertEquals(
-            "Insufficient space",
-            DownloadManagerModule.reasonToString(
-                DownloadManager.STATUS_FAILED,
-                DownloadManager.ERROR_INSUFFICIENT_SPACE,
-            ),
-        )
-    }
-
-    @Test
-    fun `reasonToString maps ERROR_TOO_MANY_REDIRECTS when status is failed`() {
-        assertEquals(
-            "Too many redirects",
-            DownloadManagerModule.reasonToString(
-                DownloadManager.STATUS_FAILED,
-                DownloadManager.ERROR_TOO_MANY_REDIRECTS,
-            ),
-        )
-    }
-
-    @Test
-    fun `reasonToString maps ERROR_UNHANDLED_HTTP_CODE when status is failed`() {
-        assertEquals(
-            "Unhandled HTTP code",
-            DownloadManagerModule.reasonToString(
-                DownloadManager.STATUS_FAILED,
-                DownloadManager.ERROR_UNHANDLED_HTTP_CODE,
-            ),
-        )
-    }
-
-    @Test
-    fun `reasonToString maps ERROR_UNKNOWN when status is failed`() {
-        assertEquals(
-            "Unknown error",
-            DownloadManagerModule.reasonToString(
-                DownloadManager.STATUS_FAILED,
-                DownloadManager.ERROR_UNKNOWN,
-            ),
-        )
-    }
-
-    @Test
-    fun `reasonToString includes error code for unrecognized failure reason`() {
-        assertEquals(
-            "Error: 999",
-            DownloadManagerModule.reasonToString(DownloadManager.STATUS_FAILED, 999),
-        )
-    }
-
-    // ── reasonToString — other statuses ──────────────────────────────────────
-
-    @Test
-    fun `reasonToString returns empty string when status is not paused or failed`() {
-        assertEquals("", DownloadManagerModule.reasonToString(DownloadManager.STATUS_PENDING, 0))
-        assertEquals("", DownloadManagerModule.reasonToString(DownloadManager.STATUS_RUNNING, 0))
-        assertEquals("", DownloadManagerModule.reasonToString(DownloadManager.STATUS_SUCCESSFUL, 0))
-    }
-
-    // ── hasNoActiveDownloads ────────────────────────────────────────────────
-
-    private fun downloadsArray(vararg statuses: String): org.json.JSONArray {
-        val arr = org.json.JSONArray()
-        statuses.forEach { arr.put(JSONObject().put("downloadId", arr.length().toLong()).put("status", it)) }
-        return arr
-    }
-
-    @Test
-    fun `hasNoActiveDownloads returns true for empty list`() {
-        assertTrue(DownloadManagerModule.hasNoActiveDownloads(org.json.JSONArray()))
-    }
-
-    @Test
-    fun `hasNoActiveDownloads returns false when a download is pending`() {
-        assertFalse(DownloadManagerModule.hasNoActiveDownloads(downloadsArray(DownloadManagerModule.STATUS_PENDING)))
-    }
-
-    @Test
-    fun `hasNoActiveDownloads returns false when a download is running`() {
-        assertFalse(DownloadManagerModule.hasNoActiveDownloads(downloadsArray(DownloadManagerModule.STATUS_RUNNING)))
-    }
-
-    @Test
-    fun `hasNoActiveDownloads returns false when a download is paused`() {
-        assertFalse(DownloadManagerModule.hasNoActiveDownloads(downloadsArray(DownloadManagerModule.STATUS_PAUSED)))
-    }
-
-    @Test
-    fun `hasNoActiveDownloads returns true when all are completed`() {
-        assertTrue(DownloadManagerModule.hasNoActiveDownloads(downloadsArray(DownloadManagerModule.STATUS_COMPLETED, DownloadManagerModule.STATUS_COMPLETED)))
-    }
-
-    @Test
-    fun `hasNoActiveDownloads returns true when all are failed`() {
-        assertTrue(DownloadManagerModule.hasNoActiveDownloads(downloadsArray(DownloadManagerModule.STATUS_FAILED, DownloadManagerModule.STATUS_FAILED)))
-    }
-
-    @Test
-    fun `hasNoActiveDownloads returns true for mix of completed and failed`() {
-        assertTrue(DownloadManagerModule.hasNoActiveDownloads(downloadsArray(DownloadManagerModule.STATUS_COMPLETED, DownloadManagerModule.STATUS_FAILED)))
-    }
-
-    @Test
-    fun `hasNoActiveDownloads returns false when one of many is still running`() {
-        assertFalse(DownloadManagerModule.hasNoActiveDownloads(downloadsArray(DownloadManagerModule.STATUS_COMPLETED, DownloadManagerModule.STATUS_RUNNING, DownloadManagerModule.STATUS_FAILED)))
-    }
-
-    @Test
-    fun `hasNoActiveDownloads defaults missing status to pending`() {
-        val arr = org.json.JSONArray()
-        arr.put(JSONObject().put("downloadId", 1L)) // no "status" key
-        assertFalse(DownloadManagerModule.hasNoActiveDownloads(arr))
-    }
-
-    // ── shouldRemoveDownload ──────────────────────────────────────────────────
-    //
-    // Entries are only pruned after moveCompletedDownload sets moveCompleted=true.
-    // Time-based removal alone caused downloads to vanish while the phone was
-    // sleeping — the JS side couldn't call moveCompletedDownload in time.
-
-    private fun download(
-        storedStatus: String = "pending",
-        completedAt: Long = 0L,
-        completedEventSent: Boolean = false,
-        moveCompleted: Boolean = false,
-    ) = JSONObject()
-        .put("downloadId", 42L)
-        .put("status", storedStatus)
-        .put("completedAt", completedAt)
-        .put("completedEventSent", completedEventSent)
-        .put("moveCompleted", moveCompleted)
-
-    @Test
-    fun `shouldRemoveDownload returns true when live status is unknown`() {
-        assertTrue(DownloadManagerModule.shouldRemoveDownload(download("running"), liveStatus = "unknown"))
-    }
-
-    @Test
-    fun `shouldRemoveDownload returns false for active downloads`() {
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(download("running"), liveStatus = "running"))
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(download("pending"), liveStatus = "pending"))
-    }
-
-    @Test
-    fun `shouldRemoveDownload removes completed download when move confirmed and older than 5 seconds`() {
-        val now = System.currentTimeMillis()
-        val dl = download("completed", completedAt = now - 6_000L, completedEventSent = true, moveCompleted = true)
-        assertTrue(DownloadManagerModule.shouldRemoveDownload(dl, liveStatus = "completed", currentTimeMs = now))
-    }
-
-    @Test
-    fun `shouldRemoveDownload keeps completed download when move confirmed but not yet 5 seconds old`() {
-        val now = System.currentTimeMillis()
-        val dl = download("completed", completedAt = now - 1_000L, completedEventSent = true, moveCompleted = true)
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(dl, liveStatus = "completed", currentTimeMs = now))
-    }
-
-    @Test
-    fun `shouldRemoveDownload keeps completed download when event sent but move not confirmed`() {
-        // Event sent is NOT enough — must wait for moveCompletedDownload to confirm
-        val now = System.currentTimeMillis()
-        val dl = download("completed", completedAt = now - 60_000L, completedEventSent = true, moveCompleted = false)
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(dl, liveStatus = "completed", currentTimeMs = now))
-    }
-
-    @Test
-    fun `shouldRemoveDownload keeps completed download indefinitely until move is confirmed`() {
-        // Even after 10 minutes, entry stays if moveCompleted is false
-        val now = System.currentTimeMillis()
-        val dl = download("completed", completedAt = now - 600_000L, completedEventSent = true, moveCompleted = false)
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(dl, liveStatus = "completed", currentTimeMs = now))
-    }
-
-    @Test
-    fun `shouldRemoveDownload keeps completed download when completedAt is zero`() {
-        val now = System.currentTimeMillis()
-        val dl = download("completed", completedAt = 0L, completedEventSent = true, moveCompleted = true)
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(dl, liveStatus = "completed", currentTimeMs = now))
-    }
-
     @Test
-    fun `shouldRemoveDownload returns false for non-completed stored status regardless of live status`() {
-        val now = System.currentTimeMillis()
-        val dl = download("running", completedAt = now - 10_000L, completedEventSent = true, moveCompleted = true)
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(dl, liveStatus = "running", currentTimeMs = now))
+    fun `isHostAllowed rejects look-alike domain without dot separator`() {
+        assertFalse(WorkerDownload.isHostAllowed("https://nothuggingface.co/model.gguf"))
     }
 
-    // ── shouldRemoveDownload — additional edge cases ─────────────────────────
-
-    @Test
-    fun `shouldRemoveDownload keeps paused download`() {
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(download("paused"), liveStatus = "paused"))
-    }
-
-    @Test
-    fun `shouldRemoveDownload uses exactly 5000ms threshold — not yet expired`() {
-        // t=10000, completedAt=5001 → age=4999ms — below threshold (move confirmed)
-        val dl = download("completed", completedAt = 5_001L, completedEventSent = true, moveCompleted = true)
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(dl, liveStatus = "completed", currentTimeMs = 10_000L))
-    }
-
-    @Test
-    fun `shouldRemoveDownload uses exactly 5000ms threshold — just expired`() {
-        // t=10000, completedAt=4999 → age=5001ms — above threshold (move confirmed)
-        val dl = download("completed", completedAt = 4_999L, completedEventSent = true, moveCompleted = true)
-        assertTrue(DownloadManagerModule.shouldRemoveDownload(dl, liveStatus = "completed", currentTimeMs = 10_000L))
-    }
-
-    @Test
-    fun `shouldRemoveDownload never removes without moveCompleted even when very old`() {
-        // completedAt far in the past, eventSent=true, but moveCompleted=false — must NOT remove
-        val now = System.currentTimeMillis()
-        val dl = download("completed", completedAt = now - 300_000L, completedEventSent = true, moveCompleted = false)
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(dl, liveStatus = "completed", currentTimeMs = now))
-    }
-
-    @Test
-    fun `shouldRemoveDownload requires completedAt to be set to remove`() {
-        // completedAt=0 even with moveCompleted=true — guard against incomplete records
-        val now = System.currentTimeMillis()
-        val dl = download("completed", completedAt = 0L, completedEventSent = true, moveCompleted = true)
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(dl, liveStatus = "completed", currentTimeMs = now))
-    }
-
-    @Test
-    fun `shouldRemoveDownload handles multiple downloads independently`() {
-        val now = System.currentTimeMillis()
-        val movedDl   = download("completed", completedAt = now - 10_000L, completedEventSent = true, moveCompleted = true)
-        val unmovedDl = download("completed", completedAt = now - 10_000L, completedEventSent = true, moveCompleted = false)
-        val pendingDl = download("pending")
-
-        assertTrue(DownloadManagerModule.shouldRemoveDownload(movedDl, liveStatus = "completed", currentTimeMs = now))
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(unmovedDl, liveStatus = "completed", currentTimeMs = now))
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(pendingDl, liveStatus = "pending", currentTimeMs = now))
-    }
-
-    @Test
-    fun `shouldRemoveDownload with unknown liveStatus removes regardless of stored state`() {
-        assertTrue(DownloadManagerModule.shouldRemoveDownload(download("running"), liveStatus = "unknown"))
-        assertTrue(DownloadManagerModule.shouldRemoveDownload(download("pending"), liveStatus = "unknown"))
-        assertTrue(DownloadManagerModule.shouldRemoveDownload(download("paused"), liveStatus = "unknown"))
-        assertTrue(DownloadManagerModule.shouldRemoveDownload(download("completed"), liveStatus = "unknown"))
-    }
-
-    @Test
-    fun `shouldRemoveDownload defaults moveCompleted to false when flag is absent`() {
-        // Legacy entries without moveCompleted key should NOT be removed
-        val now = System.currentTimeMillis()
-        val dl = JSONObject()
-            .put("downloadId", 42L)
-            .put("status", "completed")
-            .put("completedAt", now - 60_000L)
-            .put("completedEventSent", true)
-        // No moveCompleted key — defaults to false
-        assertFalse(DownloadManagerModule.shouldRemoveDownload(dl, liveStatus = "completed", currentTimeMs = now))
-    }
-
-    // ── watchdog constants ────────────────────────────────────────────────────
-
     @Test
-    fun `WATCHDOG_INTERVAL_MS is 15 seconds`() {
-        assertEquals(15_000L, DownloadManagerModule.WATCHDOG_INTERVAL_MS)
+    fun `isHostAllowed rejects subdomain of look-alike host`() {
+        assertFalse(WorkerDownload.isHostAllowed("https://cdn.evil-huggingface.co/model.gguf"))
     }
 
     @Test
-    fun `STUCK_THRESHOLD is 3 polls`() {
-        assertEquals(3, DownloadManagerModule.STUCK_THRESHOLD)
+    fun `isHostAllowed rejects invalid URL`() {
+        assertFalse(WorkerDownload.isHostAllowed("not a url"))
     }
 
     @Test
-    fun `MAX_RETRY_ATTEMPTS is 3`() {
-        assertEquals(3, DownloadManagerModule.MAX_RETRY_ATTEMPTS)
+    fun `isHostAllowed rejects empty string`() {
+        assertFalse(WorkerDownload.isHostAllowed(""))
     }
 
     @Test
-    fun `stuck window is 45 seconds (3 x 15s)`() {
-        val windowMs = DownloadManagerModule.STUCK_THRESHOLD * DownloadManagerModule.WATCHDOG_INTERVAL_MS
-        assertEquals(45_000L, windowMs)
+    fun `isHostAllowed rejects http scheme on allowed host`() {
+        // The allowlist checks the host, not the scheme — http is still allowed by this
+        // function; network security config handles transport-level enforcement.
+        assertTrue(WorkerDownload.isHostAllowed("http://huggingface.co/model.gguf"))
     }
 
-    // ── evaluateStuckProgress ─────────────────────────────────────────────────
+    // ── WorkerDownload.workName ───────────────────────────────────────────────
 
-    private fun track(lastBytes: Long, unchangedCount: Int, retryCount: Int = 0) =
-        DownloadManagerModule.BytesTrack(lastBytes, unchangedCount, retryCount)
-
     @Test
-    fun `progress made resets stuck counter`() {
-        val result = DownloadManagerModule.evaluateStuckProgress(track(1000L, 2), currentBytes = 2000L)
-        assertTrue(result is DownloadManagerModule.StuckAction.ResetCounter)
-        val reset = result as DownloadManagerModule.StuckAction.ResetCounter
-        assertEquals(2000L, reset.newTrack.lastBytes)
-        assertEquals(0, reset.newTrack.unchangedCount)
+    fun `workName returns download underscore id`() {
+        assertEquals("download_42", WorkerDownload.workName(42L))
     }
 
     @Test
-    fun `progress made preserves existing retry count`() {
-        val result = DownloadManagerModule.evaluateStuckProgress(track(1000L, 2, retryCount = 2), currentBytes = 2000L)
-        val reset = result as DownloadManagerModule.StuckAction.ResetCounter
-        assertEquals(2, reset.newTrack.retryCount)
+    fun `workName handles zero id`() {
+        assertEquals("download_0", WorkerDownload.workName(0L))
     }
 
     @Test
-    fun `zero progress increments stuck counter`() {
-        val result = DownloadManagerModule.evaluateStuckProgress(track(1000L, 0), currentBytes = 1000L)
-        assertTrue(result is DownloadManagerModule.StuckAction.IncrementCounter)
-        val inc = result as DownloadManagerModule.StuckAction.IncrementCounter
-        assertEquals(1, inc.newTrack.unchangedCount)
-        assertEquals(1000L, inc.newTrack.lastBytes)
+    fun `workName handles large timestamp id`() {
+        assertEquals("download_1712345678901", WorkerDownload.workName(1712345678901L))
     }
 
     @Test
-    fun `zero progress below threshold does not yet trigger retry`() {
-        // unchangedCount=1 → newCount=2, below STUCK_THRESHOLD of 3
-        val result = DownloadManagerModule.evaluateStuckProgress(track(1000L, 1), currentBytes = 1000L)
-        assertTrue(result is DownloadManagerModule.StuckAction.IncrementCounter)
-        val inc = result as DownloadManagerModule.StuckAction.IncrementCounter
-        assertEquals(2, inc.newTrack.unchangedCount)
+    fun `workName is unique per id`() {
+        val name1 = WorkerDownload.workName(1L)
+        val name2 = WorkerDownload.workName(2L)
+        assertTrue(name1 != name2)
     }
 
-    @Test
-    fun `zero progress at threshold triggers retry`() {
-        // unchangedCount is STUCK_THRESHOLD-1 going in — this poll hits the threshold
-        val threshold = DownloadManagerModule.STUCK_THRESHOLD
-        val result = DownloadManagerModule.evaluateStuckProgress(track(1000L, threshold - 1), currentBytes = 1000L)
-        assertTrue(result is DownloadManagerModule.StuckAction.Retry)
-        val retry = result as DownloadManagerModule.StuckAction.Retry
-        assertEquals(1, retry.retryCount)
-    }
+    // ── DownloadStatus enum ───────────────────────────────────────────────────
 
     @Test
-    fun `retry count increments on each stuck trigger`() {
-        val result = DownloadManagerModule.evaluateStuckProgress(track(1000L, 4, retryCount = 2), currentBytes = 1000L)
-        val retry = result as DownloadManagerModule.StuckAction.Retry
-        assertEquals(3, retry.retryCount)
+    fun `DownloadStatus contains all required values`() {
+        val values = DownloadStatus.values().map { it.name }
+        assertTrue(values.contains("QUEUED"))
+        assertTrue(values.contains("RUNNING"))
+        assertTrue(values.contains("PAUSED"))
+        assertTrue(values.contains("COMPLETED"))
+        assertTrue(values.contains("FAILED"))
+        assertTrue(values.contains("CANCELLED"))
     }
 
     @Test
-    fun `gives up when retry count equals MAX_RETRY_ATTEMPTS`() {
-        val maxRetries = DownloadManagerModule.MAX_RETRY_ATTEMPTS
-        val result = DownloadManagerModule.evaluateStuckProgress(track(1000L, 4, retryCount = maxRetries), currentBytes = 1000L)
-        assertTrue(result is DownloadManagerModule.StuckAction.GiveUp)
+    fun `DownloadStatus RUNNING lowercased matches legacy constant`() {
+        assertEquals(DownloadManagerModule.STATUS_RUNNING, DownloadStatus.RUNNING.name.lowercase())
     }
 
     @Test
-    fun `gives up when retry count exceeds MAX_RETRY_ATTEMPTS`() {
-        val result = DownloadManagerModule.evaluateStuckProgress(track(1000L, 4, retryCount = 99), currentBytes = 1000L)
-        assertTrue(result is DownloadManagerModule.StuckAction.GiveUp)
+    fun `DownloadStatus PAUSED lowercased matches legacy constant`() {
+        assertEquals(DownloadManagerModule.STATUS_PAUSED, DownloadStatus.PAUSED.name.lowercase())
     }
 
     @Test
-    fun `even one byte of progress resets counter`() {
-        val result = DownloadManagerModule.evaluateStuckProgress(track(1000L, 4), currentBytes = 1001L)
-        assertTrue(result is DownloadManagerModule.StuckAction.ResetCounter)
+    fun `DownloadStatus COMPLETED lowercased matches legacy constant`() {
+        assertEquals(DownloadManagerModule.STATUS_COMPLETED, DownloadStatus.COMPLETED.name.lowercase())
     }
 
     @Test
-    fun `bytes going backwards counts as zero progress`() {
-        // Should not happen normally but guard against it
-        val result = DownloadManagerModule.evaluateStuckProgress(track(1000L, 0), currentBytes = 500L)
-        assertTrue(result is DownloadManagerModule.StuckAction.IncrementCounter)
+    fun `DownloadStatus FAILED lowercased matches legacy constant`() {
+        assertEquals(DownloadManagerModule.STATUS_FAILED, DownloadStatus.FAILED.name.lowercase())
     }
 
-    @Test
-    fun `zero bytes on first poll increments startup counter but does not retry`() {
-        // Download just started — still connecting. Should increment but not trigger retry yet.
-        val result = DownloadManagerModule.evaluateStuckProgress(track(0L, 0), currentBytes = 0L)
-        assertTrue(result is DownloadManagerModule.StuckAction.IncrementCounter)
-        val inc = result as DownloadManagerModule.StuckAction.IncrementCounter
-        assertEquals(1, inc.newTrack.unchangedCount)
-    }
+    // ── DownloadManagerModule legacy constants ────────────────────────────────
 
     @Test
-    fun `zero bytes below startup timeout does not trigger retry`() {
-        // Simulate polls at 0 bytes — should not retry until STARTUP_TIMEOUT_POLLS is hit
-        val belowTimeout = DownloadManagerModule.STARTUP_TIMEOUT_POLLS - 1
-        val result = DownloadManagerModule.evaluateStuckProgress(track(0L, belowTimeout - 1), currentBytes = 0L)
-        assertTrue(result is DownloadManagerModule.StuckAction.IncrementCounter)
+    fun `legacy status constants have correct string values`() {
+        assertEquals("pending", DownloadManagerModule.STATUS_PENDING)
+        assertEquals("running", DownloadManagerModule.STATUS_RUNNING)
+        assertEquals("paused", DownloadManagerModule.STATUS_PAUSED)
+        assertEquals("completed", DownloadManagerModule.STATUS_COMPLETED)
+        assertEquals("failed", DownloadManagerModule.STATUS_FAILED)
+        assertEquals("unknown", DownloadManagerModule.STATUS_UNKNOWN)
     }
 
-    @Test
-    fun `zero bytes at startup timeout fires StartupTimeout not Retry`() {
-        // After STARTUP_TIMEOUT_POLLS of never receiving a byte, give up — let user retry manually
-        val timeout = DownloadManagerModule.STARTUP_TIMEOUT_POLLS
-        val result = DownloadManagerModule.evaluateStuckProgress(track(0L, timeout - 1), currentBytes = 0L)
-        assertTrue(result is DownloadManagerModule.StuckAction.StartupTimeout)
-    }
+    // ── WorkerDownload constants ──────────────────────────────────────────────
 
     @Test
-    fun `zero bytes startup timeout is 2 minutes (8 x 15s)`() {
-        assertEquals(120_000L, DownloadManagerModule.STARTUP_TIMEOUT_POLLS * DownloadManagerModule.WATCHDOG_INTERVAL_MS)
+    fun `DEFAULT_PROGRESS_INTERVAL is 1 second`() {
+        assertEquals(1_000L, WorkerDownload.DEFAULT_PROGRESS_INTERVAL)
     }
 
     @Test
-    fun `stuck detection only starts after first byte received`() {
-        // Once bytes > 0 then stop, THAT is when the short stuck threshold kicks in
-        val result = DownloadManagerModule.evaluateStuckProgress(track(1000L, 0), currentBytes = 1000L)
-        assertTrue(result is DownloadManagerModule.StuckAction.IncrementCounter)
-        val inc = result as DownloadManagerModule.StuckAction.IncrementCounter
-        assertEquals(1, inc.newTrack.unchangedCount)
+    fun `KEY_DOWNLOAD_ID constant is defined`() {
+        assertEquals("download_id", WorkerDownload.KEY_DOWNLOAD_ID)
     }
 
     @Test
-    fun `backoff for retry 1 is 30 seconds`() {
-        // Backoff is retryCount * 30_000ms, independent of watchdog interval
-        assertEquals(30_000L, 1 * 30_000L)
+    fun `KEY_PROGRESS constant is defined`() {
+        assertEquals("progress", WorkerDownload.KEY_PROGRESS)
     }
 
     @Test
-    fun `backoff for retry 3 is 90 seconds`() {
-        assertEquals(90_000L, 3 * 30_000L)
+    fun `KEY_TOTAL constant is defined`() {
+        assertEquals("total", WorkerDownload.KEY_TOTAL)
     }
 }

--- a/src/screens/DownloadManagerScreen/items.tsx
+++ b/src/screens/DownloadManagerScreen/items.tsx
@@ -165,6 +165,13 @@ export function buildDownloadItems(data: DownloadItemsData): DownloadItem[] {
   return items;
 }
 
+function getStatusLabel(item: DownloadItem): string {
+  if (item.status === 'retrying' && item.reason) return item.reason;
+  const base = getStatusText(item.status);
+  if (!item.reason) return base;
+  return `${base} · ${item.reason}`;
+}
+
 // ─── Item components ──────────────────────────────────────────────────────────
 
 interface ActiveDownloadCardProps {
@@ -200,9 +207,7 @@ export const ActiveDownloadCard: React.FC<ActiveDownloadCardProps> = ({ item, on
           <Text style={styles.quantText}>{item.quantization}</Text>
         </View>
         <Text style={styles.statusText}>
-          {item.status === 'retrying' && item.reason
-            ? item.reason
-            : `${getStatusText(item.status)}${item.reason ? ` · ${item.reason}` : ''}`}
+          {getStatusLabel(item)}
         </Text>
       </View>
     </Card>

--- a/src/screens/DownloadManagerScreen/items.tsx
+++ b/src/screens/DownloadManagerScreen/items.tsx
@@ -30,7 +30,7 @@ export type DownloadItem = {
 };
 
 export interface DownloadItemsData {
-  downloadProgress: Record<string, { progress: number; bytesDownloaded: number; totalBytes: number; reason?: string }>;
+  downloadProgress: Record<string, { progress: number; bytesDownloaded: number; totalBytes: number; status?: string; reason?: string }>;
   activeDownloads: BackgroundDownloadInfo[];
   activeBackgroundDownloads: Record<number, { modelId: string; fileName: string; author: string; quantization: string; totalBytes: number } | null>;
   downloadedModels: DownloadedModel[];
@@ -60,9 +60,10 @@ export function extractQuantization(fileName: string): string {
 }
 
 export function getStatusText(status: string): string {
-  if (status === 'running') return 'Downloading...';
+  if (status === 'running' || status === 'downloading') return 'Downloading...';
   if (status === 'pending') return 'Queued';
   if (status === 'paused') return 'Paused';
+  if (status === 'retrying') return 'Reconnecting...';
   if (status === 'unknown') return 'Stuck - Remove & retry';
   return status;
 }
@@ -92,7 +93,7 @@ export function buildDownloadItems(data: DownloadItemsData): DownloadItem[] {
       fileSize: progress.totalBytes,
       bytesDownloaded: progress.bytesDownloaded,
       progress: progress.progress,
-      status: 'downloading',
+      status: progress.status ?? 'downloading',
       reason: progress.reason,
     });
   });
@@ -199,7 +200,9 @@ export const ActiveDownloadCard: React.FC<ActiveDownloadCardProps> = ({ item, on
           <Text style={styles.quantText}>{item.quantization}</Text>
         </View>
         <Text style={styles.statusText}>
-          {getStatusText(item.status)}{item.reason ? ` · ${item.reason}` : ''}
+          {item.status === 'retrying' && item.reason
+            ? item.reason
+            : `${getStatusText(item.status)}${item.reason ? ` · ${item.reason}` : ''}`}
         </Text>
       </View>
     </Card>

--- a/src/screens/DownloadManagerScreen/useDownloadManager.ts
+++ b/src/screens/DownloadManagerScreen/useDownloadManager.ts
@@ -127,7 +127,7 @@ export function useDownloadManager(): UseDownloadManagerResult {
       unsubError();
     };
 
-  }, []);
+  }, [setDownloadProgress]);
 
   const loadActiveDownloads = async () => {
     if (backgroundDownloadService.isAvailable()) {
@@ -144,7 +144,7 @@ export function useDownloadManager(): UseDownloadManagerResult {
     setDownloadedImageModels(imageModels);
     setIsRefreshing(false);
 
-  }, []);
+  }, [setDownloadedModels, setDownloadedImageModels]);
 
   const executeRemoveDownload = async (item: DownloadItem) => {
     setAlertState(hideAlert());

--- a/src/screens/DownloadManagerScreen/useDownloadManager.ts
+++ b/src/screens/DownloadManagerScreen/useDownloadManager.ts
@@ -85,6 +85,18 @@ export function useDownloadManager(): UseDownloadManagerResult {
       if (!metadata) return;
       const key = `${metadata.modelId}/${metadata.fileName}`;
       if (cancelledKeysRef.current.has(key)) return;
+      if (event.status === 'retrying') {
+        // Keep existing bytes — just update status and reason so the UI shows "Reconnecting..."
+        const existing = useAppStore.getState().downloadProgress[key];
+        setDownloadProgress(key, {
+          progress: existing?.progress ?? 0,
+          bytesDownloaded: existing?.bytesDownloaded ?? 0,
+          totalBytes: existing?.totalBytes ?? 0,
+          status: 'retrying',
+          reason: event.reason,
+        });
+        return;
+      }
       if ((useAppStore.getState().downloadProgress[key]?.bytesDownloaded ?? -1) >= event.bytesDownloaded) return;
       setDownloadProgress(key, {
         progress: event.totalBytes > 0 ? event.bytesDownloaded / event.totalBytes : 0,

--- a/src/screens/ModelsScreen/imageDownloadActions.ts
+++ b/src/screens/ModelsScreen/imageDownloadActions.ts
@@ -179,6 +179,7 @@ export async function downloadCoreMLMultiFile(
       }
     });
     listeners.setProgressUnsub(backgroundDownloadService.onProgress(downloadInfo.downloadId, (ev) => {
+      if (ev.status === 'retrying') return;
       deps.updateModelProgress(modelInfo.id, ev.totalBytes > 0 ? (ev.bytesDownloaded / ev.totalBytes) * 0.95 : 0);
     }));
     backgroundDownloadService.startProgressPolling();
@@ -237,6 +238,7 @@ export async function proceedWithDownload(
       await registerAndNotify(deps, { imageModel, modelName: modelInfo.name, downloadId: downloadInfo.downloadId });
     });
     listeners.setProgressUnsub(backgroundDownloadService.onProgress(downloadInfo.downloadId, (ev) => {
+      if (ev.status === 'retrying') return;
       deps.updateModelProgress(modelInfo.id, ev.totalBytes > 0 ? (ev.bytesDownloaded / ev.totalBytes) * 0.9 : 0);
     }));
     backgroundDownloadService.startProgressPolling();

--- a/src/screens/ModelsScreen/useImageModels.ts
+++ b/src/screens/ModelsScreen/useImageModels.ts
@@ -104,10 +104,10 @@ export function useImageModels(setAlertState: (s: AlertState) => void) {
     triedImageGen: onboardingChecklist.triedImageGen,
   });
 
-  const loadDownloadedImageModels = async () => {
+  const loadDownloadedImageModels = useCallback(async () => {
     const models = await modelManager.getDownloadedImageModels();
     setDownloadedImageModels(models);
-  };
+  }, [setDownloadedImageModels]);
 
   const loadHFModels = useCallback(async (forceRefresh = false) => {
     setHfModelsLoading(true); setHfModelsError(null);
@@ -234,8 +234,10 @@ export function useImageModels(setAlertState: (s: AlertState) => void) {
   useEffect(() => {
     loadDownloadedImageModels();
     restoreActiveImageDownloads();
-
-  }, []);
+  // restoreActiveImageDownloads is intentionally mount-only — it reads
+  // current store state via useAppStore.getState() to avoid stale closures.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loadDownloadedImageModels]);
 
   useEffect(() => {
     let cancelled = false;
@@ -252,6 +254,9 @@ export function useImageModels(setAlertState: (s: AlertState) => void) {
     });
     return () => { cancelled = true; };
 
+  // Intentionally mount-only: fetches hardware recommendation once.
+  // userChangedBackendFilter is read inside but should not re-trigger this fetch.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const clearImageFilters = useCallback(() => {

--- a/src/screens/ModelsScreen/useImageModels.ts
+++ b/src/screens/ModelsScreen/useImageModels.ts
@@ -177,6 +177,7 @@ export function useImageModels(setAlertState: (s: AlertState) => void) {
         metadata, modelId, modelDir, imageModelsDir, downloadId: download.downloadId, deps,
       }),
     ).setProgressUnsub(backgroundDownloadService.onProgress(download.downloadId, (ev) => {
+      if (ev.status === 'retrying') return;
       const scale = metadata.imageDownloadType === 'zip' ? 0.9 : 0.95;
       deps.updateModelProgress(modelId, ev.totalBytes > 0 ? (ev.bytesDownloaded / ev.totalBytes) * scale : 0);
     }));

--- a/src/services/backgroundDownloadService.ts
+++ b/src/services/backgroundDownloadService.ts
@@ -40,6 +40,7 @@ class BackgroundDownloadService {
       title: params.title || `Downloading ${params.fileName}`,
       description: params.description || 'Model download in progress...',
       totalBytes: params.totalBytes || 0,
+      sha256: params.sha256,
     });
 
     return {

--- a/src/services/backgroundDownloadService.ts
+++ b/src/services/backgroundDownloadService.ts
@@ -343,6 +343,26 @@ class BackgroundDownloadService {
         this.errorListeners.get('error_all')?.(e);
       }
     }));
+    // DownloadRetrying — worker hit a transient error and will retry automatically.
+    // Route it as a progress event with status='retrying' so the UI shows
+    // "Retrying..." instead of surfacing a false error to the user.
+    push(this.eventEmitter.addListener('DownloadRetrying', (e: {
+      downloadId: number; fileName: string; modelId: string; reason: string; attempt: number;
+    }) => {
+      const retryEvent: DownloadProgressEvent = {
+        downloadId: e.downloadId,
+        fileName: e.fileName,
+        modelId: e.modelId,
+        bytesDownloaded: 0,
+        totalBytes: 0,
+        status: 'retrying',
+        reason: `Connection lost — retrying (attempt ${e.attempt + 1})`,
+      };
+      this.progressListeners.get(`progress_${e.downloadId}`)?.(retryEvent);
+      if (!this.silentDownloadIds.has(e.downloadId)) {
+        this.progressListeners.get('progress_all')?.(retryEvent);
+      }
+    }));
   }
 }
 export const backgroundDownloadService = new BackgroundDownloadService();

--- a/src/services/backgroundDownloadTypes.ts
+++ b/src/services/backgroundDownloadTypes.ts
@@ -7,6 +7,7 @@ export interface DownloadParams {
   title?: string;
   description?: string;
   totalBytes?: number;
+  sha256?: string;
 }
 
 export interface MultiFileDownloadParams {

--- a/src/services/huggingface.ts
+++ b/src/services/huggingface.ts
@@ -98,7 +98,7 @@ class HuggingFaceService {
     };
   };
 
-  private transformFileInfo(modelId: string, file: { rfilename: string; size?: number; lfs?: { size: number } }): ModelFile {
+  private transformFileInfo(modelId: string, file: { rfilename: string; size?: number; lfs?: { size: number; sha256: string } }): ModelFile {
     const fileName = file.rfilename;
     const size = file.lfs?.size || file.size || 0;
     const quantization = this.extractQuantization(fileName);
@@ -108,6 +108,7 @@ class HuggingFaceService {
       size,
       quantization,
       downloadUrl: this.getDownloadUrl(modelId, fileName),
+      sha256: file.lfs?.sha256,
     };
   }
 

--- a/src/services/modelManager/download.ts
+++ b/src/services/modelManager/download.ts
@@ -110,7 +110,8 @@ async function startBgDownload(opts: StartBgDownloadOpts): Promise<BackgroundDow
 
   const downloadInfo = await backgroundDownloadService.startDownload({
     url: downloadUrl, fileName: file.name, modelId,
-    title: `Downloading ${file.name}`, description: `${modelId} - ${file.quantization}`, totalBytes: file.size,
+    title: `Downloading ${file.name}`, description: `${modelId} - ${file.quantization}`,
+    totalBytes: file.size, sha256: file.sha256,
   });
 
   // Start mmproj download in parallel if needed
@@ -121,6 +122,7 @@ async function startBgDownload(opts: StartBgDownloadOpts): Promise<BackgroundDow
       url: file.mmProjFile!.downloadUrl, fileName: file.mmProjFile!.name, modelId,
       title: `Downloading ${file.mmProjFile!.name} (vision)`,
       description: `${modelId} - vision projection`, totalBytes: file.mmProjFile!.size,
+      sha256: file.mmProjFile!.sha256,
     });
     mmProjDownloadId = mmProjInfo.downloadId;
     backgroundDownloadService.markSilent(mmProjDownloadId);

--- a/src/services/modelManager/download.ts
+++ b/src/services/modelManager/download.ts
@@ -118,11 +118,12 @@ async function startBgDownload(opts: StartBgDownloadOpts): Promise<BackgroundDow
   const needsMmProj = !!(file.mmProjFile && mmProjLocalPath && !mmProjExists);
   let mmProjDownloadId: number | undefined;
   if (needsMmProj) {
+    const mmProjFile = file.mmProjFile!;
     const mmProjInfo = await backgroundDownloadService.startDownload({
-      url: file.mmProjFile!.downloadUrl, fileName: file.mmProjFile!.name, modelId,
-      title: `Downloading ${file.mmProjFile!.name} (vision)`,
-      description: `${modelId} - vision projection`, totalBytes: file.mmProjFile!.size,
-      sha256: file.mmProjFile!.sha256,
+      url: mmProjFile.downloadUrl, fileName: mmProjFile.name, modelId,
+      title: `Downloading ${mmProjFile.name} (vision)`,
+      description: `${modelId} - vision projection`, totalBytes: mmProjFile.size,
+      sha256: mmProjFile.sha256,
     });
     mmProjDownloadId = mmProjInfo.downloadId;
     backgroundDownloadService.markSilent(mmProjDownloadId);

--- a/src/services/modelManager/download.ts
+++ b/src/services/modelManager/download.ts
@@ -146,13 +146,19 @@ async function startBgDownload(opts: StartBgDownloadOpts): Promise<BackgroundDow
   };
 
   const removeProgressListener = backgroundDownloadService.onProgress(
-    downloadInfo.downloadId, (event) => { mainBytesDownloaded = event.bytesDownloaded; reportProgress(); },
+    downloadInfo.downloadId, (event) => {
+      if (event.status === 'retrying') return; // keep existing bytes on transient failure
+      mainBytesDownloaded = event.bytesDownloaded; reportProgress();
+    },
   );
 
   let removeMmProjProgressListener: (() => void) | undefined;
   if (mmProjDownloadId) {
     removeMmProjProgressListener = backgroundDownloadService.onProgress(
-      mmProjDownloadId, (event) => { mmProjBytesDownloaded = event.bytesDownloaded; reportProgress(); },
+      mmProjDownloadId, (event) => {
+        if (event.status === 'retrying') return;
+        mmProjBytesDownloaded = event.bytesDownloaded; reportProgress();
+      },
     );
   }
 

--- a/src/services/modelManager/index.ts
+++ b/src/services/modelManager/index.ts
@@ -290,6 +290,7 @@ class ModelManager {
     let resolvedPath = mmProjLocalPath;
     await new Promise<void>((resolve, reject) => {
       const removeProgress = backgroundDownloadService.onProgress(info.downloadId, (event) => {
+        if (event.status === 'retrying') return;
         opts?.onProgress?.({ modelId, fileName: file.mmProjFile!.name, bytesDownloaded: event.bytesDownloaded, totalBytes, progress: totalBytes > 0 ? event.bytesDownloaded / totalBytes : 0 });
       });
       const removeComplete = backgroundDownloadService.onComplete(info.downloadId, async (event) => {

--- a/src/services/modelManager/restore.ts
+++ b/src/services/modelManager/restore.ts
@@ -118,14 +118,20 @@ async function restoreDownloadEntry(opts: RestoreEntryOpts): Promise<void> {
   };
 
   const removeProgressListener = backgroundDownloadService.onProgress(
-    download.downloadId, (event) => { mainBytesDownloaded = event.bytesDownloaded; reportProgress(); },
+    download.downloadId, (event) => {
+      if (event.status === 'retrying') return;
+      mainBytesDownloaded = event.bytesDownloaded; reportProgress();
+    },
   );
 
   let removeMmProjProgressListener: (() => void) | undefined;
   if (mmProjDownloadId && !mmProjCompleted) {
     backgroundDownloadService.markSilent(mmProjDownloadId);
     removeMmProjProgressListener = backgroundDownloadService.onProgress(
-      mmProjDownloadId, (event) => { mmProjBytesDownloaded = event.bytesDownloaded; reportProgress(); },
+      mmProjDownloadId, (event) => {
+        if (event.status === 'retrying') return;
+        mmProjBytesDownloaded = event.bytesDownloaded; reportProgress();
+      },
     );
   }
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -4,7 +4,7 @@ import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { DeviceInfo, DownloadedModel, ModelRecommendation, ONNXImageModel, ImageGenerationMode, AutoDetectMethod, ModelLoadingStrategy, CacheType, GeneratedImage, PersistedDownloadInfo } from '../types';
 
-type DownloadProgressInfo = { progress: number; bytesDownloaded: number; totalBytes: number; reason?: string };
+type DownloadProgressInfo = { progress: number; bytesDownloaded: number; totalBytes: number; status?: string; reason?: string };
 
 type OnboardingChecklist = {
   downloadedModel: boolean; loadedModel: boolean; sentMessage: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,11 +31,13 @@ export interface ModelFile {
   size: number;
   quantization: string;
   downloadUrl: string;
+  sha256?: string;
   // Companion mmproj for vision models
   mmProjFile?: {
     name: string;
     size: number;
     downloadUrl: string;
+    sha256?: string;
   };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -322,7 +322,7 @@ export interface Project {
   createdAt: string;
   updatedAt: string;
 }
-export type BackgroundDownloadStatus = 'pending' | 'running' | 'paused' | 'completed' | 'failed' | 'unknown';
+export type BackgroundDownloadStatus = 'pending' | 'running' | 'paused' | 'completed' | 'failed' | 'unknown' | 'retrying';
 export interface BackgroundDownloadInfo {
   downloadId: number;
   fileName: string;


### PR DESCRIPTION
Summary

Complete migration of the Android download layer from the legacy DownloadManager + SharedPreferences approach to a Room + WorkManager + OkHttp architecture.

What changed

New persistence layer (Room SQLite)

DownloadEntity — @Entity with all download fields (id, url, fileName, modelId, title, destination, totalBytes, downloadedBytes, status, createdAt, error)
DownloadDao — typed queries: getDownload, insertDownload, deleteDownload, updateProgress, updateStatus
DownloadDatabase — thread-safe singleton with double-checked locking

New worker (WorkerDownload.kt)

CoroutineWorker replaces DownloadManager callbacks
OkHttp singleton with Range: bytes=N- resume support; handles 206/200/416 response codes
DB-driven pause: worker polls DownloadStatus.PAUSED mid-loop → Result.retry()
Cognitive complexity reduced from 39 → ~12 by extracting private helpers (syncFileSizeWithDb, buildRequest, handleResponse, handleResponseCode, calculateTotalBytes, streamToFile, checkCancellationOrPause, failDownload)
SSRF protection: isHostAllowed() host allowlist (huggingface.co, cdn-lfs.huggingface.co, cas-bridge.xethub.hf.co)
enqueueResume() uses ExistingWorkPolicy.KEEP — leaves running work untouched

New module (DownloadManagerModule.kt)

CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate) replaces Handler + watchdog polling
WorkInfo LiveData observers — progress pushed via setProgress, no polling loop
startProgressPolling() re-attaches observers on app resume for downloads that ran while the app was backgrounded
pauseDownload / resumeDownload wired to DB status + enqueueResume
Path traversal protection in moveCompletedDownload: canonical path validated against app sandbox dirs

Legacy files retained during transition:

WorkerDownloadStore.kt + DownloadCompleteBroadcastReceiver.kt + AndroidManifest receiver entry preserved

Tests

Replaced 569-line test file for removed DownloadManager/SharedPrefs functions with focused tests for the new pure functions: isHostAllowed, workName, DownloadStatus enum, and legacy status constants
Issues addressed
SSRF host allowlist, path traversal canonical check, Future.get() unhandled exception (replaced with KEEP policy)
Reduced cognitive complexity (doWork 39 → ~12)
Improved reliability by removing ListenableFuture.get()