### PR TITLE
Fix file delete from source error

### DIFF
--- a/src/screens/KnowledgeBaseScreen.tsx
+++ b/src/screens/KnowledgeBaseScreen.tsx
@@ -7,12 +7,13 @@ import {
   Switch,
   ActivityIndicator,
   Alert,
+  Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import Icon from 'react-native-vector-icons/Feather';
-import { pick } from '@react-native-documents/picker';
+import { pick, keepLocalCopy } from '@react-native-documents/picker';
 import { useTheme, useThemedStyles } from '../theme';
 import { createStyles } from './KnowledgeBaseScreen.styles';
 import { useProjectStore } from '../stores';
@@ -58,7 +59,11 @@ export const KnowledgeBaseScreen: React.FC = () => {
 
   const handleAddDocument = async () => {
     try {
-      const files = await pick({ mode: 'import', allowMultiSelection: true });
+      // iOS: 'import' → Apple copies the file before handing it to us, original untouched.
+      // Android: 'open' → returns a content:// URI; keepLocalCopy() copies it to a real path.
+      const files = Platform.OS === 'android'
+        ? await pick({ mode: 'open', allowMultiSelection: true })
+        : await pick({ mode: 'import', allowMultiSelection: true });
       if (!files?.length) return;
 
       for (let i = 0; i < files.length; i++) {
@@ -66,12 +71,25 @@ export const KnowledgeBaseScreen: React.FC = () => {
         const fileName = file.name || 'document';
         setIndexingFile(files.length > 1 ? `${fileName} (${i + 1}/${files.length})` : fileName);
 
-        // mode: 'import' means iOS already provided a local copy — original is untouched
         let pathForDb = file.uri;
-        try {
-          pathForDb = decodeURIComponent(file.uri).replace(/^file:\/\//, '');
-        } catch {
-          // use uri as-is
+        if (Platform.OS === 'android') {
+          try {
+            const copyResult = await keepLocalCopy({
+              files: [{ uri: file.uri, fileName }],
+              destination: 'documentDirectory',
+            });
+            if (copyResult[0]?.status === 'success' && copyResult[0].localUri) {
+              pathForDb = decodeURIComponent(copyResult[0].localUri).replace(/^file:\/\//, '');
+            }
+          } catch {
+            // fall through with original uri
+          }
+        } else {
+          try {
+            pathForDb = decodeURIComponent(file.uri).replace(/^file:\/\//, '');
+          } catch {
+            // use uri as-is
+          }
         }
 
         try {

--- a/src/screens/KnowledgeBaseScreen.tsx
+++ b/src/screens/KnowledgeBaseScreen.tsx
@@ -24,6 +24,28 @@ import { RootStackParamList } from '../navigation/types';
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 type RouteProps = RouteProp<RootStackParamList, 'KnowledgeBase'>;
 
+const resolveLocalPath = async (uri: string, fileName: string): Promise<string> => {
+  if (Platform.OS === 'android') {
+    try {
+      const copyResult = await keepLocalCopy({
+        files: [{ uri, fileName }],
+        destination: 'documentDirectory',
+      });
+      if (copyResult[0]?.status === 'success' && copyResult[0].localUri) {
+        return decodeURIComponent(copyResult[0].localUri).replace(/^file:\/\//, '');
+      }
+    } catch {
+      // fall through with original uri
+    }
+    return uri;
+  }
+  try {
+    return decodeURIComponent(uri).replace(/^file:\/\//, '');
+  } catch {
+    return uri;
+  }
+};
+
 const formatFileSize = (bytes: number): string => {
   if (bytes < 1024) return `${bytes} B`;
   return bytes < 1024 * 1024 ? `${(bytes / 1024).toFixed(1)} KB` : `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -71,26 +93,7 @@ export const KnowledgeBaseScreen: React.FC = () => {
         const fileName = file.name || 'document';
         setIndexingFile(files.length > 1 ? `${fileName} (${i + 1}/${files.length})` : fileName);
 
-        let pathForDb = file.uri;
-        if (Platform.OS === 'android') {
-          try {
-            const copyResult = await keepLocalCopy({
-              files: [{ uri: file.uri, fileName }],
-              destination: 'documentDirectory',
-            });
-            if (copyResult[0]?.status === 'success' && copyResult[0].localUri) {
-              pathForDb = decodeURIComponent(copyResult[0].localUri).replace(/^file:\/\//, '');
-            }
-          } catch {
-            // fall through with original uri
-          }
-        } else {
-          try {
-            pathForDb = decodeURIComponent(file.uri).replace(/^file:\/\//, '');
-          } catch {
-            // use uri as-is
-          }
-        }
+        const pathForDb = await resolveLocalPath(file.uri, fileName);
 
         try {
           await ragService.indexDocument({ projectId, filePath: pathForDb, fileName, fileSize: file.size || 0 });

--- a/src/screens/KnowledgeBaseScreen.tsx
+++ b/src/screens/KnowledgeBaseScreen.tsx
@@ -26,18 +26,14 @@ type RouteProps = RouteProp<RootStackParamList, 'KnowledgeBase'>;
 
 const resolveLocalPath = async (uri: string, fileName: string): Promise<string> => {
   if (Platform.OS === 'android') {
-    try {
-      const copyResult = await keepLocalCopy({
-        files: [{ uri, fileName }],
-        destination: 'documentDirectory',
-      });
-      if (copyResult[0]?.status === 'success' && copyResult[0].localUri) {
-        return decodeURIComponent(copyResult[0].localUri).replace(/^file:\/\//, '');
-      }
-    } catch {
-      // fall through with original uri
+    const copyResult = await keepLocalCopy({
+      files: [{ uri, fileName }],
+      destination: 'documentDirectory',
+    });
+    if (copyResult[0]?.status === 'success' && copyResult[0].localUri) {
+      return decodeURIComponent(copyResult[0].localUri).replace(/^file:\/\//, '');
     }
-    return uri;
+    throw new Error('Failed to create a local copy of the document');
   }
   try {
     return decodeURIComponent(uri).replace(/^file:\/\//, '');

--- a/src/screens/ProjectDetailKnowledgeBaseSection.tsx
+++ b/src/screens/ProjectDetailKnowledgeBaseSection.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, TouchableOpacity, Switch, ActivityIndicator, ScrollView } from 'react-native';
+import { View, Text, TouchableOpacity, Switch, ActivityIndicator, ScrollView, Platform } from 'react-native';
 import Icon from 'react-native-vector-icons/Feather';
-import { pick } from '@react-native-documents/picker';
+import { pick, keepLocalCopy } from '@react-native-documents/picker';
 import { Button } from '../components/Button';
 import { showAlert, AlertState } from '../components/CustomAlert';
 import { ragService } from '../services/rag';
@@ -43,7 +43,11 @@ export const KnowledgeBaseSection: React.FC<KBSectionProps> = ({ projectId, colo
 
   const handleAddDocument = async () => {
     try {
-      const files = await pick({ mode: 'import', allowMultiSelection: true });
+      // iOS: 'import' → Apple copies the file before handing it to us, original untouched.
+      // Android: 'open' → returns a content:// URI; keepLocalCopy() copies it to a real path.
+      const files = Platform.OS === 'android'
+        ? await pick({ mode: 'open', allowMultiSelection: true })
+        : await pick({ mode: 'import', allowMultiSelection: true });
       if (!files?.length) return;
 
       for (let i = 0; i < files.length; i++) {
@@ -51,7 +55,20 @@ export const KnowledgeBaseSection: React.FC<KBSectionProps> = ({ projectId, colo
         const fileName = file.name || 'document';
         setIndexingFile(files.length > 1 ? `${fileName} (${i + 1}/${files.length})` : fileName);
 
-        const pathForDb = decodeFilePath(file.uri);
+        let pathForDb = decodeFilePath(file.uri);
+        if (Platform.OS === 'android') {
+          try {
+            const copyResult = await keepLocalCopy({
+              files: [{ uri: file.uri, fileName }],
+              destination: 'documentDirectory',
+            });
+            if (copyResult[0]?.status === 'success' && copyResult[0].localUri) {
+              pathForDb = decodeFilePath(copyResult[0].localUri);
+            }
+          } catch {
+            // fall through with original uri
+          }
+        }
 
         await ragService.indexDocument({ projectId, filePath: pathForDb, fileName, fileSize: file.size || 0 });
         await loadKbDocs();

--- a/src/screens/ProjectDetailKnowledgeBaseSection.tsx
+++ b/src/screens/ProjectDetailKnowledgeBaseSection.tsx
@@ -8,6 +8,17 @@ import { ragService } from '../services/rag';
 import type { RagDocument } from '../services/rag';
 
 
+async function resolveAndroidPath(uri: string, fileName: string): Promise<string> {
+  const copyResult = await keepLocalCopy({
+    files: [{ uri, fileName }],
+    destination: 'documentDirectory',
+  });
+  if (copyResult[0]?.status === 'success' && copyResult[0].localUri) {
+    return decodeFilePath(copyResult[0].localUri);
+  }
+  throw new Error('Failed to create a local copy of the document');
+}
+
 function decodeFilePath(filePath: string): string {
   try {
     return decodeURIComponent(filePath).replace(/^file:\/\//, '');
@@ -55,20 +66,9 @@ export const KnowledgeBaseSection: React.FC<KBSectionProps> = ({ projectId, colo
         const fileName = file.name || 'document';
         setIndexingFile(files.length > 1 ? `${fileName} (${i + 1}/${files.length})` : fileName);
 
-        let pathForDb = decodeFilePath(file.uri);
-        if (Platform.OS === 'android') {
-          try {
-            const copyResult = await keepLocalCopy({
-              files: [{ uri: file.uri, fileName }],
-              destination: 'documentDirectory',
-            });
-            if (copyResult[0]?.status === 'success' && copyResult[0].localUri) {
-              pathForDb = decodeFilePath(copyResult[0].localUri);
-            }
-          } catch {
-            // fall through with original uri
-          }
-        }
+        const pathForDb = Platform.OS === 'android'
+          ? await resolveAndroidPath(file.uri, fileName)
+          : decodeFilePath(file.uri);
 
         await ragService.indexDocument({ projectId, filePath: pathForDb, fileName, fileSize: file.size || 0 });
         await loadKbDocs();


### PR DESCRIPTION
## Problem

On Android, adding a PDF or document to the RAG knowledge base crashed
the app to the home screen every time. This was a 100% reproducible
regression introduced in #208.

Root cause: #208 switched from `mode: 'open' + keepLocalCopy()` to
`mode: 'import'` to fix iOS deleting the source file. On iOS this is
safe — Apple copies the file natively before handing any URI to the
app. On Android, `mode: 'import'` can return a `content://` URI
instead of a real file path. When that URI is passed directly to the
native PDF extractor, the native module crashes the process because it
expects a file path, not a content URI.

## Fix

Use platform-specific picker modes:

- **iOS** — keep `mode: 'import'` (Apple handles the copy, original untouched)
- **Android** — `mode: 'open'` + `keepLocalCopy()`, which explicitly
  copies the file to the app's documents directory and always returns a
  real `file://` path the native modules can read

This restores the Android behaviour that worked in v0.0.81 while
keeping the iOS source-file fix from #208 intact.

Works correctly on Android variants (GrapheneOS, CalyxOS, LineageOS)
since they use the same content provider system and return `'android'`
for `Platform.OS`.

## Files changed

- `src/screens/KnowledgeBaseScreen.tsx`
- `src/screens/ProjectDetailKnowledgeBaseSection.tsx`
