### PR TITLE
fix(chat): project selection doesn't stick on new conversations

### DIFF
--- a/src/screens/ChatScreen/useChatScreen.ts
+++ b/src/screens/ChatScreen/useChatScreen.ts
@@ -51,6 +51,7 @@ export const useChatScreen = () => {
   const [supportsToolCalling, setSupportsToolCalling] = useState(false);
   const [supportsThinking, setSupportsThinking] = useState(false);
   const [isCompacting, setIsCompacting] = useState(false);
+  const [pendingProjectId, setPendingProjectId] = useState<string | null>(route.params?.projectId ?? null);
   const lastMessageCountRef = useRef(0);
   const generatingForConversationRef = useRef<string | null>(null);
   const modelLoadStartTimeRef = useRef<number | null>(null);
@@ -117,7 +118,9 @@ export const useChatScreen = () => {
   const hasActiveModel = activeModelInfo.modelId !== null;
   const activeModelName = activeModelInfo.modelName;
 
-  const activeProject = activeConversation?.projectId ? getProject(activeConversation.projectId) : null;
+  const activeProject = activeConversation?.projectId
+    ? getProject(activeConversation.projectId)
+    : (pendingProjectId ? getProject(pendingProjectId) : null);
   const activeImageModel = downloadedImageModels.find(m => m.id === activeImageModelId);
   const imageModelLoaded = !!activeImageModel;
   const isGeneratingImage = imageGenState.isGenerating;
@@ -131,7 +134,7 @@ export const useChatScreen = () => {
     setActiveConversation, removeImagesByConversationId, generatingForConversationRef, navigation, setShowSettingsPanel,
     ensureModelLoaded: async () => ensureModelLoadedFn(modelDeps),
     createConversation,
-    pendingProjectId: route.params?.projectId,
+    pendingProjectId: pendingProjectId ?? undefined,
   };
 
   const modelDeps = {
@@ -260,8 +263,14 @@ export const useChatScreen = () => {
       handleRetryMessageFn(message, genDeps, { activeConversationId, hasActiveModel, activeConversation, deleteMessagesAfter, setDebugInfo }),
     handleEditMessage: (message: Message, newContent: string) =>
       handleEditMessageFn(genDeps, { message, newContent, activeConversationId, hasActiveModel, updateMessageContent, deleteMessagesAfter, setDebugInfo }),
-    handleSelectProject: (project: Project | null) =>
-      handleSelectProjectFn({ activeConversationId, setConversationProject, setShowProjectSelector }, project),
+    handleSelectProject: (project: Project | null) => {
+      if (!activeConversationId) {
+        setPendingProjectId(project?.id ?? null);
+        setShowProjectSelector(false);
+      } else {
+        handleSelectProjectFn({ activeConversationId, setConversationProject, setShowProjectSelector }, project);
+      }
+    },
     handleGenerateImageFromMessage: (prompt: string) =>
       handleGenerateImageFromMsgFn(prompt, genDeps, { activeConversationId, activeImageModel, setAlertState }),
     handleImagePress: (uri: string) => setViewerImageUri(uri),


### PR DESCRIPTION
When switching projects from the in-chat selector before sending any message, the selection was silently dropped. The conversation doesn't exist yet at that point — it's only created on first send — so activeConversationId is null and the setConversationProject call was guarded behind an if-check that always failed.

Fix: track the selection in a pendingProjectId state variable. On project select with no active conversation, store it there instead. On first send, createConversation already accepts a projectId so pendingProjectId is passed through and the conversation is created with the correct project from the start. activeProject also falls back to pendingProjectId so the UI reflects the selection immediately.

## Summary

<!-- Briefly describe what this PR does and why -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Chore (build process, CI, dependency updates, etc.)

## Screenshots / Screen Recordings

<!-- Mandatory for any UI change. Remove sections that don't apply. -->

### Android

| Before | After |
|--------|-------|
|        |       |

### iOS

| Before | After |
|--------|-------|
|        |       |

## Checklist

### General

- [ ] My code follows the project's coding style and conventions
- [ ] I have performed a self-review of my code
- [ ] I have added/updated comments where the logic isn't self-evident
- [ ] My changes generate no new warnings or errors

### Testing

- [ ] I have tested on **Android** (physical device or emulator)
- [ ] I have tested on **iOS** (physical device or simulator)
- [ ] I have tested in **light mode** and **dark mode**
- [ ] Existing tests pass locally (`npm test`)
- [ ] I have added tests that prove my fix is effective or my feature works

### React Native Specific

- [ ] No new native module without corresponding platform implementation (Android + iOS)
- [ ] New native modules are added to the Xcode project build target (`project.pbxproj`)
- [ ] No hardcoded pixel values — uses `SPACING` / `TYPOGRAPHY` constants from the theme
- [ ] Styles use `useThemedStyles` pattern (not inline or static `StyleSheet.create`)
- [ ] Animations/gestures work smoothly on both platforms
- [ ] Large lists use `FlatList` / `FlashList` (not `.map()` inside `ScrollView`)
- [ ] No unnecessary re-renders introduced (check with React DevTools Profiler if unsure)

### Performance & Models

- [ ] Downloads / long-running tasks report progress to the UI
- [ ] File paths are resolved correctly on both platforms (no hardcoded `/` vs `\\`)
- [ ] Large files (models, assets) are not committed to the repository

### Security

- [ ] No secrets, API keys, or credentials are included in the code
- [ ] User input is validated/sanitized where applicable

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Additional Notes

<!-- Any context, trade-offs, or follow-up work worth mentioning -->
