### PR TITLE
fix: allow viewing old chats without an active model

### DIFF
--- a/__tests__/rntl/screens/ChatScreen.test.tsx
+++ b/__tests__/rntl/screens/ChatScreen.test.tsx
@@ -587,6 +587,36 @@ describe('ChatScreen', () => {
       // Modal should open
       expect(queryByTestId('model-selector-modal')).toBeTruthy();
     });
+
+    it('shows existing chat messages when no model is active (read-only mode)', () => {
+      // Set up an existing conversation with messages but NO active model
+      const conversation = createConversation({
+        messages: [
+          createUserMessage('Hello from before'),
+          createAssistantMessage('Hi there!'),
+        ],
+      });
+      useChatStore.setState({
+        conversations: [conversation],
+        activeConversationId: conversation.id,
+      });
+      mockRoute.params = { conversationId: conversation.id };
+
+      const { queryByText, getByTestId } = renderChatScreen();
+
+      // Should NOT show NoModelScreen when there are messages to display
+      expect(queryByText('No Model Selected')).toBeNull();
+
+      // Should show the existing messages
+      expect(getByTestId(`message-content-${conversation.messages[0].id}`).props.children).toBe('Hello from before');
+      expect(getByTestId(`message-content-${conversation.messages[1].id}`).props.children).toBe('Hi there!');
+    });
+
+    it('shows NoModelScreen when no model and no existing messages', () => {
+      // No model active and no conversation with messages
+      const { getByText } = renderChatScreen();
+      expect(getByText('No Model Selected')).toBeTruthy();
+    });
   });
 
   // ============================================================================

--- a/src/screens/ChatScreen/index.tsx
+++ b/src/screens/ChatScreen/index.tsx
@@ -110,7 +110,7 @@ export const ChatScreen: React.FC = () => {
       onClose={() => chat.setAlertState(hideAlert())}
     />
   );
-  if (!chat.hasActiveModel) {
+  if (!chat.hasActiveModel && chat.displayMessages.length === 0) {
     return (
       <>
         <NoModelScreen


### PR DESCRIPTION
Fixes #201

## Problem
When a user had no model active (e.g., after deleting all downloaded models), navigating to an existing conversation from the Chats or Projects tab immediately showed the "No Model Selected" screen instead of the conversation history. This prevented users from reading their past chats.

## Solution
Changed the guard condition in `ChatScreen/index.tsx` from:
```ts
if (!chat.hasActiveModel)
```
to:
```ts
if (!chat.hasActiveModel && chat.displayMessages.length === 0)
```

This way `NoModelScreen` is only shown when there is truly nothing to display (no model + no messages). When an existing conversation has messages, the full chat layout is rendered with the input already disabled via `ChatInput`'s existing `disabled={!chat.hasActiveModel}` prop, allowing read-only access to prior chats.

## Testing
- Added two new RNTL unit tests in the `no model state` describe block:
  - Verifies that existing messages are rendered (not `NoModelScreen`) when no model is active but a conversation with messages exists.
  - Verifies `NoModelScreen` is still shown when no model is active and there are no messages.
- All 150 existing `ChatScreen.test.tsx` tests continue to pass.