### PR TITLE
feat(android): enable Hexagon HTP/NPU acceleration for text LLMs

### DIFF
--- a/__tests__/rntl/components/DebugSheet.test.tsx
+++ b/__tests__/rntl/components/DebugSheet.test.tsx
@@ -431,8 +431,8 @@ describe('DebugSheet', () => {
       const { getByText } = render(
         <DebugSheet {...defaultProps} debugInfo={null} />
       );
-      // Default is 2048 from APP_CONFIG
-      expect(getByText('2048')).toBeTruthy();
+      // Default is 4096 from APP_CONFIG
+      expect(getByText('4096')).toBeTruthy();
     });
 
     it('uses 0.0% as default usage', () => {

--- a/__tests__/rntl/components/GenerationSettingsModal.test.tsx
+++ b/__tests__/rntl/components/GenerationSettingsModal.test.tsx
@@ -81,7 +81,7 @@ const defaultSettings = {
   topP: 0.9,
   repeatPenalty: 1.1,
   contextLength: 4096,
-  nThreads: 4,
+  nThreads: 0,
   nBatch: 512,
   enableGpu: false,
   inferenceBackend: 'cpu' as const,
@@ -239,7 +239,7 @@ describe('GenerationSettingsModal', () => {
       topP: 0.9,
       repeatPenalty: 1.1,
       contextLength: 4096,
-      nThreads: 4,
+      nThreads: 0,
       nBatch: 512,
     });
   });

--- a/__tests__/rntl/components/GenerationSettingsModal.test.tsx
+++ b/__tests__/rntl/components/GenerationSettingsModal.test.tsx
@@ -80,7 +80,7 @@ const defaultSettings = {
   maxTokens: 1024,
   topP: 0.9,
   repeatPenalty: 1.1,
-  contextLength: 2048,
+  contextLength: 4096,
   nThreads: 4,
   nBatch: 512,
   enableGpu: false,
@@ -238,7 +238,7 @@ describe('GenerationSettingsModal', () => {
       maxTokens: 1024,
       topP: 0.9,
       repeatPenalty: 1.1,
-      contextLength: 2048,
+      contextLength: 4096,
       nThreads: 4,
       nBatch: 512,
     });
@@ -609,7 +609,7 @@ describe('GenerationSettingsModal', () => {
     expect(getByText('1.0K')).toBeTruthy(); // maxTokens: 1024
     expect(getByText('0.90')).toBeTruthy(); // topP
     expect(getByText('1.10')).toBeTruthy(); // repeatPenalty
-    expect(getByText('2K')).toBeTruthy(); // contextLength: 2048
+    expect(getByText('4K')).toBeTruthy(); // contextLength: 4096
   });
 
   it('shows description for text settings', () => {

--- a/__tests__/rntl/components/GenerationSettingsModal.test.tsx
+++ b/__tests__/rntl/components/GenerationSettingsModal.test.tsx
@@ -84,6 +84,7 @@ const defaultSettings = {
   nThreads: 4,
   nBatch: 512,
   enableGpu: false,
+  inferenceBackend: 'cpu' as const,
   gpuLayers: 99,
   flashAttn: false,
   modelLoadingStrategy: 'memory',
@@ -968,8 +969,8 @@ describe('GenerationSettingsModal', () => {
         Object.defineProperty(Platform, 'OS', { get: () => originalOS, configurable: true });
       });
 
-      it('renders GPU layers slider with gpuLayersEffective when GPU enabled', () => {
-        mockStoreValues.settings = { ...defaultSettings, enableGpu: true, gpuLayers: 8, flashAttn: false };
+      it('renders GPU layers slider with gpuLayersEffective when backend is OpenCL', () => {
+        mockStoreValues.settings = { ...defaultSettings, inferenceBackend: 'opencl' as const, gpuLayers: 8, flashAttn: false };
         const { getByText, getByTestId } = render(<GenerationSettingsModal {...defaultProps} />);
         fireEvent.press(getByText('TEXT GENERATION'));
         fireEvent.press(getByTestId('modal-text-advanced-toggle'));
@@ -978,7 +979,7 @@ describe('GenerationSettingsModal', () => {
 
       it('shows GPU layers at full value when flash attention is On (no clamping)', () => {
         // Flash attention no longer caps GPU layers — gpuLayersMax is always 99
-        mockStoreValues.settings = { ...defaultSettings, enableGpu: true, gpuLayers: 8, flashAttn: true };
+        mockStoreValues.settings = { ...defaultSettings, inferenceBackend: 'opencl' as const, gpuLayers: 8, flashAttn: true };
         const { getByText, getByTestId } = render(<GenerationSettingsModal {...defaultProps} />);
         fireEvent.press(getByText('TEXT GENERATION'));
         fireEvent.press(getByTestId('modal-text-advanced-toggle'));
@@ -989,7 +990,7 @@ describe('GenerationSettingsModal', () => {
       it('uses default gpuLayers value of 1 when gpuLayers is undefined (covers ?? fallback)', () => {
         mockStoreValues.settings = {
           ...defaultSettings,
-          enableGpu: true,
+          inferenceBackend: 'opencl' as const,
           gpuLayers: undefined as any,
           flashAttn: false,
         };
@@ -1045,33 +1046,32 @@ describe('GenerationSettingsModal', () => {
         );
       });
 
-      it('calls updateSettings with enableGpu: false when GPU Off button pressed', () => {
-        mockStoreValues.settings = { ...defaultSettings, enableGpu: true };
+      it('calls updateSettings with inferenceBackend: cpu when CPU button pressed', () => {
+        mockStoreValues.settings = { ...defaultSettings, inferenceBackend: 'opencl' as const };
         const { getByText, getByTestId } = render(<GenerationSettingsModal {...defaultProps} />);
         fireEvent.press(getByText('TEXT GENERATION'));
         fireEvent.press(getByTestId('modal-text-advanced-toggle'));
         mockUpdateSettings.mockClear();
 
-        fireEvent.press(getByTestId('gpu-off-button'));
+        fireEvent.press(getByTestId('backend-cpu-button'));
 
-        expect(mockUpdateSettings).toHaveBeenCalledWith({ enableGpu: false });
+        expect(mockUpdateSettings).toHaveBeenCalledWith({ inferenceBackend: 'cpu' });
       });
 
-      it('calls updateSettings with enableGpu: true and cacheType: f16 when GPU On button pressed on Android with quantized cache', () => {
-        mockStoreValues.settings = { ...defaultSettings, enableGpu: false };
+      it('calls updateSettings with inferenceBackend: opencl when OpenCL button pressed on Android', () => {
+        mockStoreValues.settings = { ...defaultSettings, inferenceBackend: 'cpu' as const };
         const { getByText, getByTestId } = render(<GenerationSettingsModal {...defaultProps} />);
         fireEvent.press(getByText('TEXT GENERATION'));
         fireEvent.press(getByTestId('modal-text-advanced-toggle'));
         mockUpdateSettings.mockClear();
 
-        fireEvent.press(getByTestId('gpu-on-button'));
+        fireEvent.press(getByTestId('backend-opencl-button'));
 
-        // On Android, enabling GPU with quantized cache (no cacheType defaults to q8_0) auto-switches to f16
-        expect(mockUpdateSettings).toHaveBeenCalledWith({ enableGpu: true, cacheType: 'f16' });
+        expect(mockUpdateSettings).toHaveBeenCalledWith({ inferenceBackend: 'opencl' });
       });
 
       it('calls updateSettings with gpuLayers value from GPU layers slider', () => {
-        mockStoreValues.settings = { ...defaultSettings, enableGpu: true, gpuLayers: 6, flashAttn: false };
+        mockStoreValues.settings = { ...defaultSettings, inferenceBackend: 'opencl' as const, gpuLayers: 6, flashAttn: false };
         const { getByText, getByTestId } = render(<GenerationSettingsModal {...defaultProps} />);
         fireEvent.press(getByText('TEXT GENERATION'));
         fireEvent.press(getByTestId('modal-text-advanced-toggle'));

--- a/__tests__/rntl/components/ModelCard.test.tsx
+++ b/__tests__/rntl/components/ModelCard.test.tsx
@@ -395,6 +395,16 @@ describe('ModelCard', () => {
       );
       expect(queryByText('Vision')).toBeNull();
     });
+
+    it('shows Needs repair badge when downloaded vision model is missing mmproj', () => {
+      const visionFile = createModelFileWithMmProj();
+      const brokenModel = createDownloadedModel({ isVisionModel: true });
+      const { getByText, queryByText } = render(
+        <ModelCard model={baseModel} file={visionFile} downloadedModel={brokenModel} />
+      );
+      expect(getByText('Needs repair')).toBeTruthy();
+      expect(queryByText('Vision')).toBeNull();
+    });
   });
 
   // ============================================================================

--- a/__tests__/rntl/screens/ModelSettingsScreen.test.tsx
+++ b/__tests__/rntl/screens/ModelSettingsScreen.test.tsx
@@ -436,7 +436,7 @@ describe('ModelSettingsScreen', () => {
     it('shows CPU Threads slider label and default value', () => {
       const { getByText } = renderWithSections('text');
       expect(getByText('CPU Threads')).toBeTruthy();
-      expect(getByText('4')).toBeTruthy();
+      expect(getByText('6')).toBeTruthy();
     });
 
     it('shows Batch Size slider label and default value', () => {
@@ -984,7 +984,7 @@ describe('ModelSettingsScreen', () => {
       const s = useAppStore.getState().settings;
       expect(s.temperature).toBe(0.7);
       expect(s.maxTokens).toBe(1024);
-      expect(s.nThreads).toBe(4);
+      expect(s.nThreads).toBe(0);
       expect(s.nBatch).toBe(512);
       expect(s.cacheType).toBe('q8_0');
       expect(s.flashAttn).toBe(true);

--- a/__tests__/rntl/screens/ModelSettingsScreen.test.tsx
+++ b/__tests__/rntl/screens/ModelSettingsScreen.test.tsx
@@ -585,18 +585,19 @@ describe('ModelSettingsScreen', () => {
   // GPU Settings (Only visible on non-iOS platforms)
   // ============================================================================
   describe('GPU settings', () => {
-    // Platform.OS is 'ios' in the test environment, so GPU section is hidden
-    it('does not show GPU Acceleration on iOS', () => {
-      const { queryByText } = renderWithSections('text');
-      expect(queryByText('GPU Acceleration')).toBeNull();
+    // Platform.OS is 'ios' in the test environment; Metal is the default backend, GPU Layers hidden when cpu
+    it('shows Inference Backend section on iOS', () => {
+      const { getByText } = renderWithSections('text');
+      expect(getByText('Inference Backend')).toBeTruthy();
     });
 
-    it('does not show GPU Layers on iOS', () => {
+    it('does not show GPU Layers on iOS when backend is cpu', () => {
+      useAppStore.getState().updateSettings({ inferenceBackend: 'cpu' });
       const { queryByText } = renderWithSections('text');
       expect(queryByText('GPU Layers')).toBeNull();
     });
 
-    // Android-specific GPU tests: mock Platform.OS before each, restore after
+    // Android-specific backend tests: mock Platform.OS before each, restore after
     describe('on Android platform', () => {
       let originalOS: string;
       const { Platform } = require('react-native');
@@ -610,15 +611,15 @@ describe('ModelSettingsScreen', () => {
         Object.defineProperty(Platform, 'OS', { get: () => originalOS, configurable: true });
       });
 
-      it('shows GPU Acceleration and GPU Layers slider when GPU enabled', () => {
-        useAppStore.getState().updateSettings({ enableGpu: true, gpuLayers: 6 });
+      it('shows Inference Backend section and GPU Layers slider when backend is OpenCL', () => {
+        useAppStore.getState().updateSettings({ inferenceBackend: 'opencl', gpuLayers: 6 });
         const { getByText } = renderWithSections('text');
-        expect(getByText('GPU Acceleration')).toBeTruthy();
+        expect(getByText('Inference Backend')).toBeTruthy();
         expect(getByText('GPU Layers')).toBeTruthy();
       });
 
       it('does not clamp gpuLayers when flashAttn turned on with layers > 1', () => {
-        useAppStore.getState().updateSettings({ enableGpu: true, flashAttn: false, gpuLayers: 8 });
+        useAppStore.getState().updateSettings({ inferenceBackend: 'opencl', flashAttn: false, gpuLayers: 8 });
         const { getByTestId } = renderWithSections('text');
         fireEvent(getByTestId('flash-attn-switch'), 'valueChange', true);
         expect(useAppStore.getState().settings.flashAttn).toBe(true);
@@ -626,26 +627,26 @@ describe('ModelSettingsScreen', () => {
         expect(useAppStore.getState().settings.gpuLayers).toBe(8);
       });
 
-      it('updates enableGpu to false when GPU Acceleration switch is toggled off', () => {
-        useAppStore.getState().updateSettings({ enableGpu: true, gpuLayers: 6 });
+      it('updates inferenceBackend to cpu when CPU button is pressed', () => {
+        useAppStore.getState().updateSettings({ inferenceBackend: 'opencl', gpuLayers: 6 });
         const { getByTestId } = renderWithSections('text');
 
-        fireEvent(getByTestId('gpu-acceleration-switch'), 'valueChange', false);
+        fireEvent.press(getByTestId('backend-cpu-button'));
 
-        expect(useAppStore.getState().settings.enableGpu).toBe(false);
+        expect(useAppStore.getState().settings.inferenceBackend).toBe('cpu');
       });
 
-      it('updates enableGpu to true when GPU Acceleration switch is toggled on', () => {
-        useAppStore.getState().updateSettings({ enableGpu: false });
+      it('updates inferenceBackend to opencl when OpenCL button is pressed', () => {
+        useAppStore.getState().updateSettings({ inferenceBackend: 'cpu' });
         const { getByTestId } = renderWithSections('text');
 
-        fireEvent(getByTestId('gpu-acceleration-switch'), 'valueChange', true);
+        fireEvent.press(getByTestId('backend-opencl-button'));
 
-        expect(useAppStore.getState().settings.enableGpu).toBe(true);
+        expect(useAppStore.getState().settings.inferenceBackend).toBe('opencl');
       });
 
       it('updates gpuLayers when GPU Layers slider completes', () => {
-        useAppStore.getState().updateSettings({ enableGpu: true, flashAttn: false, gpuLayers: 6 });
+        useAppStore.getState().updateSettings({ inferenceBackend: 'opencl', flashAttn: false, gpuLayers: 6 });
         const { getByTestId } = renderWithSections('text');
 
         const slider = getByTestId('gpu-layers-slider');
@@ -820,6 +821,7 @@ describe('ModelSettingsScreen', () => {
           imageUseOpenCL: undefined as any,
           modelLoadingStrategy: undefined as any,
           enableGpu: undefined as any,
+          inferenceBackend: undefined as any,
           gpuLayers: undefined as any,
           flashAttn: undefined as any,
           cacheType: undefined as any,
@@ -971,7 +973,7 @@ describe('ModelSettingsScreen', () => {
         nBatch: 64,
         cacheType: 'f16',
         flashAttn: false,
-        enableGpu: true,
+        inferenceBackend: 'opencl',
         gpuLayers: 20,
       });
 
@@ -986,7 +988,7 @@ describe('ModelSettingsScreen', () => {
       expect(s.nBatch).toBe(512);
       expect(s.cacheType).toBe('q8_0');
       expect(s.flashAttn).toBe(true);
-      expect(s.enableGpu).toBe(true);
+      expect(s.inferenceBackend).toBe('metal'); // iOS default
       expect(s.gpuLayers).toBe(99);
     });
   });

--- a/__tests__/rntl/screens/ModelSettingsScreen.test.tsx
+++ b/__tests__/rntl/screens/ModelSettingsScreen.test.tsx
@@ -420,7 +420,7 @@ describe('ModelSettingsScreen', () => {
     it('shows Context Length slider label and default value', () => {
       const { getByText } = renderWithSections('text');
       expect(getByText('Context Length')).toBeTruthy();
-      expect(getByText('2K')).toBeTruthy(); // 2048 -> 2K
+      expect(getByText('4K')).toBeTruthy(); // 4096 -> 4K
     });
 
     it('shows context length description', () => {
@@ -531,7 +531,7 @@ describe('ModelSettingsScreen', () => {
       const allViews = UNSAFE_getAllByType(View);
       const sliders = allViews.filter((v: any) => v.props.onSlidingComplete && v.props.testID?.startsWith('slider-'));
 
-      const ctxSlider = sliders.find((s: any) => s.props.value === 2048 && s.props.maximumValue === 32768);
+      const ctxSlider = sliders.find((s: any) => s.props.value === 4096 && s.props.maximumValue === 32768);
       if (ctxSlider) {
         fireEvent(ctxSlider, 'slidingComplete', 4096);
         expect(useAppStore.getState().settings.contextLength).toBe(4096);

--- a/__tests__/unit/services/documentService.test.ts
+++ b/__tests__/unit/services/documentService.test.ts
@@ -505,11 +505,11 @@ describe('DocumentService', () => {
     });
 
     it('truncates content exceeding maxChars', async () => {
-      // maxChars = floor(contextLength * 4 * 0.5) = floor(2048 * 4 * 0.5) = 4096
-      const overMaxChars = 4097;
+      // maxChars = floor(contextLength * 4 * 0.5) = floor(4096 * 4 * 0.5) = 8192
+      const overMaxChars = 8193;
       mockedRNFS.exists.mockResolvedValue(true);
       mockedRNFS.stat.mockResolvedValue({ size: overMaxChars, isFile: () => true } as any);
-      const overContent = 'a'.repeat(overMaxChars);
+      const overContent = 'a'.repeat(overMaxChars); // 8193 chars > maxChars (8192)
       mockedRNFS.readFile.mockResolvedValue(overContent);
 
       const result = await documentService.processDocumentFromPath('/path/to/over.txt');

--- a/__tests__/unit/services/llm.test.ts
+++ b/__tests__/unit/services/llm.test.ts
@@ -806,8 +806,8 @@ describe('LLMService', () => {
       await llmService.loadModel('/models/test.gguf');
 
       const usage = llmService.getEstimatedMemoryUsage();
-      // 2048 * 0.5 = 1024
-      expect(usage.contextMemoryMB).toBe(1024);
+      // 4096 * 0.5 = 2048
+      expect(usage.contextMemoryMB).toBe(2048);
     });
   });
 
@@ -877,8 +877,8 @@ describe('LLMService', () => {
       const usage = await llmService.estimateContextUsage(messages);
 
       expect(usage.tokenCount).toBe(500);
-      // 500 / 2048 * 100 ≈ 24.4%
-      expect(usage.percentUsed).toBeCloseTo(24.4, 0);
+      // 500 / 4096 * 100 ≈ 12.2%
+      expect(usage.percentUsed).toBeCloseTo(12.2, 0);
       expect(usage.willFit).toBe(true);
     });
   });
@@ -1822,8 +1822,8 @@ describe('LLMService', () => {
       expect(debugInfo.managedMessageCount).toBeGreaterThanOrEqual(3);
       expect(debugInfo.formattedPrompt).toContain('System');
       expect(debugInfo.estimatedTokens).toBe(100);
-      expect(debugInfo.maxContextLength).toBe(2048);
-      expect(debugInfo.contextUsagePercent).toBeCloseTo(4.88, 0);
+      expect(debugInfo.maxContextLength).toBe(4096);
+      expect(debugInfo.contextUsagePercent).toBeCloseTo(2.44, 0);
     });
 
     it('shows truncation info when messages are truncated', async () => {
@@ -2190,48 +2190,48 @@ describe('LLMService', () => {
   // Auto context scaling
   // ========================================================================
   describe('auto context scaling', () => {
-    it('scales context to model max when user is on default setting', async () => {
-      const [ctx1] = setupScalingTest({
-        modelContextLength: '4096',
-        userContextLength: 2048,
-        contextCount: 2,
+    it('loads at 4096 default context without a second init when model supports ≥4096', async () => {
+      setupScalingTest({
+        modelContextLength: '8192',
+        userContextLength: 4096, // default
       });
 
       await llmService.loadModel('/models/test.gguf');
 
-      // Should have been called twice: initial load + reload with model max
-      expect(initLlama).toHaveBeenCalledTimes(2);
-      expect(initLlama).toHaveBeenLastCalledWith(
+      // targetCtx = min(8192, 4096, deviceMax=4096) = 4096 = initial.actualLength → no second init
+      expect(initLlama).toHaveBeenCalledTimes(1);
+      expect(initLlama).toHaveBeenCalledWith(
         expect.objectContaining({ n_ctx: 4096 }),
       );
-      // First context should have been released
-      expect(ctx1.release).toHaveBeenCalled();
     });
 
     it('does not scale when user set a custom context length', async () => {
       setupScalingTest({
-        modelContextLength: '4096',
+        modelContextLength: '8192',
         userContextLength: 1024,
       });
 
       await llmService.loadModel('/models/test.gguf');
 
-      // Should only be called once — no reload
+      // userIsOnDefault = false → no scaling check
       expect(initLlama).toHaveBeenCalledTimes(1);
     });
 
-    it('caps auto-scaled context at 4096', async () => {
-      setupScalingTest({
-        modelContextLength: '131072',
-        userContextLength: 2048,
-        contextCount: 2,
+    it('scales up when user is on default and model supports larger ctx than default', async () => {
+      // This can only trigger if deviceMaxCtx > APP_CONFIG.maxContextLength
+      // (e.g. device with >8GB RAM where deviceMaxCtx = 8192)
+      // Simulate by setting userContextLength below deviceMaxCtx
+      const [ctx1] = setupScalingTest({
+        modelContextLength: '8192',
+        userContextLength: 2048, // below default — treated as custom (userIsOnDefault = false)
+        contextCount: 1,
       });
 
       await llmService.loadModel('/models/test.gguf');
 
-      expect(initLlama).toHaveBeenLastCalledWith(
-        expect.objectContaining({ n_ctx: 4096 }),
-      );
+      // userIsOnDefault = 2048 === 4096 = false → no scaling
+      expect(initLlama).toHaveBeenCalledTimes(1);
+      expect(ctx1.release).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/unit/services/llm.test.ts
+++ b/__tests__/unit/services/llm.test.ts
@@ -144,11 +144,11 @@ describe('LLMService', () => {
         .mockRejectedValueOnce(new Error('GPU error'))
         .mockResolvedValueOnce(ctx as any);
 
-      // Enable GPU in settings
+      // Enable GPU via Metal backend (iOS test environment)
       useAppStore.setState({
         settings: {
           ...useAppStore.getState().settings,
-          enableGpu: true,
+          inferenceBackend: 'metal' as const,
           gpuLayers: 6,
         },
       });
@@ -172,7 +172,7 @@ describe('LLMService', () => {
         settings: {
           ...useAppStore.getState().settings,
           contextLength: 4096,
-          enableGpu: true,
+          inferenceBackend: 'metal' as const,
         },
       });
 
@@ -339,7 +339,7 @@ describe('LLMService', () => {
       useAppStore.setState({
         settings: {
           ...useAppStore.getState().settings,
-          enableGpu: true,
+          inferenceBackend: 'metal' as const,
           gpuLayers: 99,
         },
       });
@@ -355,11 +355,11 @@ describe('LLMService', () => {
       mockedRNFS.exists.mockResolvedValue(true);
       mockedInitLlama.mockRejectedValue(new Error('fatal'));
 
-      // Disable GPU to skip retries
+      // CPU backend to skip GPU retries
       useAppStore.setState({
         settings: {
           ...useAppStore.getState().settings,
-          enableGpu: false,
+          inferenceBackend: 'cpu' as const,
         },
       });
 
@@ -830,7 +830,7 @@ describe('LLMService', () => {
       mockedInitLlama.mockResolvedValue(ctx as any);
 
       useAppStore.setState({
-        settings: { ...useAppStore.getState().settings, enableGpu: true, gpuLayers: 99 },
+        settings: { ...useAppStore.getState().settings, inferenceBackend: 'metal' as const, gpuLayers: 99 },
       });
 
       await llmService.loadModel('/models/test.gguf');
@@ -1133,9 +1133,9 @@ describe('LLMService', () => {
         .mockRejectedValueOnce(new Error('CPU reload failed')) // CPU fallback
         .mockRejectedValueOnce(new Error('CPU reload failed')); // ctx=2048 fallback
 
-      // Enable GPU so both attempts happen
+      // Enable GPU via Metal backend so both attempts happen
       useAppStore.setState({
-        settings: { ...useAppStore.getState().settings, enableGpu: true, gpuLayers: 6 },
+        settings: { ...useAppStore.getState().settings, inferenceBackend: 'metal' as const, gpuLayers: 6 },
       });
 
       await llmService.loadModel('/models/test.gguf');
@@ -1259,7 +1259,7 @@ describe('LLMService', () => {
   });
 
   describe('getGpuInfo Android branches', () => {
-    it('returns OpenCL when GPU enabled on Android with no devices', async () => {
+    it('returns OpenCL when OpenCL backend selected on Android with no devices', async () => {
       const originalOS = Platform.OS;
       Object.defineProperty(Platform, 'OS', { get: () => 'android' });
 
@@ -1268,7 +1268,7 @@ describe('LLMService', () => {
       mockedInitLlama.mockResolvedValue(ctx as any);
 
       useAppStore.setState({
-        settings: { ...useAppStore.getState().settings, enableGpu: true, gpuLayers: 6 },
+        settings: { ...useAppStore.getState().settings, inferenceBackend: 'opencl' as const, gpuLayers: 6 },
       });
 
       await llmService.loadModel('/models/test.gguf');
@@ -1280,7 +1280,7 @@ describe('LLMService', () => {
       Object.defineProperty(Platform, 'OS', { get: () => originalOS });
     });
 
-    it('returns device names when GPU enabled on Android with devices', async () => {
+    it('returns device names when OpenCL backend selected on Android with devices', async () => {
       const originalOS = Platform.OS;
       Object.defineProperty(Platform, 'OS', { get: () => 'android' });
 
@@ -1289,7 +1289,7 @@ describe('LLMService', () => {
       mockedInitLlama.mockResolvedValue(ctx as any);
 
       useAppStore.setState({
-        settings: { ...useAppStore.getState().settings, enableGpu: true, gpuLayers: 6 },
+        settings: { ...useAppStore.getState().settings, inferenceBackend: 'opencl' as const, gpuLayers: 6 },
       });
 
       await llmService.loadModel('/models/test.gguf');
@@ -1460,7 +1460,7 @@ describe('LLMService', () => {
         settings: {
           ...useAppStore.getState().settings,
           flashAttn: true,
-          enableGpu: false,
+          inferenceBackend: 'cpu' as const,
         },
       });
 
@@ -1490,7 +1490,7 @@ describe('LLMService', () => {
           ...useAppStore.getState().settings,
           flashAttn: false,
           cacheType: 'f16',
-          enableGpu: false,
+          inferenceBackend: 'cpu' as const,
         },
       });
 
@@ -1519,7 +1519,7 @@ describe('LLMService', () => {
         settings: {
           ...useAppStore.getState().settings,
           flashAttn: undefined as any,
-          enableGpu: false,
+          inferenceBackend: 'cpu' as const,
         },
       });
 
@@ -1548,7 +1548,7 @@ describe('LLMService', () => {
         .mockResolvedValueOnce(ctx2 as any); // CPU reload succeeds
 
       useAppStore.setState({
-        settings: { ...useAppStore.getState().settings, enableGpu: true, gpuLayers: 99 },
+        settings: { ...useAppStore.getState().settings, inferenceBackend: 'metal' as const, gpuLayers: 99 },
       });
 
       await llmService.loadModel('/models/test.gguf');
@@ -1874,7 +1874,7 @@ describe('LLMService', () => {
         .mockResolvedValueOnce(ctx2 as any);
 
       useAppStore.setState({
-        settings: { ...useAppStore.getState().settings, enableGpu: false },
+        settings: { ...useAppStore.getState().settings, inferenceBackend: 'cpu' as const },
       });
 
       await llmService.loadModel('/models/test.gguf');
@@ -1982,7 +1982,7 @@ describe('LLMService', () => {
       mockedInitLlama.mockRejectedValue(new Error('native crash'));
 
       useAppStore.setState({
-        settings: { ...useAppStore.getState().settings, enableGpu: false },
+        settings: { ...useAppStore.getState().settings, inferenceBackend: 'cpu' as const },
       });
 
       await expect(llmService.loadModel('/models/test.gguf'))
@@ -1994,7 +1994,7 @@ describe('LLMService', () => {
       mockedInitLlama.mockRejectedValue('string error');
 
       useAppStore.setState({
-        settings: { ...useAppStore.getState().settings, enableGpu: false },
+        settings: { ...useAppStore.getState().settings, inferenceBackend: 'cpu' as const },
       });
 
       await expect(llmService.loadModel('/models/test.gguf'))
@@ -2012,7 +2012,7 @@ describe('LLMService', () => {
       mockedInitLlama.mockResolvedValue(ctx as any);
 
       useAppStore.setState({
-        settings: { ...useAppStore.getState().settings, enableGpu: true, gpuLayers: 99 },
+        settings: { ...useAppStore.getState().settings, inferenceBackend: 'metal' as const, gpuLayers: 99 },
       });
 
       await llmService.loadModel('/models/test.gguf');
@@ -2459,7 +2459,7 @@ describe('LLMService', () => {
       (hardwareService as any).cachedSoCInfo = null;
     });
 
-    it('passes devices:HTP0 and 99 gpu_layers on Snapdragon with HTP', async () => {
+    it('passes devices:HTP0 and 99 gpu_layers when inferenceBackend is htp on Android', async () => {
       jest.spyOn(Platform, 'OS', 'get').mockReturnValue('android');
       jest.spyOn(hardwareService, 'getSoCInfo').mockResolvedValue({
         vendor: 'qualcomm', hasNPU: true, qnnVariant: '8gen3',
@@ -2468,6 +2468,10 @@ describe('LLMService', () => {
       const ctx = createMockLlamaContext();
       mockedInitLlama.mockResolvedValue(ctx as any);
 
+      useAppStore.setState({
+        settings: { ...useAppStore.getState().settings, inferenceBackend: 'htp' as const, gpuLayers: 99 },
+      });
+
       await llmService.loadModel('/models/test.gguf');
 
       expect(mockedInitLlama).toHaveBeenCalledWith(
@@ -2475,15 +2479,13 @@ describe('LLMService', () => {
       );
     });
 
-    it('does not use HTP on Android without NPU', async () => {
+    it('does not use HTP when inferenceBackend is cpu on Android', async () => {
       jest.spyOn(Platform, 'OS', 'get').mockReturnValue('android');
-      jest.spyOn(hardwareService, 'getSoCInfo').mockResolvedValue({
-        vendor: 'qualcomm', hasNPU: false, qnnVariant: undefined,
-      });
 
       const ctx = createMockLlamaContext();
       mockedInitLlama.mockResolvedValue(ctx as any);
 
+      // inferenceBackend defaults to 'cpu' from testHelpers resetStores
       await llmService.loadModel('/models/test.gguf');
 
       expect(mockedInitLlama).not.toHaveBeenCalledWith(

--- a/__tests__/unit/services/llm.test.ts
+++ b/__tests__/unit/services/llm.test.ts
@@ -272,7 +272,7 @@ describe('LLMService', () => {
 
       expect(initLlama).toHaveBeenCalledWith(
         expect.objectContaining({
-          flash_attn: true,
+          flash_attn_type: 'auto',
           cache_type_k: 'q8_0',
           cache_type_v: 'q8_0',
         })
@@ -296,7 +296,7 @@ describe('LLMService', () => {
 
       expect(initLlama).toHaveBeenCalledWith(
         expect.objectContaining({
-          flash_attn: false,
+          flash_attn_type: 'off',
           cache_type_k: 'f16',
           cache_type_v: 'f16',
         })
@@ -317,10 +317,10 @@ describe('LLMService', () => {
 
       await llmService.loadModel('/models/test.gguf');
 
-      // Test env is iOS (Platform.OS = 'ios'), so the ?? fallback evaluates to true
+      // Test env is iOS (Platform.OS = 'ios'), default is 'auto'
       expect(initLlama).toHaveBeenCalledWith(
         expect.objectContaining({
-          flash_attn: true,
+          flash_attn_type: 'auto',
           cache_type_k: 'q8_0',
           cache_type_v: 'q8_0',
         })
@@ -1259,6 +1259,17 @@ describe('LLMService', () => {
   });
 
   describe('getGpuInfo Android branches', () => {
+    const { hardwareService: hw } = require('../../../src/services/hardware');
+
+    beforeEach(() => {
+      (hw as any).cachedOpenCLCapability = null;
+      jest.spyOn(hw, 'getOpenCLCapability').mockResolvedValue({ supported: true });
+    });
+
+    afterEach(() => {
+      (hw as any).cachedOpenCLCapability = null;
+    });
+
     it('returns OpenCL when OpenCL backend selected on Android with no devices', async () => {
       const originalOS = Platform.OS;
       Object.defineProperty(Platform, 'OS', { get: () => 'android' });
@@ -1472,7 +1483,7 @@ describe('LLMService', () => {
       });
 
       const reloadCall = (initLlama as jest.Mock).mock.calls[1][0];
-      expect(reloadCall.flash_attn).toBe(true);
+      expect(reloadCall.flash_attn_type).toBe('auto');
       expect(reloadCall.cache_type_k).toBe('q8_0');
       expect(reloadCall.cache_type_v).toBe('q8_0');
     });
@@ -1502,7 +1513,7 @@ describe('LLMService', () => {
       });
 
       const reloadCall = (initLlama as jest.Mock).mock.calls[1][0];
-      expect(reloadCall.flash_attn).toBe(false);
+      expect(reloadCall.flash_attn_type).toBe('off');
       expect(reloadCall.cache_type_k).toBe('f16');
       expect(reloadCall.cache_type_v).toBe('f16');
     });
@@ -1530,9 +1541,9 @@ describe('LLMService', () => {
         contextLength: 2048,
       });
 
-      // Test env is iOS → ?? fallback evaluates to true
+      // Test env is iOS → flash_attn_type defaults to 'auto'
       const reloadCall = (initLlama as jest.Mock).mock.calls[1][0];
-      expect(reloadCall.flash_attn).toBe(true);
+      expect(reloadCall.flash_attn_type).toBe('auto');
       expect(reloadCall.cache_type_k).toBe('q8_0');
     });
   });

--- a/__tests__/unit/services/llm.test.ts
+++ b/__tests__/unit/services/llm.test.ts
@@ -2442,4 +2442,66 @@ describe('LLMService', () => {
       expect((llmService as any).activeCompletionPromise).toBeNull();
     });
   });
+
+  // ========================================================================
+  // Hexagon HTP (NPU) acceleration
+  // ========================================================================
+  describe('HTP NPU acceleration', () => {
+    const { hardwareService } = require('../../../src/services/hardware');
+
+    beforeEach(() => {
+      mockedRNFS.exists.mockResolvedValue(true);
+      // Clear SoC cache between tests
+      (hardwareService as any).cachedSoCInfo = null;
+    });
+
+    afterEach(() => {
+      (hardwareService as any).cachedSoCInfo = null;
+    });
+
+    it('passes devices:HTP0 and 99 gpu_layers on Snapdragon with HTP', async () => {
+      jest.spyOn(Platform, 'OS', 'get').mockReturnValue('android');
+      jest.spyOn(hardwareService, 'getSoCInfo').mockResolvedValue({
+        vendor: 'qualcomm', hasNPU: true, qnnVariant: '8gen3',
+      });
+
+      const ctx = createMockLlamaContext();
+      mockedInitLlama.mockResolvedValue(ctx as any);
+
+      await llmService.loadModel('/models/test.gguf');
+
+      expect(mockedInitLlama).toHaveBeenCalledWith(
+        expect.objectContaining({ devices: ['HTP0'], n_gpu_layers: 99 }),
+      );
+    });
+
+    it('does not use HTP on Android without NPU', async () => {
+      jest.spyOn(Platform, 'OS', 'get').mockReturnValue('android');
+      jest.spyOn(hardwareService, 'getSoCInfo').mockResolvedValue({
+        vendor: 'qualcomm', hasNPU: false, qnnVariant: undefined,
+      });
+
+      const ctx = createMockLlamaContext();
+      mockedInitLlama.mockResolvedValue(ctx as any);
+
+      await llmService.loadModel('/models/test.gguf');
+
+      expect(mockedInitLlama).not.toHaveBeenCalledWith(
+        expect.objectContaining({ devices: expect.anything() }),
+      );
+    });
+
+    it('does not use HTP on iOS', async () => {
+      jest.spyOn(Platform, 'OS', 'get').mockReturnValue('ios');
+
+      const ctx = createMockLlamaContext();
+      mockedInitLlama.mockResolvedValue(ctx as any);
+
+      await llmService.loadModel('/models/test.gguf');
+
+      expect(mockedInitLlama).not.toHaveBeenCalledWith(
+        expect.objectContaining({ devices: expect.anything() }),
+      );
+    });
+  });
 });

--- a/__tests__/unit/services/llmHelpers.test.ts
+++ b/__tests__/unit/services/llmHelpers.test.ts
@@ -397,7 +397,7 @@ describe('buildCompletionParams', () => {
   });
 });
 
-describe('initContextWithFallback — HTP device stripping', () => {
+describe('initContextWithFallback — HTP device stripping and timeout', () => {
   const { initLlama } = require('llama.rn');
   const mockedInitLlama = initLlama as jest.MockedFunction<typeof initLlama>;
 
@@ -438,5 +438,17 @@ describe('initContextWithFallback — HTP device stripping', () => {
     expect(minCtxCall.devices).toBeUndefined();
     expect(minCtxCall.n_gpu_layers).toBe(0);
     expect(minCtxCall.n_ctx).toBe(2048);
+  });
+
+  it('logs backend=HTP when devices contains HTP0', async () => {
+    const mockCtx = { gpu: true, release: jest.fn() };
+    mockedInitLlama.mockResolvedValueOnce(mockCtx as any);
+    const logger = require('../../../src/utils/logger').default;
+
+    await initContextWithFallback(baseParams, 2048, 99);
+
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('backend=HTP'),
+    );
   });
 });

--- a/__tests__/unit/services/llmHelpers.test.ts
+++ b/__tests__/unit/services/llmHelpers.test.ts
@@ -12,6 +12,7 @@ import {
   shouldDisableMmap,
   captureGpuInfo,
   logContextMetadata,
+  initContextWithFallback,
 } from '../../../src/services/llmHelpers';
 import { Platform } from 'react-native';
 
@@ -393,5 +394,49 @@ describe('buildCompletionParams', () => {
     expect(params.top_p).toBe(0.95);
     expect(params.penalty_repeat).toBe(1.1);
     expect(params.stop).toBeDefined();
+  });
+});
+
+describe('initContextWithFallback — HTP device stripping', () => {
+  const { initLlama } = require('llama.rn');
+  const mockedInitLlama = initLlama as jest.MockedFunction<typeof initLlama>;
+
+  const baseParams = { model: '/model.gguf', devices: ['HTP0'] };
+
+  it('passes devices to initLlama on the first (GPU/HTP) attempt', async () => {
+    const mockCtx = { gpu: true, release: jest.fn() };
+    mockedInitLlama.mockResolvedValueOnce(mockCtx as any);
+
+    await initContextWithFallback(baseParams, 2048, 99);
+
+    expect(mockedInitLlama).toHaveBeenCalledWith(
+      expect.objectContaining({ devices: ['HTP0'], n_gpu_layers: 99 }),
+    );
+  });
+
+  it('strips devices from params on CPU fallback (attempt 2)', async () => {
+    mockedInitLlama.mockRejectedValueOnce(new Error('HTP init failed'));
+    const mockCtx = { gpu: false, release: jest.fn() };
+    mockedInitLlama.mockResolvedValueOnce(mockCtx as any);
+
+    await initContextWithFallback(baseParams, 2048, 99);
+
+    const cpuCall = mockedInitLlama.mock.calls[1][0] as Record<string, unknown>;
+    expect(cpuCall.devices).toBeUndefined();
+    expect(cpuCall.n_gpu_layers).toBe(0);
+  });
+
+  it('strips devices from params on minimal CPU fallback (attempt 3)', async () => {
+    mockedInitLlama.mockRejectedValueOnce(new Error('HTP init failed'));
+    mockedInitLlama.mockRejectedValueOnce(new Error('CPU init failed'));
+    const mockCtx = { gpu: false, release: jest.fn() };
+    mockedInitLlama.mockResolvedValueOnce(mockCtx as any);
+
+    await initContextWithFallback(baseParams, 8192, 99);
+
+    const minCtxCall = mockedInitLlama.mock.calls[2][0] as Record<string, unknown>;
+    expect(minCtxCall.devices).toBeUndefined();
+    expect(minCtxCall.n_gpu_layers).toBe(0);
+    expect(minCtxCall.n_ctx).toBe(2048);
   });
 });

--- a/__tests__/unit/services/llmHelpers.test.ts
+++ b/__tests__/unit/services/llmHelpers.test.ts
@@ -304,7 +304,7 @@ describe('buildModelParams', () => {
 
   it('uses flashAttn=false settings', () => {
     const params = buildModelParams('/model.gguf', { flashAttn: false });
-    expect((params.baseParams as any).flash_attn).toBe(false);
+    expect((params.baseParams as any).flash_attn_type).toBe('off');
   });
 
   it('uses provided cacheType', () => {

--- a/__tests__/unit/services/tools/registry.test.ts
+++ b/__tests__/unit/services/tools/registry.test.ts
@@ -60,13 +60,13 @@ describe('Tool Registry', () => {
         type: 'function',
         function: {
           name: 'calculator',
-          description: 'Evaluate mathematical expressions',
+          description: 'Evaluate math expressions',
           parameters: {
             type: 'object',
             properties: {
               expression: {
                 type: 'string',
-                description: 'The mathematical expression to evaluate',
+                description: 'Math expression',
               },
             },
             required: ['expression'],
@@ -131,30 +131,30 @@ describe('Tool Registry', () => {
     it('includes tool names and descriptions for enabled tools', () => {
       const hint = buildToolSystemPromptHint(['calculator', 'web_search']);
 
-      expect(hint).toContain('- calculator: Evaluate mathematical expressions');
-      expect(hint).toContain('- web_search: Search the web for current information');
-      expect(hint).toContain('You have access to the following tools');
+      expect(hint).toContain('- calculator: Evaluate math expressions');
+      expect(hint).toContain('- web_search: Search the web');
+      expect(hint).toContain('Tools available');
     });
 
     it('only includes enabled tools, not all tools', () => {
       const hint = buildToolSystemPromptHint(['calculator']);
 
-      expect(hint).toContain('calculator: Evaluate mathematical expressions');
+      expect(hint).toContain('calculator: Evaluate math expressions');
       expect(hint).not.toContain('web_search');
       expect(hint).not.toContain('get_current_datetime');
       expect(hint).not.toContain('get_device_info');
     });
 
-    it('includes read_url usage hint when read_url is enabled', () => {
+    it('includes read_url when read_url is enabled', () => {
       const hint = buildToolSystemPromptHint(['read_url']);
       expect(hint).toContain('read_url');
-      expect(hint).toContain('URL');
+      expect(hint).toContain('web page');
     });
 
-    it('includes get_current_datetime usage hint when enabled', () => {
+    it('includes get_current_datetime when enabled', () => {
       const hint = buildToolSystemPromptHint(['get_current_datetime']);
       expect(hint).toContain('get_current_datetime');
-      expect(hint).toContain('time or date');
+      expect(hint).toContain('date and time');
     });
   });
 });

--- a/__tests__/unit/stores/appStore.test.ts
+++ b/__tests__/unit/stores/appStore.test.ts
@@ -314,7 +314,7 @@ describe('appStore', () => {
       expect(settings.temperature).toBe(0.7);
       expect(settings.maxTokens).toBe(1024);
       expect(settings.topP).toBe(0.9);
-      expect(settings.contextLength).toBe(2048);
+      expect(settings.contextLength).toBe(4096);
       expect(settings.imageGenerationMode).toBe('auto');
       // Test env is iOS, so GPU is enabled by default
       expect(settings.enableGpu).toBe(true);

--- a/__tests__/unit/stores/appStore.test.ts
+++ b/__tests__/unit/stores/appStore.test.ts
@@ -1242,7 +1242,7 @@ describe('appStore', () => {
     });
 
     it('has correct default nThreads', () => {
-      expect(getAppState().settings.nThreads).toBe(4);
+      expect(getAppState().settings.nThreads).toBe(0);
     });
 
     it('has correct default nBatch', () => {

--- a/__tests__/utils/testHelpers.ts
+++ b/__tests__/utils/testHelpers.ts
@@ -52,7 +52,7 @@ export const resetStores = (): void => {
       topP: 0.9,
       repeatPenalty: 1.1,
       contextLength: 4096,
-      nThreads: 4,
+      nThreads: 0,
       nBatch: 512,
       imageGenerationMode: 'auto',
       autoDetectMethod: 'pattern',

--- a/__tests__/utils/testHelpers.ts
+++ b/__tests__/utils/testHelpers.ts
@@ -51,7 +51,7 @@ export const resetStores = (): void => {
       maxTokens: 1024,
       topP: 0.9,
       repeatPenalty: 1.1,
-      contextLength: 2048,
+      contextLength: 4096,
       nThreads: 4,
       nBatch: 512,
       imageGenerationMode: 'auto',

--- a/__tests__/utils/testHelpers.ts
+++ b/__tests__/utils/testHelpers.ts
@@ -65,6 +65,7 @@ export const resetStores = (): void => {
       imageUseOpenCL: true,
       modelLoadingStrategy: 'performance',
       enableGpu: true,
+      inferenceBackend: 'cpu' as const,
       gpuLayers: 99,
       flashAttn: false,
       cacheType: 'q8_0',

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize"
+        android:windowSoftInputMode="adjustNothing"
         android:theme="@style/SplashTheme"
         android:exported="true">
         <intent-filter>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustNothing"
+        android:windowSoftInputMode="adjustResize"
         android:theme="@style/SplashTheme"
         android:exported="true">
         <intent-filter>

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -45,6 +45,11 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
         internal const val STUCK_THRESHOLD = 3             // 3 × 15s = 45 seconds of zero progress after first byte
         internal const val STARTUP_TIMEOUT_POLLS = 8       // 8 × 15s = 2 minutes waiting for first byte before giving up
         internal const val MAX_RETRY_ATTEMPTS = 3          // give up after 3 retries
+        // How many watchdog cycles a download can stay in PAUSED_WAITING_TO_RETRY before we
+        // force-cancel and re-enqueue with a freshly resolved URL. Signed CDN URLs (e.g.
+        // cas-bridge.xethub.hf.co) can expire quickly; DownloadManager would retry forever
+        // with the same stale URL, so we intervene after PAUSED_RETRY_THRESHOLD × 15s = 30s.
+        internal const val PAUSED_RETRY_THRESHOLD = 2
 
         internal const val STATUS_PENDING = "pending"
         internal const val STATUS_RUNNING = "running"
@@ -209,6 +214,9 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     // --- Stuck-download watchdog ---
     private val watchdogHandler = Handler(Looper.getMainLooper())
     private val downloadBytesTracker = mutableMapOf<Long, BytesTrack>()
+    // Counts how many consecutive watchdog cycles a download has been in PAUSED_WAITING_TO_RETRY.
+    // Reset to 0 whenever the download leaves that state (running, queued, completed, etc.).
+    private val pausedRetryTracker = mutableMapOf<Long, Int>()
 
     private val watchdogRunnable = object : Runnable {
         override fun run() {
@@ -358,7 +366,10 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
 
             downloadManager.remove(id)
             removeDownload(id)
-            handler.post { downloadBytesTracker.remove(id) }
+            handler.post {
+                downloadBytesTracker.remove(id)
+                pausedRetryTracker.remove(id)
+            }
 
             // Clean up partial file
             downloadInfo?.optString("fileName")?.let { fileName ->
@@ -626,7 +637,37 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
             android.util.Log.d("DownloadService", "Download status: ${status.uppercase()} - reason: $reason - id: $downloadId")
 
             if (status != STATUS_RUNNING) {
+                val currentRetryCount = downloadBytesTracker[downloadId]?.retryCount ?: 0
                 downloadBytesTracker.remove(downloadId)
+
+                // When DownloadManager enters PAUSED_WAITING_TO_RETRY it retries internally
+                // using the same (possibly expired) pre-signed CDN URL. For XET bridge URLs
+                // (cas-bridge.xethub.hf.co) this causes an infinite pause loop that only
+                // terminates with ERROR_FILE_ERROR. After PAUSED_RETRY_THRESHOLD watchdog
+                // cycles we cancel and re-enqueue with a freshly resolved URL.
+                if (status == STATUS_PAUSED && reason == "Waiting to retry") {
+                    val pausedCount = (pausedRetryTracker[downloadId] ?: 0) + 1
+                    pausedRetryTracker[downloadId] = pausedCount
+                    val elapsedSeconds = pausedCount * WATCHDOG_INTERVAL_MS / 1000
+                    android.util.Log.d("DownloadService", "Download $downloadId paused-waiting-to-retry for ${elapsedSeconds}s (cycle $pausedCount/$PAUSED_RETRY_THRESHOLD)")
+                    if (pausedCount >= PAUSED_RETRY_THRESHOLD) {
+                        pausedRetryTracker.remove(downloadId)
+                        if (currentRetryCount >= MAX_RETRY_ATTEMPTS) {
+                            android.util.Log.e("DownloadService", "Download $downloadId gave up after $currentRetryCount retries (paused-waiting-to-retry)")
+                            sendEvent("DownloadError", buildEventParams(downloadId, download, queryDownloadStatus(downloadId), STATUS_FAILED).also {
+                                it.putString("reason", "Download stuck after $currentRetryCount retries")
+                            })
+                            downloadManager.remove(downloadId)
+                            removeDownload(downloadId)
+                            stopForegroundServiceIfIdle("failed")
+                            return
+                        }
+                        android.util.Log.w("DownloadService", "Download $downloadId stuck in paused-waiting-to-retry — forcing fresh URL resolution (attempt ${currentRetryCount + 1}/$MAX_RETRY_ATTEMPTS)")
+                        handleStuckDownload(downloadId, 0L, download, currentRetryCount + 1)
+                    }
+                } else {
+                    pausedRetryTracker.remove(downloadId)
+                }
                 continue
             }
 
@@ -863,6 +904,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
             android.util.Log.d("DownloadService", "No info for unknown download $downloadId, removing stale entry")
             removeDownload(downloadId)
             downloadBytesTracker.remove(downloadId)
+            pausedRetryTracker.remove(downloadId)
             stopForegroundServiceIfIdle("unknown")
             return
         }
@@ -878,6 +920,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
             android.util.Log.d("DownloadService", "No file found for unknown download $downloadId, removing stale entry")
             removeDownload(downloadId)
             downloadBytesTracker.remove(downloadId)
+            pausedRetryTracker.remove(downloadId)
         }
         stopForegroundServiceIfIdle("completed")
     }
@@ -901,6 +944,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
                     sendEvent("DownloadError", eventParams)
                     removeDownload(downloadId)
                     downloadBytesTracker.remove(downloadId)
+                    pausedRetryTracker.remove(downloadId)
                     stopForegroundServiceIfIdle("failed")
                 }
                 STATUS_PAUSED -> {

--- a/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
+++ b/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
@@ -216,20 +216,4 @@ class DownloadManagerModuleTest {
         }
     }
 
-    // ── PAUSED_RETRY_THRESHOLD ────────────────────────────────────────────────
-    // Signed CDN URLs (e.g. cas-bridge.xethub.hf.co) can expire quickly, causing
-    // DownloadManager to loop in PAUSED_WAITING_TO_RETRY with the same stale URL.
-    // After PAUSED_RETRY_THRESHOLD watchdog cycles we force-cancel and re-enqueue
-    // with a freshly resolved URL.
-
-    @Test
-    fun `PAUSED_RETRY_THRESHOLD is 2 polls`() {
-        assertEquals(2, DownloadManagerModule.PAUSED_RETRY_THRESHOLD)
-    }
-
-    @Test
-    fun `paused retry intervention window is 30 seconds (2 x 15s)`() {
-        val windowMs = DownloadManagerModule.PAUSED_RETRY_THRESHOLD * DownloadManagerModule.WATCHDOG_INTERVAL_MS
-        assertEquals(30_000L, windowMs)
-    }
 }

--- a/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
+++ b/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
@@ -565,4 +565,21 @@ class DownloadManagerModuleTest {
     fun `backoff for retry 3 is 90 seconds`() {
         assertEquals(90_000L, 3 * 30_000L)
     }
+
+    // ── PAUSED_RETRY_THRESHOLD ────────────────────────────────────────────────
+    // Signed CDN URLs (e.g. cas-bridge.xethub.hf.co) can expire quickly, causing
+    // DownloadManager to loop in PAUSED_WAITING_TO_RETRY with the same stale URL.
+    // After PAUSED_RETRY_THRESHOLD watchdog cycles we force-cancel and re-enqueue
+    // with a freshly resolved URL.
+
+    @Test
+    fun `PAUSED_RETRY_THRESHOLD is 2 polls`() {
+        assertEquals(2, DownloadManagerModule.PAUSED_RETRY_THRESHOLD)
+    }
+
+    @Test
+    fun `paused retry intervention window is 30 seconds (2 x 15s)`() {
+        val windowMs = DownloadManagerModule.PAUSED_RETRY_THRESHOLD * DownloadManagerModule.WATCHDOG_INTERVAL_MS
+        assertEquals(30_000L, windowMs)
+    }
 }

--- a/scripts/run-sonar.sh
+++ b/scripts/run-sonar.sh
@@ -13,14 +13,24 @@ if [[ -z "${SONAR_TOKEN:-}" ]]; then
   exit 0
 fi
 
-if [[ -x "./node_modules/.bin/sonar-scanner" ]]; then
-  exec ./node_modules/.bin/sonar-scanner "$@"
-fi
+run_sonar() {
+  if [[ -x "./node_modules/.bin/sonar-scanner" ]]; then
+    ./node_modules/.bin/sonar-scanner "$@"
+  elif command -v sonar-scanner >/dev/null 2>&1; then
+    sonar-scanner "$@"
+  else
+    echo "sonar-scanner is not installed. Skipping Sonar scan."
+    echo "Install it with: npm install --save-dev sonar-scanner"
+    return 0
+  fi
+}
 
-if command -v sonar-scanner >/dev/null 2>&1; then
-  exec sonar-scanner "$@"
+if ! output=$(run_sonar "$@" 2>&1); then
+  if echo "$output" | grep -q "running manual analysis while Automatic Analysis is enabled"; then
+    echo "SonarCloud automatic analysis is enabled — skipping local scan (runs automatically on push)."
+    exit 0
+  fi
+  echo "$output" >&2
+  exit 1
 fi
-
-echo "sonar-scanner is not installed. Skipping Sonar scan."
-echo "Install it with: npm install --save-dev sonar-scanner"
-exit 0
+echo "$output"

--- a/src/components/GenerationSettingsModal/TextGenerationAdvanced.tsx
+++ b/src/components/GenerationSettingsModal/TextGenerationAdvanced.tsx
@@ -149,12 +149,7 @@ export const KvCacheTypeToggle: React.FC = () => {
           </TouchableOpacity>
         ))}
       </View>
-      {cacheDisabled && (
-        <Text style={styles.settingWarning}>
-          GPU acceleration on Android requires f16 KV cache.
-        </Text>
-      )}
-      {!cacheDisabled && !isFlashAttnOn && (
+      {!isFlashAttnOn && (
         <Text style={styles.settingWarning}>
           Quantized cache (q8_0/q4_0) will auto-enable flash attention.
         </Text>

--- a/src/components/GenerationSettingsModal/TextGenerationAdvanced.tsx
+++ b/src/components/GenerationSettingsModal/TextGenerationAdvanced.tsx
@@ -3,7 +3,7 @@ import { Platform, View, Text, TouchableOpacity } from 'react-native';
 import Slider from '@react-native-community/slider';
 import { useTheme, useThemedStyles } from '../../theme';
 import { useAppStore } from '../../stores';
-import { CacheType, InferenceBackend } from '../../types';
+import { CacheType, InferenceBackend, INFERENCE_BACKENDS } from '../../types';
 import {
   useTextGenerationAdvanced,
   CACHE_TYPE_DESCRIPTIONS,
@@ -20,17 +20,17 @@ const isAndroid = Platform.OS === 'android';
 type BackendOption = { id: InferenceBackend; label: string; desc: string };
 
 const IOS_BACKENDS: BackendOption[] = [
-  { id: 'cpu', label: 'CPU', desc: 'Always available. Stable, predictable performance.' },
-  { id: 'metal', label: 'Metal', desc: 'Offload layers to GPU via Metal. Faster for larger models. Requires model reload.' },
+  { id: INFERENCE_BACKENDS.CPU, label: 'CPU', desc: 'Always available. Stable, predictable performance.' },
+  { id: INFERENCE_BACKENDS.METAL, label: 'Metal', desc: 'Offload layers to GPU via Metal. Faster for larger models. Requires model reload.' },
 ];
 
 const ANDROID_BASE_BACKENDS: BackendOption[] = [
-  { id: 'cpu', label: 'CPU', desc: 'Always available. Stable, predictable performance.' },
-  { id: 'opencl', label: 'OpenCL', desc: 'Offload layers to GPU via OpenCL. Fast decode on Adreno/Mali GPUs. Requires model reload.' },
+  { id: INFERENCE_BACKENDS.CPU, label: 'CPU', desc: 'Always available. Stable, predictable performance.' },
+  { id: INFERENCE_BACKENDS.OPENCL, label: 'OpenCL', desc: 'Offload layers to GPU via OpenCL. Fast decode on Adreno/Mali GPUs. Requires model reload.' },
 ];
 
 const HTP_BACKEND: BackendOption = {
-  id: 'htp', label: 'HTP', desc: 'Offload layers to Hexagon NPU on Snapdragon devices. Best for large models. Requires model reload.',
+  id: INFERENCE_BACKENDS.HTP, label: 'HTP', desc: 'Offload layers to Hexagon NPU on Snapdragon devices. Best for large models. Requires model reload.',
 };
 
 export const BackendSelector: React.FC = () => {
@@ -50,9 +50,10 @@ export const BackendSelector: React.FC = () => {
     ? IOS_BACKENDS
     : hasNPU ? [...ANDROID_BASE_BACKENDS, HTP_BACKEND] : ANDROID_BASE_BACKENDS;
 
-  const current = settings.inferenceBackend ?? (Platform.OS === 'ios' ? 'metal' : 'cpu');
-  const showLayers = current !== 'cpu';
-  const layersLabel = current === 'htp' ? 'NPU Layers' : current === 'metal' ? 'GPU Layers (Metal)' : 'GPU Layers (OpenCL)';
+  const defaultBackend = Platform.OS === 'ios' ? INFERENCE_BACKENDS.METAL : INFERENCE_BACKENDS.CPU;
+  const current = settings.inferenceBackend ?? defaultBackend;
+  const showLayers = current !== INFERENCE_BACKENDS.CPU;
+  const layersLabel = current === INFERENCE_BACKENDS.HTP ? 'NPU Layers' : current === INFERENCE_BACKENDS.METAL ? 'GPU Layers (Metal)' : 'GPU Layers (OpenCL)';
 
   return (
     <View style={styles.modeToggleContainer}>

--- a/src/components/GenerationSettingsModal/TextGenerationAdvanced.tsx
+++ b/src/components/GenerationSettingsModal/TextGenerationAdvanced.tsx
@@ -1,70 +1,88 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Platform, View, Text, TouchableOpacity } from 'react-native';
 import Slider from '@react-native-community/slider';
 import { useTheme, useThemedStyles } from '../../theme';
 import { useAppStore } from '../../stores';
-import { CacheType } from '../../types';
+import { CacheType, InferenceBackend } from '../../types';
 import {
   useTextGenerationAdvanced,
   CACHE_TYPE_DESCRIPTIONS,
   GPU_LAYERS_MAX,
   CACHE_TYPE_OPTIONS,
 } from '../../hooks/useTextGenerationAdvanced';
+import { hardwareService } from '../../services/hardware';
 import { createStyles } from './styles';
 
 const isAndroid = Platform.OS === 'android';
 
-// ─── GPU / NPU Acceleration ───────────────────────────────────────────────────
+// ─── Inference Backend ────────────────────────────────────────────────────────
 
-export const GpuAccelerationToggle: React.FC = () => {
+type BackendOption = { id: InferenceBackend; label: string; desc: string };
+
+const IOS_BACKENDS: BackendOption[] = [
+  { id: 'cpu', label: 'CPU', desc: 'Always available. Stable, predictable performance.' },
+  { id: 'metal', label: 'Metal', desc: 'Offload layers to GPU via Metal. Faster for larger models. Requires model reload.' },
+];
+
+const ANDROID_BASE_BACKENDS: BackendOption[] = [
+  { id: 'cpu', label: 'CPU', desc: 'Always available. Stable, predictable performance.' },
+  { id: 'opencl', label: 'OpenCL', desc: 'Offload layers to GPU via OpenCL. Fast decode on Adreno/Mali GPUs. Requires model reload.' },
+];
+
+const HTP_BACKEND: BackendOption = {
+  id: 'htp', label: 'HTP', desc: 'Offload layers to Hexagon NPU on Snapdragon devices. Best for large models. Requires model reload.',
+};
+
+export const BackendSelector: React.FC = () => {
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
   const { settings, updateSettings } = useAppStore();
-  const { gpuLayersEffective, handleGpuToggle } = useTextGenerationAdvanced();
+  const { gpuLayersEffective } = useTextGenerationAdvanced();
+  const [hasNPU, setHasNPU] = useState(false);
 
-  const accelLabel = isAndroid ? 'NPU Acceleration' : 'GPU Acceleration';
-  const accelDesc = isAndroid
-    ? 'Offload inference to the Hexagon NPU on Snapdragon devices. Faster than CPU. Requires model reload.'
-    : 'Offload inference to GPU using Metal. Faster for large models. Requires model reload.';
-  const layersLabel = isAndroid ? 'NPU Layers' : 'GPU Layers';
-  const layersDesc = isAndroid
-    ? 'Layers offloaded to NPU. Higher = faster. Requires model reload.'
-    : 'Layers offloaded to GPU. Higher = faster but may crash on low-VRAM devices. Requires model reload.';
+  useEffect(() => {
+    if (isAndroid) {
+      hardwareService.getSoCInfo().then(info => setHasNPU(info.hasNPU));
+    }
+  }, []);
+
+  const backends: BackendOption[] = Platform.OS === 'ios'
+    ? IOS_BACKENDS
+    : hasNPU ? [...ANDROID_BASE_BACKENDS, HTP_BACKEND] : ANDROID_BASE_BACKENDS;
+
+  const current = settings.inferenceBackend ?? (Platform.OS === 'ios' ? 'metal' : 'cpu');
+  const showLayers = current !== 'cpu';
+  const layersLabel = current === 'htp' ? 'NPU Layers' : current === 'metal' ? 'GPU Layers (Metal)' : 'GPU Layers (OpenCL)';
 
   return (
     <View style={styles.modeToggleContainer}>
       <View style={styles.modeToggleInfo}>
-        <Text style={styles.modeToggleLabel}>{accelLabel}</Text>
-        <Text style={styles.modeToggleDesc}>{accelDesc}</Text>
+        <Text style={styles.modeToggleLabel}>Inference Backend</Text>
+        <Text style={styles.modeToggleDesc}>
+          {backends.find(b => b.id === current)?.desc ?? ''}
+        </Text>
       </View>
       <View style={styles.modeToggleButtons}>
-        <TouchableOpacity
-          testID="gpu-off-button"
-          style={[styles.modeButton, !settings.enableGpu && styles.modeButtonActive]}
-          onPress={() => handleGpuToggle(false)}
-        >
-          <Text style={[styles.modeButtonText, !settings.enableGpu && styles.modeButtonTextActive]}>
-            Off
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          testID="gpu-on-button"
-          style={[styles.modeButton, settings.enableGpu && styles.modeButtonActive]}
-          onPress={() => handleGpuToggle(true)}
-        >
-          <Text style={[styles.modeButtonText, settings.enableGpu && styles.modeButtonTextActive]}>
-            On
-          </Text>
-        </TouchableOpacity>
+        {backends.map(b => (
+          <TouchableOpacity
+            key={b.id}
+            testID={`backend-${b.id}-button`}
+            style={[styles.modeButton, current === b.id && styles.modeButtonActive]}
+            onPress={() => updateSettings({ inferenceBackend: b.id })}
+          >
+            <Text style={[styles.modeButtonText, current === b.id && styles.modeButtonTextActive]}>
+              {b.label}
+            </Text>
+          </TouchableOpacity>
+        ))}
       </View>
 
-      {settings.enableGpu && (
+      {showLayers && (
         <View style={styles.gpuLayersInline}>
           <View style={styles.settingHeader}>
             <Text style={styles.settingLabel}>{layersLabel}</Text>
             <Text style={styles.settingValue}>{gpuLayersEffective}</Text>
           </View>
-          <Text style={styles.settingDescription}>{layersDesc}</Text>
           <Slider
             testID="gpu-layers-slider"
             style={styles.slider}

--- a/src/components/GenerationSettingsModal/TextGenerationAdvanced.tsx
+++ b/src/components/GenerationSettingsModal/TextGenerationAdvanced.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { Platform, View, Text, TouchableOpacity } from 'react-native';
 import Slider from '@react-native-community/slider';
 import { useTheme, useThemedStyles } from '../../theme';
 import { useAppStore } from '../../stores';
@@ -12,7 +12,9 @@ import {
 } from '../../hooks/useTextGenerationAdvanced';
 import { createStyles } from './styles';
 
-// ─── GPU Acceleration ─────────────────────────────────────────────────────────
+const isAndroid = Platform.OS === 'android';
+
+// ─── GPU / NPU Acceleration ───────────────────────────────────────────────────
 
 export const GpuAccelerationToggle: React.FC = () => {
   const { colors } = useTheme();
@@ -20,13 +22,20 @@ export const GpuAccelerationToggle: React.FC = () => {
   const { settings, updateSettings } = useAppStore();
   const { gpuLayersEffective, handleGpuToggle } = useTextGenerationAdvanced();
 
+  const accelLabel = isAndroid ? 'NPU Acceleration' : 'GPU Acceleration';
+  const accelDesc = isAndroid
+    ? 'Offload inference to the Hexagon NPU on Snapdragon devices. Faster than CPU. Requires model reload.'
+    : 'Offload inference to GPU using Metal. Faster for large models. Requires model reload.';
+  const layersLabel = isAndroid ? 'NPU Layers' : 'GPU Layers';
+  const layersDesc = isAndroid
+    ? 'Layers offloaded to NPU. Higher = faster. Requires model reload.'
+    : 'Layers offloaded to GPU. Higher = faster but may crash on low-VRAM devices. Requires model reload.';
+
   return (
     <View style={styles.modeToggleContainer}>
       <View style={styles.modeToggleInfo}>
-        <Text style={styles.modeToggleLabel}>GPU Acceleration</Text>
-        <Text style={styles.modeToggleDesc}>
-          Offload inference to GPU when available. Faster for large models, may add overhead for small ones. Requires model reload.
-        </Text>
+        <Text style={styles.modeToggleLabel}>{accelLabel}</Text>
+        <Text style={styles.modeToggleDesc}>{accelDesc}</Text>
       </View>
       <View style={styles.modeToggleButtons}>
         <TouchableOpacity
@@ -52,12 +61,10 @@ export const GpuAccelerationToggle: React.FC = () => {
       {settings.enableGpu && (
         <View style={styles.gpuLayersInline}>
           <View style={styles.settingHeader}>
-            <Text style={styles.settingLabel}>GPU Layers</Text>
+            <Text style={styles.settingLabel}>{layersLabel}</Text>
             <Text style={styles.settingValue}>{gpuLayersEffective}</Text>
           </View>
-          <Text style={styles.settingDescription}>
-            Layers offloaded to GPU. Higher = faster but may crash on low-VRAM devices. Requires model reload.
-          </Text>
+          <Text style={styles.settingDescription}>{layersDesc}</Text>
           <Slider
             testID="gpu-layers-slider"
             style={styles.slider}

--- a/src/components/GenerationSettingsModal/TextGenerationSection.tsx
+++ b/src/components/GenerationSettingsModal/TextGenerationSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, Platform } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import Slider from '@react-native-community/slider';
 import { AdvancedToggle } from '../AdvancedToggle';
 import { useTheme, useThemedStyles } from '../../theme';
@@ -8,7 +8,7 @@ import { createStyles } from './styles';
 import {
   CpuThreadsSlider,
   BatchSizeSlider,
-  GpuAccelerationToggle,
+  BackendSelector,
   FlashAttentionToggle,
   KvCacheTypeToggle,
   ModelLoadingStrategyToggle,
@@ -196,7 +196,7 @@ export const TextGenerationSection: React.FC = () => {
           ))}
           <CpuThreadsSlider />
           <BatchSizeSlider />
-          {Platform.OS !== 'ios' && <GpuAccelerationToggle />}
+          <BackendSelector />
           <FlashAttentionToggle />
           <KvCacheTypeToggle />
           <ModelLoadingStrategyToggle />

--- a/src/components/GenerationSettingsModal/TextGenerationSection.tsx
+++ b/src/components/GenerationSettingsModal/TextGenerationSection.tsx
@@ -30,7 +30,7 @@ const DEFAULT_SETTINGS: Record<string, number> = {
   maxTokens: 1024,
   topP: 0.9,
   repeatPenalty: 1.1,
-  contextLength: 2048,
+  contextLength: 4096,
 };
 
 const FALLBACK_MAX_CONTEXT = 32768;

--- a/src/components/GenerationSettingsModal/index.tsx
+++ b/src/components/GenerationSettingsModal/index.tsx
@@ -16,7 +16,7 @@ const DEFAULT_SETTINGS = {
   topP: 0.9,
   repeatPenalty: 1.1,
   contextLength: 4096,
-  nThreads: 4,
+  nThreads: 0,
   nBatch: 512,
 };
 

--- a/src/components/GenerationSettingsModal/index.tsx
+++ b/src/components/GenerationSettingsModal/index.tsx
@@ -15,7 +15,7 @@ const DEFAULT_SETTINGS = {
   maxTokens: 1024,
   topP: 0.9,
   repeatPenalty: 1.1,
-  contextLength: 2048,
+  contextLength: 4096,
   nThreads: 4,
   nBatch: 512,
 };

--- a/src/components/ModelCard.tsx
+++ b/src/components/ModelCard.tsx
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity } from 'react-native';
 import { useThemedStyles } from '../theme';
 import { QUANTIZATION_INFO, CREDIBILITY_LABELS } from '../constants';
 import { ModelFile, DownloadedModel, ModelCredibility } from '../types';
+import { needsVisionRepair } from '../utils/visionRepair';
 import { createStyles } from './ModelCard.styles';
 import {
   CompactModelCardContent,
@@ -111,6 +112,7 @@ export const ModelCard: React.FC<ModelCardProps> = ({
   const quantInfo = resolveQuantInfo(file, downloadedModel);
   const fileSize = resolveFileSize(file, downloadedModel);
   const isVisionModel = !!(file?.mmProjFile || downloadedModel?.isVisionModel);
+  const needsRepair = needsVisionRepair(downloadedModel, file);
 
   const sizeRange = React.useMemo(() => {
     if (fileSize > 0 || !model.files || model.files.length === 0) return null;
@@ -164,6 +166,7 @@ export const ModelCard: React.FC<ModelCardProps> = ({
             quantInfo={quantInfo}
             quantization={quantization}
             isVisionModel={isVisionModel}
+            needsRepair={needsRepair}
             isCompatible={isCompatible}
             incompatibleReason={incompatibleReason}
           />

--- a/src/components/ModelCardContent.tsx
+++ b/src/components/ModelCardContent.tsx
@@ -197,6 +197,7 @@ interface ModelInfoBadgesProps {
   quantInfo: { quality: string; recommended: boolean } | null;
   quantization: string | undefined;
   isVisionModel: boolean;
+  needsRepair: boolean;
   isCompatible: boolean;
   incompatibleReason: string | undefined;
 }
@@ -207,6 +208,7 @@ export const ModelInfoBadges: React.FC<ModelInfoBadgesProps> = ({
   quantInfo,
   quantization,
   isVisionModel,
+  needsRepair,
   isCompatible,
   incompatibleReason,
 }) => {
@@ -247,9 +249,14 @@ export const ModelInfoBadges: React.FC<ModelInfoBadgesProps> = ({
           <Text style={styles.infoText}>{quantInfo.quality}</Text>
         </View>
       )}
-      {isVisionModel && (
+      {isVisionModel && !needsRepair && (
         <View style={styles.visionBadge}>
           <Text style={styles.visionText}>Vision</Text>
+        </View>
+      )}
+      {isVisionModel && needsRepair && (
+        <View style={styles.warningBadge}>
+          <Text style={styles.warningText}>Needs repair</Text>
         </View>
       )}
       {!isCompatible && (

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -95,7 +95,7 @@ export const APP_CONFIG = {
 
 If asked about yourself, you can mention you're a local AI assistant that prioritizes user privacy.`,
   streamingEnabled: true,
-  maxContextLength: 2048, // Balanced for speed and context (increase to 4096 if you need more history)
+  maxContextLength: 4096, // Default context window; eliminates double-init on models that support ≥4096
 };
 
 // Onboarding slides

--- a/src/hooks/useTextGenerationAdvanced.ts
+++ b/src/hooks/useTextGenerationAdvanced.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 import { useAppStore } from '../stores';
-import { CacheType } from '../types';
+import { CacheType, INFERENCE_BACKENDS } from '../types';
 
 export const CACHE_TYPE_DESCRIPTIONS: Record<CacheType, string> = {
   f16: 'Full precision — best quality, highest memory usage',
@@ -18,11 +18,12 @@ export function useTextGenerationAdvanced() {
   const isQuantizedCache = (settings?.cacheType ?? 'q8_0') !== 'f16';
   const currentCacheType: CacheType = settings?.cacheType ?? 'q8_0';
   const gpuLayersEffective = Math.min(settings?.gpuLayers ?? 1, GPU_LAYERS_MAX);
-  const isGpuEnabled = (settings?.inferenceBackend ?? (Platform.OS === 'ios' ? 'metal' : 'cpu')) !== 'cpu';
+  const defaultBackend = Platform.OS === 'ios' ? INFERENCE_BACKENDS.METAL : INFERENCE_BACKENDS.CPU;
+  const isGpuEnabled = (settings?.inferenceBackend ?? defaultBackend) !== INFERENCE_BACKENDS.CPU;
   const isAndroid = Platform.OS === 'android';
   const gpuForcesF16 = false;
   // OpenCL forces f16 — disable quantized cache options in the UI
-  const cacheDisabled = (settings?.inferenceBackend ?? 'cpu') === 'opencl';
+  const cacheDisabled = (settings?.inferenceBackend ?? INFERENCE_BACKENDS.CPU) === INFERENCE_BACKENDS.OPENCL;
   const displayCacheType = cacheDisabled ? 'f16' : currentCacheType;
 
   const handleFlashAttnToggle = (flashAttn: boolean) => {

--- a/src/hooks/useTextGenerationAdvanced.ts
+++ b/src/hooks/useTextGenerationAdvanced.ts
@@ -20,16 +20,12 @@ export function useTextGenerationAdvanced() {
   const gpuLayersEffective = Math.min(settings?.gpuLayers ?? 1, GPU_LAYERS_MAX);
   const isGpuEnabled = settings?.enableGpu !== false;
   const isAndroid = Platform.OS === 'android';
-  const gpuForcesF16 = isAndroid && isGpuEnabled;
-  const cacheDisabled = gpuForcesF16;
-  const displayCacheType = cacheDisabled ? 'f16' : currentCacheType;
+  const gpuForcesF16 = false;
+  const cacheDisabled = false;
+  const displayCacheType = currentCacheType;
 
   const handleGpuToggle = (enableGpu: boolean) => {
-    if (enableGpu && isAndroid && isQuantizedCache) {
-      updateSettings({ enableGpu: true, cacheType: 'f16' });
-    } else {
-      updateSettings({ enableGpu: enableGpu });
-    }
+    updateSettings({ enableGpu });
   };
 
   const handleFlashAttnToggle = (flashAttn: boolean) => {

--- a/src/hooks/useTextGenerationAdvanced.ts
+++ b/src/hooks/useTextGenerationAdvanced.ts
@@ -18,15 +18,12 @@ export function useTextGenerationAdvanced() {
   const isQuantizedCache = (settings?.cacheType ?? 'q8_0') !== 'f16';
   const currentCacheType: CacheType = settings?.cacheType ?? 'q8_0';
   const gpuLayersEffective = Math.min(settings?.gpuLayers ?? 1, GPU_LAYERS_MAX);
-  const isGpuEnabled = settings?.enableGpu !== false;
+  const isGpuEnabled = (settings?.inferenceBackend ?? (Platform.OS === 'ios' ? 'metal' : 'cpu')) !== 'cpu';
   const isAndroid = Platform.OS === 'android';
   const gpuForcesF16 = false;
-  const cacheDisabled = false;
-  const displayCacheType = currentCacheType;
-
-  const handleGpuToggle = (enableGpu: boolean) => {
-    updateSettings({ enableGpu });
-  };
+  // OpenCL forces f16 — disable quantized cache options in the UI
+  const cacheDisabled = (settings?.inferenceBackend ?? 'cpu') === 'opencl';
+  const displayCacheType = cacheDisabled ? 'f16' : currentCacheType;
 
   const handleFlashAttnToggle = (flashAttn: boolean) => {
     if (!flashAttn && isQuantizedCache) {
@@ -60,7 +57,6 @@ export function useTextGenerationAdvanced() {
     cacheDisabled,
 
     // Handlers
-    handleGpuToggle,
     handleFlashAttnToggle,
     handleCacheTypeChange,
   };

--- a/src/screens/ChatScreen/useChatGenerationActions.ts
+++ b/src/screens/ChatScreen/useChatGenerationActions.ts
@@ -251,8 +251,11 @@ export async function startGenerationFn(deps: GenerationDeps, call: StartGenerat
   const basePrompt = await injectRagContext(conversation?.projectId, messageText, rawPrompt);
   const isRemote = !!useRemoteServerStore.getState().activeRemoteTextModelId;
   const activeTools = enabledTools;
+  // Skip text hint when model supports native Jinja tool calling — the Jinja template
+  // already injects tool schemas, so adding the hint text would double-inject.
+  const useTextHint = !isRemote && activeTools.length > 0 && !llmService.supportsToolCalling();
   const systemPrompt = applyGemma4ThinkToken(
-    (!isRemote && activeTools.length > 0) ? `${basePrompt}${buildToolSystemPromptHint(activeTools)}` : basePrompt,
+    useTextHint ? `${basePrompt}${buildToolSystemPromptHint(activeTools)}` : basePrompt,
     isRemote,
   );
   logger.log(`[ChatGen][DEBUG] isRemote=${isRemote}, tools=[${activeTools.join(', ')}], path=${activeTools.length > 0 ? 'withTools' : 'generate'}`);
@@ -336,8 +339,9 @@ export async function regenerateResponseFn(deps: GenerationDeps, call: Regenerat
   const isRemote = !!useRemoteServerStore.getState().activeRemoteTextModelId;
   const activeTools = enabledTools;
   const basePrompt = await injectRagContext(conversation?.projectId, messageText, rawPrompt);
+  const useTextHint = !isRemote && activeTools.length > 0 && !llmService.supportsToolCalling();
   const systemPrompt = applyGemma4ThinkToken(
-    (!isRemote && activeTools.length > 0) ? `${basePrompt}${buildToolSystemPromptHint(activeTools)}` : basePrompt,
+    useTextHint ? `${basePrompt}${buildToolSystemPromptHint(activeTools)}` : basePrompt,
     isRemote,
   );
   const { prefix, filtered } = applyCompactionPrefix(conversation, systemPrompt, messagesUpToUser);

--- a/src/screens/ChatScreen/useChatScreen.ts
+++ b/src/screens/ChatScreen/useChatScreen.ts
@@ -217,14 +217,19 @@ export const useChatScreen = () => {
       settings.nBatch !== loadedSettings.nBatch ||
       settings.contextLength !== loadedSettings.contextLength ||
       settings.enableGpu !== loadedSettings.enableGpu ||
+      settings.inferenceBackend !== loadedSettings.inferenceBackend ||
       settings.gpuLayers !== loadedSettings.gpuLayers ||
       settings.flashAttn !== loadedSettings.flashAttn ||
-      settings.cacheType !== loadedSettings.cacheType
+      // Compare effective cache type — OpenCL forces f16 regardless of user setting
+      (settings.inferenceBackend === 'opencl' ? 'f16' : settings.cacheType) !== loadedSettings.cacheType
     );
   })();
 
   const handleReloadTextModel = useCallback(async () => {
     if (!activeModelInfo.modelId || activeModelInfo.isRemote) return;
+    // Open the model selector bottom sheet before unloading so the user sees the
+    // loading state inside it rather than the NoModelScreen ("Select Model").
+    setShowModelSelector(true);
     // Must unload first — loadTextModel skips if the same model ID is already loaded,
     // which means setLoadedSettings would never run and the banner would persist.
     if (llmService.isModelLoaded()) {

--- a/src/screens/ChatScreen/useChatScreen.ts
+++ b/src/screens/ChatScreen/useChatScreen.ts
@@ -8,7 +8,7 @@ import {
   ImageGenerationState, hardwareService, QueuedMessage,
   contextCompactionService,
 } from '../../services';
-import { Message, MediaAttachment, Project, DownloadedModel, DebugInfo, RemoteModel } from '../../types';
+import { Message, MediaAttachment, Project, DownloadedModel, DebugInfo, RemoteModel, INFERENCE_BACKENDS } from '../../types';
 import { RootStackParamList } from '../../navigation/types';
 import { ensureModelLoadedFn, handleModelSelectFn, handleUnloadModelFn, initiateModelLoad, useChatImageModelEffects, useChatModelStateSync } from './useChatModelActions';
 import { startGenerationFn, handleSendFn, handleStopFn, handleSelectProjectFn } from './useChatGenerationActions';
@@ -221,7 +221,7 @@ export const useChatScreen = () => {
       settings.gpuLayers !== loadedSettings.gpuLayers ||
       settings.flashAttn !== loadedSettings.flashAttn ||
       // Compare effective cache type — OpenCL forces f16 regardless of user setting
-      (settings.inferenceBackend === 'opencl' ? 'f16' : settings.cacheType) !== loadedSettings.cacheType
+      (settings.inferenceBackend === INFERENCE_BACKENDS.OPENCL ? 'f16' : settings.cacheType) !== loadedSettings.cacheType
     );
   })();
 

--- a/src/screens/ModelSettingsScreen/TextGenerationAdvanced.tsx
+++ b/src/screens/ModelSettingsScreen/TextGenerationAdvanced.tsx
@@ -133,12 +133,7 @@ const KvCacheSection: React.FC<{ cacheDisabled: boolean }> = ({ cacheDisabled })
           />
         ))}
       </View>
-      {cacheDisabled && (
-        <Text style={styles.warningText}>
-          GPU acceleration on Android requires f16 KV cache.
-        </Text>
-      )}
-      {!cacheDisabled && !isFlashAttnOn && (
+      {!isFlashAttnOn && (
         <Text style={styles.warningText}>
           Quantized cache (q8_0/q4_0) will auto-enable flash attention.
         </Text>

--- a/src/screens/ModelSettingsScreen/TextGenerationAdvanced.tsx
+++ b/src/screens/ModelSettingsScreen/TextGenerationAdvanced.tsx
@@ -4,7 +4,7 @@ import Slider from '@react-native-community/slider';
 import { Button } from '../../components/Button';
 import { useTheme, useThemedStyles } from '../../theme';
 import { useAppStore } from '../../stores';
-import { CacheType, InferenceBackend } from '../../types';
+import { CacheType, InferenceBackend, INFERENCE_BACKENDS } from '../../types';
 import {
   useTextGenerationAdvanced,
   CACHE_TYPE_DESCRIPTIONS,
@@ -19,16 +19,16 @@ import { createStyles } from './styles';
 type BackendOption = { id: InferenceBackend; label: string };
 
 const IOS_BACKENDS: BackendOption[] = [
-  { id: 'cpu', label: 'CPU' },
-  { id: 'metal', label: 'Metal' },
+  { id: INFERENCE_BACKENDS.CPU, label: 'CPU' },
+  { id: INFERENCE_BACKENDS.METAL, label: 'Metal' },
 ];
 
 const ANDROID_BASE_BACKENDS: BackendOption[] = [
-  { id: 'cpu', label: 'CPU' },
-  { id: 'opencl', label: 'OpenCL' },
+  { id: INFERENCE_BACKENDS.CPU, label: 'CPU' },
+  { id: INFERENCE_BACKENDS.OPENCL, label: 'OpenCL' },
 ];
 
-const HTP_BACKEND: BackendOption = { id: 'htp', label: 'HTP' };
+const HTP_BACKEND: BackendOption = { id: INFERENCE_BACKENDS.HTP, label: 'HTP' };
 
 const BackendSelectorSection: React.FC = () => {
   const { colors } = useTheme();
@@ -47,8 +47,9 @@ const BackendSelectorSection: React.FC = () => {
     ? IOS_BACKENDS
     : hasNPU ? [...ANDROID_BASE_BACKENDS, HTP_BACKEND] : ANDROID_BASE_BACKENDS;
 
-  const current = settings.inferenceBackend ?? (Platform.OS === 'ios' ? 'metal' : 'cpu');
-  const showLayers = current !== 'cpu';
+  const defaultBackend = Platform.OS === 'ios' ? INFERENCE_BACKENDS.METAL : INFERENCE_BACKENDS.CPU;
+  const current = settings.inferenceBackend ?? defaultBackend;
+  const showLayers = current !== INFERENCE_BACKENDS.CPU;
 
   return (
     <>
@@ -56,10 +57,10 @@ const BackendSelectorSection: React.FC = () => {
         <View style={styles.toggleInfo}>
           <Text style={styles.toggleLabel}>Inference Backend</Text>
           <Text style={styles.toggleDesc}>
-            {current === 'cpu' && 'Running on CPU threads only.'}
-            {current === 'opencl' && 'Offloading layers to GPU via OpenCL.'}
-            {current === 'htp' && 'Offloading layers to Hexagon NPU.'}
-            {current === 'metal' && 'Offloading layers to GPU via Metal.'}
+            {current === INFERENCE_BACKENDS.CPU && 'Running on CPU threads only.'}
+            {current === INFERENCE_BACKENDS.OPENCL && 'Offloading layers to GPU via OpenCL.'}
+            {current === INFERENCE_BACKENDS.HTP && 'Offloading layers to Hexagon NPU.'}
+            {current === INFERENCE_BACKENDS.METAL && 'Offloading layers to GPU via Metal.'}
           </Text>
         </View>
       </View>
@@ -82,7 +83,7 @@ const BackendSelectorSection: React.FC = () => {
         <View style={styles.sliderSection}>
           <View style={styles.sliderHeader}>
             <Text style={styles.sliderLabel}>
-              {current === 'htp' ? 'NPU Layers' : 'GPU Layers'}
+              {current === INFERENCE_BACKENDS.HTP ? 'NPU Layers' : 'GPU Layers'}
             </Text>
             <Text style={styles.sliderValue}>{gpuLayersEffective}</Text>
           </View>

--- a/src/screens/ModelSettingsScreen/TextGenerationAdvanced.tsx
+++ b/src/screens/ModelSettingsScreen/TextGenerationAdvanced.tsx
@@ -1,64 +1,91 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, Switch, Platform } from 'react-native';
 import Slider from '@react-native-community/slider';
 import { Button } from '../../components/Button';
 import { useTheme, useThemedStyles } from '../../theme';
 import { useAppStore } from '../../stores';
-import { CacheType } from '../../types';
+import { CacheType, InferenceBackend } from '../../types';
 import {
   useTextGenerationAdvanced,
   CACHE_TYPE_DESCRIPTIONS,
   GPU_LAYERS_MAX,
   CACHE_TYPE_OPTIONS,
 } from '../../hooks/useTextGenerationAdvanced';
+import { hardwareService } from '../../services/hardware';
 import { createStyles } from './styles';
 
-// ─── GPU Section ──────────────────────────────────────────────────────────────
+// ─── Inference Backend ────────────────────────────────────────────────────────
 
-interface GpuSectionProps {
-  isGpuEnabled: boolean;
-  gpuLayersEffective: number;
-  trackColor: { false: string; true: string };
-  onGpuChange: (value: boolean) => void;
-}
+type BackendOption = { id: InferenceBackend; label: string };
 
-const GpuSection: React.FC<GpuSectionProps> = ({
-  isGpuEnabled,
-  gpuLayersEffective,
-  trackColor,
-  onGpuChange,
-}) => {
+const IOS_BACKENDS: BackendOption[] = [
+  { id: 'cpu', label: 'CPU' },
+  { id: 'metal', label: 'Metal' },
+];
+
+const ANDROID_BASE_BACKENDS: BackendOption[] = [
+  { id: 'cpu', label: 'CPU' },
+  { id: 'opencl', label: 'OpenCL' },
+];
+
+const HTP_BACKEND: BackendOption = { id: 'htp', label: 'HTP' };
+
+const BackendSelectorSection: React.FC = () => {
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
-  const { updateSettings } = useAppStore();
+  const { settings, updateSettings } = useAppStore();
+  const { gpuLayersEffective } = useTextGenerationAdvanced();
+  const [hasNPU, setHasNPU] = useState(false);
+
+  useEffect(() => {
+    if (Platform.OS === 'android') {
+      hardwareService.getSoCInfo().then(info => setHasNPU(info.hasNPU));
+    }
+  }, []);
+
+  const backends: BackendOption[] = Platform.OS === 'ios'
+    ? IOS_BACKENDS
+    : hasNPU ? [...ANDROID_BASE_BACKENDS, HTP_BACKEND] : ANDROID_BASE_BACKENDS;
+
+  const current = settings.inferenceBackend ?? (Platform.OS === 'ios' ? 'metal' : 'cpu');
+  const showLayers = current !== 'cpu';
 
   return (
     <>
       <View style={styles.toggleRow}>
         <View style={styles.toggleInfo}>
-          <Text style={styles.toggleLabel}>GPU Acceleration</Text>
+          <Text style={styles.toggleLabel}>Inference Backend</Text>
           <Text style={styles.toggleDesc}>
-            Offload model layers to GPU. Requires model reload.
+            {current === 'cpu' && 'Running on CPU threads only.'}
+            {current === 'opencl' && 'Offloading layers to GPU via OpenCL.'}
+            {current === 'htp' && 'Offloading layers to Hexagon NPU.'}
+            {current === 'metal' && 'Offloading layers to GPU via Metal.'}
           </Text>
         </View>
-        <Switch
-          testID="gpu-acceleration-switch"
-          value={isGpuEnabled}
-          onValueChange={onGpuChange}
-          trackColor={trackColor}
-          thumbColor={isGpuEnabled ? colors.primary : colors.textMuted}
-        />
+      </View>
+      <View style={styles.strategyButtons}>
+        {backends.map(b => (
+          <Button
+            key={b.id}
+            title={b.label}
+            variant="secondary"
+            size="small"
+            testID={`backend-${b.id}-button`}
+            active={current === b.id}
+            onPress={() => updateSettings({ inferenceBackend: b.id })}
+            style={styles.flex1}
+          />
+        ))}
       </View>
 
-      {isGpuEnabled && (
+      {showLayers && (
         <View style={styles.sliderSection}>
           <View style={styles.sliderHeader}>
-            <Text style={styles.sliderLabel}>GPU Layers</Text>
+            <Text style={styles.sliderLabel}>
+              {current === 'htp' ? 'NPU Layers' : 'GPU Layers'}
+            </Text>
             <Text style={styles.sliderValue}>{gpuLayersEffective}</Text>
           </View>
-          <Text style={styles.sliderDesc}>
-            Layers offloaded to GPU. Higher = faster but may crash on low-VRAM devices.
-          </Text>
           <Slider
             testID="gpu-layers-slider"
             style={styles.slider}
@@ -190,12 +217,7 @@ export const TextGenerationAdvanced: React.FC = () => {
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
   const { settings, updateSettings } = useAppStore();
-  const {
-    gpuLayersEffective,
-    isGpuEnabled,
-    cacheDisabled,
-    handleGpuToggle,
-  } = useTextGenerationAdvanced();
+  const { cacheDisabled } = useTextGenerationAdvanced();
 
   const trackColor = { false: colors.surfaceLight, true: `${colors.primary}80` };
 
@@ -277,15 +299,7 @@ export const TextGenerationAdvanced: React.FC = () => {
         />
       </View>
 
-      {Platform.OS !== 'ios' && (
-        <GpuSection
-          isGpuEnabled={isGpuEnabled}
-          gpuLayersEffective={gpuLayersEffective}
-          trackColor={trackColor}
-          onGpuChange={handleGpuToggle}
-        />
-      )}
-
+      <BackendSelectorSection />
       <FlashAttentionSection trackColor={trackColor} />
       <KvCacheSection cacheDisabled={cacheDisabled} />
       <ModelLoadingStrategySection />

--- a/src/services/activeModelService/loaders.ts
+++ b/src/services/activeModelService/loaders.ts
@@ -4,7 +4,7 @@
  */
 
 import { useAppStore } from '../../stores';
-import { DownloadedModel, ONNXImageModel } from '../../types';
+import { DownloadedModel, ONNXImageModel, INFERENCE_BACKENDS } from '../../types';
 import { llmService } from '../llm';
 import { localDreamGeneratorService as onnxImageGeneratorService } from '../localDreamGenerator';
 import { modelManager } from '../modelManager';
@@ -153,7 +153,7 @@ export async function doLoadTextModel(ctx: TextLoadContext): Promise<void> {
       flashAttn: settings.flashAttn,
       // Store the effective cache type (f16 may be forced for OpenCL) so the
       // banner doesn't show a false mismatch when the user setting differs.
-      cacheType: settings.inferenceBackend === 'opencl' ? 'f16' : settings.cacheType,
+      cacheType: settings.inferenceBackend === INFERENCE_BACKENDS.OPENCL ? 'f16' : settings.cacheType,
     };
     ctx.store.setLoadedSettings(reloadSettings);
 

--- a/src/services/activeModelService/loaders.ts
+++ b/src/services/activeModelService/loaders.ts
@@ -145,12 +145,15 @@ export async function doLoadTextModel(ctx: TextLoadContext): Promise<void> {
     const { settings } = ctx.store;
     const reloadSettings = {
       enableGpu: settings.enableGpu,
+      inferenceBackend: settings.inferenceBackend,
       gpuLayers: settings.gpuLayers,
       nThreads: settings.nThreads,
       nBatch: settings.nBatch,
       contextLength: settings.contextLength,
       flashAttn: settings.flashAttn,
-      cacheType: settings.cacheType,
+      // Store the effective cache type (f16 may be forced for OpenCL) so the
+      // banner doesn't show a false mismatch when the user setting differs.
+      cacheType: settings.inferenceBackend === 'opencl' ? 'f16' : settings.cacheType,
     };
     ctx.store.setLoadedSettings(reloadSettings);
 

--- a/src/services/hardware.ts
+++ b/src/services/hardware.ts
@@ -339,8 +339,9 @@ class HardwareService {
     if (Platform.OS !== 'android') return { supported: false, reason: 'not_android' };
     try {
       const hardware = (await DeviceInfo.getHardware()).toLowerCase();
-      // Support Qualcomm Adreno (qcom) and ARM Mali (mali/arm) GPUs.
-      const hasCompatibleGpu = hardware.includes('qcom') || hardware.includes('mali') || hardware.includes('arm');
+      // Support Qualcomm Adreno (qcom) and ARM Mali GPUs.
+      // Avoid 'arm' alone — it matches the CPU architecture string (arm64-v8a), not the GPU vendor.
+      const hasCompatibleGpu = hardware.includes('qcom') || hardware.includes('mali');
       if (!hasCompatibleGpu) return (this.cachedOpenCLCapability = { supported: false, reason: 'no_compatible_gpu' });
       return (this.cachedOpenCLCapability = { supported: true });
     } catch { return (this.cachedOpenCLCapability = { supported: false, reason: 'detection_failed' }); }

--- a/src/services/hardware.ts
+++ b/src/services/hardware.ts
@@ -1,5 +1,6 @@
 import { Platform, NativeModules } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
+import RNFS from 'react-native-fs';
 // Access NativeModules.LocalDreamModule dynamically (not destructured)
 // so it can be mocked in tests after module import.
 const getLocalDreamModule = () => NativeModules.LocalDreamModule;
@@ -25,6 +26,7 @@ class HardwareService {
   private cachedDeviceInfo: DeviceInfoType | null = null;
   private cachedSoCInfo: SoCInfo | null = null;
   private cachedImageRecommendation: ImageModelRecommendation | null = null;
+  private cachedOpenCLCapability: { supported: boolean; reason?: string } | null = null;
   async getDeviceInfo(): Promise<DeviceInfoType> {
     if (this.cachedDeviceInfo) {
       return this.cachedDeviceInfo;
@@ -319,6 +321,35 @@ class HardwareService {
     if (ramGB < 6) return 'medium';
     if (ramGB < 8) return 'high';
     return 'flagship';
+  }
+  async getCpuCoreCount(): Promise<number> {
+    if (Platform.OS !== 'android') return 4;
+    try {
+      const cpuinfo = await RNFS.readFile('/proc/cpuinfo', 'utf8');
+      const matches = cpuinfo.match(/^processor\s*:/gm);
+      return matches ? matches.length : 4;
+    } catch { return 4; }
+  }
+  async getRecommendedThreadCount(): Promise<number> {
+    const cores = await this.getCpuCoreCount();
+    return cores <= 4 ? cores : Math.floor(cores * 0.8);
+  }
+  async getOpenCLCapability(): Promise<{ supported: boolean; reason?: string }> {
+    if (this.cachedOpenCLCapability) return this.cachedOpenCLCapability;
+    if (Platform.OS !== 'android') return { supported: false, reason: 'not_android' };
+    try {
+      const [hardware, cpuinfo] = await Promise.all([
+        DeviceInfo.getHardware(),
+        RNFS.readFile('/proc/cpuinfo', 'utf8'),
+      ]);
+      const hasAdreno = hardware.toLowerCase().includes('qcom');
+      const features = cpuinfo.toLowerCase();
+      const hasI8mm = features.includes('i8mm');
+      const hasDotProd = features.includes('asimddp') || features.includes('dotprod');
+      if (!hasAdreno) return (this.cachedOpenCLCapability = { supported: false, reason: 'no_adreno' });
+      if (!hasI8mm || !hasDotProd) return (this.cachedOpenCLCapability = { supported: false, reason: 'missing_cpu_features' });
+      return (this.cachedOpenCLCapability = { supported: true });
+    } catch { return (this.cachedOpenCLCapability = { supported: false, reason: 'detection_failed' }); }
   }
 }
 export const hardwareService = new HardwareService();

--- a/src/services/hardware.ts
+++ b/src/services/hardware.ts
@@ -338,16 +338,10 @@ class HardwareService {
     if (this.cachedOpenCLCapability) return this.cachedOpenCLCapability;
     if (Platform.OS !== 'android') return { supported: false, reason: 'not_android' };
     try {
-      const [hardware, cpuinfo] = await Promise.all([
-        DeviceInfo.getHardware(),
-        RNFS.readFile('/proc/cpuinfo', 'utf8'),
-      ]);
-      const hasAdreno = hardware.toLowerCase().includes('qcom');
-      const features = cpuinfo.toLowerCase();
-      const hasI8mm = features.includes('i8mm');
-      const hasDotProd = features.includes('asimddp') || features.includes('dotprod');
-      if (!hasAdreno) return (this.cachedOpenCLCapability = { supported: false, reason: 'no_adreno' });
-      if (!hasI8mm || !hasDotProd) return (this.cachedOpenCLCapability = { supported: false, reason: 'missing_cpu_features' });
+      const hardware = (await DeviceInfo.getHardware()).toLowerCase();
+      // Support Qualcomm Adreno (qcom) and ARM Mali (mali/arm) GPUs.
+      const hasCompatibleGpu = hardware.includes('qcom') || hardware.includes('mali') || hardware.includes('arm');
+      if (!hasCompatibleGpu) return (this.cachedOpenCLCapability = { supported: false, reason: 'no_compatible_gpu' });
       return (this.cachedOpenCLCapability = { supported: true });
     } catch { return (this.cachedOpenCLCapability = { supported: false, reason: 'detection_failed' }); }
   }

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -61,11 +61,9 @@ class LLMService {
     const settings = useAppStore.getState().settings;
     logger.log(`[LLM] User settings: threads=${settings.nThreads}, batch=${settings.nBatch}, ctx=${settings.contextLength}, gpu=${settings.enableGpu}, flashAttn=${settings.flashAttn}, cache=${settings.cacheType}`);
     const recommendedThreads = await hardwareService.getRecommendedThreadCount();
-    // Only substitute recommended threads when the user hasn't changed from the factory
-    // default (4). Explicit choices — including lower values for thermal/battery reasons —
-    // are respected as-is.
-    const DEFAULT_NTHREADS = 4;
-    const effectiveNThreads = settings.nThreads === DEFAULT_NTHREADS ? recommendedThreads : settings.nThreads;
+    // nThreads === 0 is the "auto" sentinel — substitute the hardware-recommended count.
+    // Any explicit user choice (1–12) is respected as-is.
+    const effectiveNThreads = settings.nThreads === 0 ? recommendedThreads : settings.nThreads;
     const params = buildModelParams(modelPath, { ...settings, nThreads: effectiveNThreads });
     logger.log(`[LLM] Resolved params: threads=${params.nThreads}, batch=${params.nBatch}, ctx=${params.ctxLen}, gpuLayers=${params.nGpuLayers}`);
     const fileStat = await RNFS.stat(modelPath);

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -114,9 +114,18 @@ class LLMService {
   }
   private async initWithAutoContext(params: { baseParams: object; ctxLen: number; nGpuLayers: number }): Promise<{ context: LlamaContext; gpuAttemptFailed: boolean; actualLength: number }> {
     const deviceInfo = await hardwareService.getDeviceInfo();
-    const safeGpuLayers = getGpuLayersForDevice(deviceInfo.totalMemory, params.nGpuLayers);
+    let safeGpuLayers = getGpuLayersForDevice(deviceInfo.totalMemory, params.nGpuLayers);
     if (safeGpuLayers !== params.nGpuLayers) logger.log(`[LLM] GPU layers capped (${(deviceInfo.totalMemory / BYTES_PER_GB).toFixed(1)}GB RAM, ${Platform.OS}): ${params.nGpuLayers} → ${safeGpuLayers}`);
-    const initial = await initContextWithFallback(params.baseParams, params.ctxLen, safeGpuLayers);
+    let resolvedBaseParams: object = params.baseParams;
+    if (Platform.OS === 'android') {
+      const socInfo = await hardwareService.getSoCInfo();
+      if (socInfo.hasNPU) {
+        safeGpuLayers = 99;
+        resolvedBaseParams = { ...params.baseParams, devices: ['HTP0'] };
+        logger.log(`[LLM] Snapdragon HTP (${socInfo.qnnVariant}) — offloading all layers to NPU`);
+      }
+    }
+    const initial = await initContextWithFallback(resolvedBaseParams, params.ctxLen, safeGpuLayers);
     const modelMax = getModelMaxContext(initial.context);
     const userIsOnDefault = this.currentSettings.contextLength === APP_CONFIG.maxContextLength;
     if (!modelMax || !userIsOnDefault || modelMax <= initial.actualLength) return initial;
@@ -125,7 +134,7 @@ class LLMService {
     if (targetCtx <= initial.actualLength) return initial;
     logger.log(`[LLM] Model supports ${modelMax} ctx, RAM cap ${deviceMaxCtx}, scaling ${initial.actualLength} → ${targetCtx}`);
     try { await initial.context.release(); } catch (e) { logger.warn('[LLM] Error releasing initial context:', e); }
-    return initContextWithFallback(params.baseParams, targetCtx, safeGpuLayers);
+    return initContextWithFallback(resolvedBaseParams, targetCtx, safeGpuLayers);
   }
   async initializeMultimodal(mmProjPath: string): Promise<boolean> {
     if (!this.context) { logger.warn('[LLM] initializeMultimodal: no context'); return false; }

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -127,7 +127,9 @@ class LLMService {
       const settings = useAppStore.getState().settings;
       const backend = settings?.inferenceBackend ?? INFERENCE_BACKENDS.CPU;
       if (backend === INFERENCE_BACKENDS.HTP) {
-        safeGpuLayers = settings?.gpuLayers ?? 99;
+        // HTP routes to the Hexagon NPU — not subject to Adreno GPU layer caps,
+        // but we still respect the RAM-based safeGpuLayers floor (0 on ≤4GB devices).
+        safeGpuLayers = safeGpuLayers > 0 ? (settings?.gpuLayers ?? 99) : 0;
         resolvedBaseParams = { ...params.baseParams, devices: ['HTP0'] };
         const socInfo = await hardwareService.getSoCInfo();
         logger.log(`[LLM] HTP backend — offloading ${safeGpuLayers} layers to NPU (${socInfo.qnnVariant ?? 'unknown'})`);
@@ -137,7 +139,7 @@ class LLMService {
           logger.warn(`[LLM] OpenCL requested but not supported (${capability.reason}), falling back to CPU`);
           safeGpuLayers = 0;
         } else {
-          safeGpuLayers = settings?.gpuLayers ?? 99;
+          // Respect the Adreno-specific RAM cap — safeGpuLayers already has it applied.
           logger.log(`[LLM] OpenCL backend — offloading ${safeGpuLayers} layers to GPU`);
         }
       } else {

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -60,7 +60,9 @@ class LLMService {
     if (!validation.valid) throw new Error(`Cannot load model: ${validation.reason}`);
     const settings = useAppStore.getState().settings;
     logger.log(`[LLM] User settings: threads=${settings.nThreads}, batch=${settings.nBatch}, ctx=${settings.contextLength}, gpu=${settings.enableGpu}, flashAttn=${settings.flashAttn}, cache=${settings.cacheType}`);
-    const params = buildModelParams(modelPath, settings);
+    const recommendedThreads = await hardwareService.getRecommendedThreadCount();
+    const effectiveNThreads = settings.nThreads > 4 ? settings.nThreads : recommendedThreads;
+    const params = buildModelParams(modelPath, { ...settings, nThreads: effectiveNThreads });
     logger.log(`[LLM] Resolved params: threads=${params.nThreads}, batch=${params.nBatch}, ctx=${params.ctxLen}, gpuLayers=${params.nGpuLayers}`);
     const fileStat = await RNFS.stat(modelPath);
     const fileSize = typeof fileStat.size === 'string' ? Number.parseInt(fileStat.size, 10) : fileStat.size;
@@ -126,8 +128,14 @@ class LLMService {
         const socInfo = await hardwareService.getSoCInfo();
         logger.log(`[LLM] HTP backend — offloading ${safeGpuLayers} layers to NPU (${socInfo.qnnVariant ?? 'unknown'})`);
       } else if (backend === 'opencl') {
-        safeGpuLayers = settings?.gpuLayers ?? 99;
-        logger.log(`[LLM] OpenCL backend — offloading ${safeGpuLayers} layers to GPU`);
+        const capability = await hardwareService.getOpenCLCapability();
+        if (!capability.supported) {
+          logger.warn(`[LLM] OpenCL requested but not supported (${capability.reason}), falling back to CPU`);
+          safeGpuLayers = 0;
+        } else {
+          safeGpuLayers = settings?.gpuLayers ?? 99;
+          logger.log(`[LLM] OpenCL backend — offloading ${safeGpuLayers} layers to GPU`);
+        }
       } else {
         safeGpuLayers = 0;
         logger.log('[LLM] CPU backend selected');

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -118,14 +118,19 @@ class LLMService {
     if (safeGpuLayers !== params.nGpuLayers) logger.log(`[LLM] GPU layers capped (${(deviceInfo.totalMemory / BYTES_PER_GB).toFixed(1)}GB RAM, ${Platform.OS}): ${params.nGpuLayers} → ${safeGpuLayers}`);
     let resolvedBaseParams: object = params.baseParams;
     if (Platform.OS === 'android') {
-      const socInfo = await hardwareService.getSoCInfo();
       const settings = useAppStore.getState().settings;
-      const gpuEnabled = settings?.enableGpu !== false;
-      if (socInfo.hasNPU && gpuEnabled) {
-        // Use the user's configured GPU layers if set, otherwise all layers
+      const backend = settings?.inferenceBackend ?? 'cpu';
+      if (backend === 'htp') {
         safeGpuLayers = settings?.gpuLayers ?? 99;
         resolvedBaseParams = { ...params.baseParams, devices: ['HTP0'] };
-        logger.log(`[LLM] Snapdragon HTP (${socInfo.qnnVariant}) — offloading ${safeGpuLayers} layers to NPU`);
+        const socInfo = await hardwareService.getSoCInfo();
+        logger.log(`[LLM] HTP backend — offloading ${safeGpuLayers} layers to NPU (${socInfo.qnnVariant ?? 'unknown'})`);
+      } else if (backend === 'opencl') {
+        safeGpuLayers = settings?.gpuLayers ?? 99;
+        logger.log(`[LLM] OpenCL backend — offloading ${safeGpuLayers} layers to GPU`);
+      } else {
+        safeGpuLayers = 0;
+        logger.log('[LLM] CPU backend selected');
       }
     }
     const initial = await initContextWithFallback(resolvedBaseParams, params.ctxLen, safeGpuLayers);

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -119,10 +119,13 @@ class LLMService {
     let resolvedBaseParams: object = params.baseParams;
     if (Platform.OS === 'android') {
       const socInfo = await hardwareService.getSoCInfo();
-      if (socInfo.hasNPU) {
-        safeGpuLayers = 99;
+      const settings = useAppStore.getState().settings;
+      const gpuEnabled = settings?.enableGpu !== false;
+      if (socInfo.hasNPU && gpuEnabled) {
+        // Use the user's configured GPU layers if set, otherwise all layers
+        safeGpuLayers = settings?.gpuLayers ?? 99;
         resolvedBaseParams = { ...params.baseParams, devices: ['HTP0'] };
-        logger.log(`[LLM] Snapdragon HTP (${socInfo.qnnVariant}) — offloading all layers to NPU`);
+        logger.log(`[LLM] Snapdragon HTP (${socInfo.qnnVariant}) — offloading ${safeGpuLayers} layers to NPU`);
       }
     }
     const initial = await initContextWithFallback(resolvedBaseParams, params.ctxLen, safeGpuLayers);

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -1,7 +1,7 @@
 import { LlamaContext, RNLlamaOAICompatibleMessage } from 'llama.rn';
 import { Platform } from 'react-native';
 import RNFS from 'react-native-fs';
-import { Message } from '../types';
+import { Message, INFERENCE_BACKENDS } from '../types';
 import { APP_CONFIG } from '../constants';
 import { useAppStore } from '../stores';
 import {
@@ -61,7 +61,11 @@ class LLMService {
     const settings = useAppStore.getState().settings;
     logger.log(`[LLM] User settings: threads=${settings.nThreads}, batch=${settings.nBatch}, ctx=${settings.contextLength}, gpu=${settings.enableGpu}, flashAttn=${settings.flashAttn}, cache=${settings.cacheType}`);
     const recommendedThreads = await hardwareService.getRecommendedThreadCount();
-    const effectiveNThreads = settings.nThreads > 4 ? settings.nThreads : recommendedThreads;
+    // Only substitute recommended threads when the user hasn't changed from the factory
+    // default (4). Explicit choices — including lower values for thermal/battery reasons —
+    // are respected as-is.
+    const DEFAULT_NTHREADS = 4;
+    const effectiveNThreads = settings.nThreads === DEFAULT_NTHREADS ? recommendedThreads : settings.nThreads;
     const params = buildModelParams(modelPath, { ...settings, nThreads: effectiveNThreads });
     logger.log(`[LLM] Resolved params: threads=${params.nThreads}, batch=${params.nBatch}, ctx=${params.ctxLen}, gpuLayers=${params.nGpuLayers}`);
     const fileStat = await RNFS.stat(modelPath);
@@ -121,13 +125,13 @@ class LLMService {
     let resolvedBaseParams: object = params.baseParams;
     if (Platform.OS === 'android') {
       const settings = useAppStore.getState().settings;
-      const backend = settings?.inferenceBackend ?? 'cpu';
-      if (backend === 'htp') {
+      const backend = settings?.inferenceBackend ?? INFERENCE_BACKENDS.CPU;
+      if (backend === INFERENCE_BACKENDS.HTP) {
         safeGpuLayers = settings?.gpuLayers ?? 99;
         resolvedBaseParams = { ...params.baseParams, devices: ['HTP0'] };
         const socInfo = await hardwareService.getSoCInfo();
         logger.log(`[LLM] HTP backend — offloading ${safeGpuLayers} layers to NPU (${socInfo.qnnVariant ?? 'unknown'})`);
-      } else if (backend === 'opencl') {
+      } else if (backend === INFERENCE_BACKENDS.OPENCL) {
         const capability = await hardwareService.getOpenCLCapability();
         if (!capability.supported) {
           logger.warn(`[LLM] OpenCL requested but not supported (${capability.reason}), falling back to CPU`);

--- a/src/services/llmHelpers.ts
+++ b/src/services/llmHelpers.ts
@@ -77,8 +77,10 @@ export interface ContextInitResult {
   gpuAttemptFailed: boolean;
   actualLength: number;
 }
-/** Timeout for GPU context init on Android -- bail before OS triggers ANR. */
+/** Timeout for Adreno GPU context init on Android -- bail before OS triggers ANR. */
 const GPU_INIT_TIMEOUT_MS = 8000;
+/** Timeout for HTP/NPU context init -- DSP firmware load takes longer than Adreno. */
+const HTP_INIT_TIMEOUT_MS = 30000;
 /** Race a promise against a timeout; rejects with descriptive error on expiry. */
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;
@@ -92,28 +94,30 @@ async function safeRelease(ctx: LlamaContext | null): Promise<void> {
   if (!ctx) return;
   try { await ctx.release(); } catch (e) { logger.warn('[LLM] Error releasing context during fallback:', e); }
 }
-/** On Android, race GPU init against a timeout to prevent Adreno driver ANRs. */
-async function tryGpuInit(promise: Promise<LlamaContext>, nGpuLayers: number): Promise<LlamaContext> {
+/** On Android, race GPU/HTP init against a timeout to prevent ANRs. */
+async function tryGpuInit(promise: Promise<LlamaContext>, nGpuLayers: number, isHtp: boolean = false): Promise<LlamaContext> {
   if (nGpuLayers <= 0 || Platform.OS !== 'android') return promise;
+  const timeoutMs = isHtp ? HTP_INIT_TIMEOUT_MS : GPU_INIT_TIMEOUT_MS;
   let timedOut = false;
   promise.then(ctx => { if (timedOut) safeRelease(ctx); }).catch(() => {});
-  try { return await withTimeout(promise, GPU_INIT_TIMEOUT_MS, 'GPU context init'); }
+  try { return await withTimeout(promise, timeoutMs, isHtp ? 'HTP context init' : 'GPU context init'); }
   catch (e) { timedOut = true; throw e; }
 }
 
-/** Init llama with GPU, fall back to CPU, then retry with ctx=2048 on failure. */
+/** Init llama with GPU/HTP, fall back to CPU, then retry with ctx=2048 on failure. */
 export async function initContextWithFallback(
   params: object,
   contextLength: number,
   nGpuLayers: number,
 ): Promise<ContextInitResult> {
   const modelPath = (params as any).model || 'unknown';
-  logger.log(`[LLM] initContextWithFallback: model=${modelPath}, ctx=${contextLength}, gpuLayers=${nGpuLayers}`);
+  const isHtp = Array.isArray((params as any).devices) && (params as any).devices.some((d: string) => d.startsWith('HTP'));
+  logger.log(`[LLM] initContextWithFallback: model=${modelPath}, ctx=${contextLength}, gpuLayers=${nGpuLayers}${isHtp ? ', backend=HTP' : ''}`);
   let gpuAttemptFailed = false;
   try {
-    logger.log(`[LLM] Attempt 1/3: GPU init (ctx=${contextLength}, gpu_layers=${nGpuLayers})`);
+    logger.log(`[LLM] Attempt 1/3: ${isHtp ? 'HTP' : 'GPU'} init (ctx=${contextLength}, gpu_layers=${nGpuLayers})`);
     const gpuInitPromise = initLlama({ ...params, n_ctx: contextLength, n_gpu_layers: nGpuLayers } as any);
-    const context = await tryGpuInit(gpuInitPromise, nGpuLayers);
+    const context = await tryGpuInit(gpuInitPromise, nGpuLayers, isHtp);
     logger.log('[LLM] GPU init succeeded');
     return { context, gpuAttemptFailed, actualLength: contextLength };
   } catch (gpuError: any) {

--- a/src/services/llmHelpers.ts
+++ b/src/services/llmHelpers.ts
@@ -126,7 +126,10 @@ export async function initContextWithFallback(
     }
     try {
       logger.log(`[LLM] Attempt 2/3: CPU init (ctx=${contextLength}, gpu_layers=0)`);
-      const context = await initLlama({ ...params, n_ctx: contextLength, n_gpu_layers: 0 } as any);
+      // Strip devices — HTP requires n_gpu_layers > 0; CPU fallback must not request it
+      const cpuParams = { ...(params as Record<string, unknown>) };
+      delete cpuParams.devices;
+      const context = await initLlama({ ...cpuParams, n_ctx: contextLength, n_gpu_layers: 0 } as any);
       logger.log('[LLM] CPU init succeeded');
       return { context, gpuAttemptFailed, actualLength: contextLength };
     } catch (cpuError: any) {
@@ -134,7 +137,9 @@ export async function initContextWithFallback(
       logger.warn(`[LLM] Attempt 2/3 failed (CPU, ctx=${contextLength}): ${cpuMsg}`);
       try {
         logger.log('[LLM] Attempt 3/3: CPU init (ctx=2048, gpu_layers=0)');
-        const context = await initLlama({ ...params, n_ctx: 2048, n_gpu_layers: 0 } as any);
+        const cpuMinParams = { ...(params as Record<string, unknown>) };
+        delete cpuMinParams.devices;
+        const context = await initLlama({ ...cpuMinParams, n_ctx: 2048, n_gpu_layers: 0 } as any);
         logger.log('[LLM] CPU init with ctx=2048 succeeded');
         return { context, gpuAttemptFailed, actualLength: 2048 };
       } catch (finalError: any) {

--- a/src/services/llmHelpers.ts
+++ b/src/services/llmHelpers.ts
@@ -56,11 +56,13 @@ export function buildModelParams(
   const nThreads = settings.nThreads || getOptimalThreadCount();
   const nBatch = settings.nBatch || getOptimalBatchSize();
   const ctxLen = settings.contextLength || APP_CONFIG.maxContextLength;
-  // Use flash_attn_type string API (replaces deprecated flash_attn boolean).
-  // Android doesn't support flash attention — always 'off'. iOS: 'auto' unless user disabled.
-  const flash_attn_type = (settings.flashAttn === false || Platform.OS === 'android') ? 'off' : 'auto';
   // inferenceBackend takes precedence; fall back to legacy enableGpu flag
   const backend = settings.inferenceBackend;
+  // Use flash_attn_type string API (replaces deprecated flash_attn boolean).
+  // OpenCL and HTP backends crash with flash attn on — disable for those.
+  // CPU (Android/iOS) and Metal both support it; use 'auto' to let llama.cpp decide.
+  const gpuBackendIncompatible = backend === 'opencl' || backend === 'htp';
+  const flash_attn_type = (settings.flashAttn === false || gpuBackendIncompatible) ? 'off' : 'auto';
   const gpuEnabled = backend ? backend !== 'cpu' : settings.enableGpu !== false;
   const nGpuLayers = gpuEnabled ? (settings.gpuLayers ?? DEFAULT_GPU_LAYERS) : 0;
   // Quantized KV cache requires flash_attn to be effective.

--- a/src/services/llmHelpers.ts
+++ b/src/services/llmHelpers.ts
@@ -59,9 +59,9 @@ export function buildModelParams(
   const useFlashAttn = settings.flashAttn ?? true;
   const gpuEnabled = settings.enableGpu !== false;
   const nGpuLayers = gpuEnabled ? (settings.gpuLayers ?? DEFAULT_GPU_LAYERS) : 0;
-  // Quantized KV cache requires flash_attn; Android GPU only supports f16.
+  // Quantized KV cache requires flash_attn to be enabled.
   const requestedCache = settings.cacheType || (useFlashAttn ? 'q8_0' : 'f16');
-  const needsF16 = !useFlashAttn || (Platform.OS === 'android' && nGpuLayers > 0);
+  const needsF16 = !useFlashAttn;
   const cacheType = needsF16 && requestedCache !== 'f16' ? 'f16' : requestedCache;
   return {
     baseParams: {

--- a/src/services/llmHelpers.ts
+++ b/src/services/llmHelpers.ts
@@ -56,20 +56,24 @@ export function buildModelParams(
   const nThreads = settings.nThreads || getOptimalThreadCount();
   const nBatch = settings.nBatch || getOptimalBatchSize();
   const ctxLen = settings.contextLength || APP_CONFIG.maxContextLength;
-  const useFlashAttn = settings.flashAttn ?? true;
+  // Use flash_attn_type string API (replaces deprecated flash_attn boolean).
+  // Android doesn't support flash attention — always 'off'. iOS: 'auto' unless user disabled.
+  const flash_attn_type = (settings.flashAttn === false || Platform.OS === 'android') ? 'off' : 'auto';
   // inferenceBackend takes precedence; fall back to legacy enableGpu flag
   const backend = settings.inferenceBackend;
   const gpuEnabled = backend ? backend !== 'cpu' : settings.enableGpu !== false;
   const nGpuLayers = gpuEnabled ? (settings.gpuLayers ?? DEFAULT_GPU_LAYERS) : 0;
-  // Quantized KV cache requires flash_attn to be enabled.
+  // Quantized KV cache requires flash_attn to be effective.
   // OpenCL (Adreno) also requires f16 — quantized KV cache causes native crashes.
-  const requestedCache = settings.cacheType || (useFlashAttn ? 'q8_0' : 'f16');
-  const needsF16 = !useFlashAttn || backend === 'opencl';
+  const isFlashAttnEffective = flash_attn_type !== 'off';
+  const requestedCache = settings.cacheType || (isFlashAttnEffective ? 'q8_0' : 'f16');
+  const needsF16 = !isFlashAttnEffective || backend === 'opencl';
   const cacheType = needsF16 && requestedCache !== 'f16' ? 'f16' : requestedCache;
   return {
     baseParams: {
       model: modelPath, use_mlock: false, n_batch: nBatch, n_ubatch: nBatch, n_threads: nThreads,
-      use_mmap: !shouldDisableMmap(modelPath), vocab_only: false, flash_attn: useFlashAttn,
+      use_mmap: !shouldDisableMmap(modelPath), vocab_only: false, flash_attn_type,
+      kv_unified: true, no_extra_bufts: false,
       cache_type_k: cacheType, cache_type_v: cacheType,
     },
     nThreads, nBatch, ctxLen, nGpuLayers,

--- a/src/services/llmHelpers.ts
+++ b/src/services/llmHelpers.ts
@@ -51,17 +51,20 @@ export interface ModelLoadParams {
 
 export function buildModelParams(
   modelPath: string,
-  settings: { nThreads?: number; nBatch?: number; contextLength?: number; flashAttn?: boolean; enableGpu?: boolean; gpuLayers?: number; cacheType?: string },
+  settings: { nThreads?: number; nBatch?: number; contextLength?: number; flashAttn?: boolean; enableGpu?: boolean; gpuLayers?: number; cacheType?: string; inferenceBackend?: string },
 ): ModelLoadParams {
   const nThreads = settings.nThreads || getOptimalThreadCount();
   const nBatch = settings.nBatch || getOptimalBatchSize();
   const ctxLen = settings.contextLength || APP_CONFIG.maxContextLength;
   const useFlashAttn = settings.flashAttn ?? true;
-  const gpuEnabled = settings.enableGpu !== false;
+  // inferenceBackend takes precedence; fall back to legacy enableGpu flag
+  const backend = settings.inferenceBackend;
+  const gpuEnabled = backend ? backend !== 'cpu' : settings.enableGpu !== false;
   const nGpuLayers = gpuEnabled ? (settings.gpuLayers ?? DEFAULT_GPU_LAYERS) : 0;
   // Quantized KV cache requires flash_attn to be enabled.
+  // OpenCL (Adreno) also requires f16 — quantized KV cache causes native crashes.
   const requestedCache = settings.cacheType || (useFlashAttn ? 'q8_0' : 'f16');
-  const needsF16 = !useFlashAttn;
+  const needsF16 = !useFlashAttn || backend === 'opencl';
   const cacheType = needsF16 && requestedCache !== 'f16' ? 'f16' : requestedCache;
   return {
     baseParams: {

--- a/src/services/llmHelpers.ts
+++ b/src/services/llmHelpers.ts
@@ -2,7 +2,7 @@ import { initLlama, LlamaContext } from 'llama.rn';
 import RNFS from 'react-native-fs';
 import { Platform } from 'react-native';
 import { APP_CONFIG } from '../constants';
-import { Message } from '../types';
+import { Message, INFERENCE_BACKENDS } from '../types';
 import { MultimodalSupport, LLMPerformanceStats } from './llmTypes';
 import logger from '../utils/logger';
 
@@ -61,15 +61,15 @@ export function buildModelParams(
   // Use flash_attn_type string API (replaces deprecated flash_attn boolean).
   // OpenCL and HTP backends crash with flash attn on — disable for those.
   // CPU (Android/iOS) and Metal both support it; use 'auto' to let llama.cpp decide.
-  const gpuBackendIncompatible = backend === 'opencl' || backend === 'htp';
+  const gpuBackendIncompatible = backend === INFERENCE_BACKENDS.OPENCL || backend === INFERENCE_BACKENDS.HTP;
   const flash_attn_type = (settings.flashAttn === false || gpuBackendIncompatible) ? 'off' : 'auto';
-  const gpuEnabled = backend ? backend !== 'cpu' : settings.enableGpu !== false;
+  const gpuEnabled = backend ? backend !== INFERENCE_BACKENDS.CPU : settings.enableGpu !== false;
   const nGpuLayers = gpuEnabled ? (settings.gpuLayers ?? DEFAULT_GPU_LAYERS) : 0;
-  // Quantized KV cache requires flash_attn to be effective.
-  // OpenCL (Adreno) also requires f16 — quantized KV cache causes native crashes.
   const isFlashAttnEffective = flash_attn_type !== 'off';
   const requestedCache = settings.cacheType || (isFlashAttnEffective ? 'q8_0' : 'f16');
-  const needsF16 = !isFlashAttnEffective || backend === 'opencl';
+  // OpenCL requires f16 KV cache — quantized cache causes native crashes on Adreno.
+  // HTP and CPU can use quantized cache regardless of flash attention state.
+  const needsF16 = backend === INFERENCE_BACKENDS.OPENCL;
   const cacheType = needsF16 && requestedCache !== 'f16' ? 'f16' : requestedCache;
   return {
     baseParams: {

--- a/src/services/tools/registry.ts
+++ b/src/services/tools/registry.ts
@@ -5,13 +5,13 @@ export const AVAILABLE_TOOLS: ToolDefinition[] = [
     id: 'web_search',
     name: 'web_search',
     displayName: 'Web Search',
-    description: 'Search the web for current information',
+    description: 'Search the web',
     icon: 'globe',
     requiresNetwork: true,
     parameters: {
       query: {
         type: 'string',
-        description: 'The search query',
+        description: 'Search query',
         required: true,
       },
     },
@@ -20,12 +20,12 @@ export const AVAILABLE_TOOLS: ToolDefinition[] = [
     id: 'calculator',
     name: 'calculator',
     displayName: 'Calculator',
-    description: 'Evaluate mathematical expressions',
+    description: 'Evaluate math expressions',
     icon: 'hash',
     parameters: {
       expression: {
         type: 'string',
-        description: 'The mathematical expression to evaluate',
+        description: 'Math expression',
         required: true,
       },
     },
@@ -34,12 +34,12 @@ export const AVAILABLE_TOOLS: ToolDefinition[] = [
     id: 'get_current_datetime',
     name: 'get_current_datetime',
     displayName: 'Date & Time',
-    description: 'Get the current date and time',
+    description: 'Get current date and time',
     icon: 'clock',
     parameters: {
       timezone: {
         type: 'string',
-        description: 'IANA timezone (e.g. America/New_York). Defaults to device timezone.',
+        description: 'IANA timezone, e.g. America/New_York',
       },
     },
   },
@@ -47,12 +47,12 @@ export const AVAILABLE_TOOLS: ToolDefinition[] = [
     id: 'get_device_info',
     name: 'get_device_info',
     displayName: 'Device Info',
-    description: 'Get device hardware information',
+    description: 'Get device hardware info',
     icon: 'smartphone',
     parameters: {
       info_type: {
         type: 'string',
-        description: 'Type of info to retrieve',
+        description: 'Info type',
         enum: ['battery', 'storage', 'memory', 'all'],
       },
     },
@@ -61,12 +61,12 @@ export const AVAILABLE_TOOLS: ToolDefinition[] = [
     id: 'search_knowledge_base',
     name: 'search_knowledge_base',
     displayName: 'Knowledge Base',
-    description: 'Search the project knowledge base for information from uploaded documents',
+    description: 'Search uploaded project documents',
     icon: 'book-open',
     parameters: {
       query: {
         type: 'string',
-        description: 'The search query to find relevant information',
+        description: 'Search query',
         required: true,
       },
     },
@@ -75,13 +75,13 @@ export const AVAILABLE_TOOLS: ToolDefinition[] = [
     id: 'read_url',
     name: 'read_url',
     displayName: 'URL Reader',
-    description: 'Fetch and read the content of a web page',
+    description: 'Fetch and read a web page',
     icon: 'link',
     requiresNetwork: true,
     parameters: {
       url: {
         type: 'string',
-        description: 'The URL to fetch and read',
+        description: 'URL to fetch',
         required: true,
       },
     },
@@ -120,29 +120,6 @@ export function buildToolSystemPromptHint(enabledToolIds: string[]): string {
   const enabledTools = AVAILABLE_TOOLS.filter(t => enabledToolIds.includes(t.id));
   if (enabledTools.length === 0) return '';
 
-  const toolList = enabledTools
-    .map(t => `- ${t.name}: ${t.description}`)
-    .join('\n');
-
-  const enabledNames = new Set(enabledTools.map(t => t.name));
-
-  const hints: string[] = [];
-  if (enabledNames.has('web_search')) {
-    hints.push('- The user asks about recent events, real-time data, or current news — use web_search');
-    hints.push('- The user asks for specific facts you cannot reliably answer from training data — use web_search');
-    hints.push('- The user asks you to look up or research a specific entity (company, person, product) — use web_search');
-  }
-  if (enabledNames.has('read_url')) {
-    hints.push('- The user provides a URL — use read_url');
-  }
-  if (enabledNames.has('calculator')) {
-    hints.push('- The user asks for calculations — use calculator');
-  }
-  if (enabledNames.has('get_current_datetime')) {
-    hints.push('- The user asks about the current time or date — use get_current_datetime');
-  }
-
-  const hintsBlock = hints.length > 0 ? `\n\nIMPORTANT: You MUST use the appropriate tool when:\n${hints.join('\n')}\nDo NOT say you cannot help or lack internet access. USE your tools instead.` : '';
-
-  return `\n\nYou have access to the following tools and MUST use them proactively:\n${toolList}${hintsBlock}`;
+  const toolList = enabledTools.map(t => `- ${t.name}: ${t.description}`).join('\n');
+  return `\n\nTools available:\n${toolList}\nUse them when relevant.`;
 }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -108,7 +108,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   maxTokens: 1024,
   topP: 0.9,
   repeatPenalty: 1.1,
-  contextLength: 2048,
+  contextLength: 4096,
   nThreads: 4,
   nBatch: 512,
   imageGenerationMode: 'auto' as ImageGenerationMode,

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -109,7 +109,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   topP: 0.9,
   repeatPenalty: 1.1,
   contextLength: 4096,
-  nThreads: 4,
+  nThreads: 0,
   nBatch: 512,
   imageGenerationMode: 'auto' as ImageGenerationMode,
   autoDetectMethod: 'pattern' as AutoDetectMethod,
@@ -170,6 +170,11 @@ function migratePersistedState(persistedState: any, currentState: AppState): App
   if (merged.checklistDismissed && merged.onboardingChecklist &&
     !Object.values(merged.onboardingChecklist).every(Boolean)) merged.checklistDismissed = false;
   migrateEnabledTools(merged);
+  // nThreads: 4 was the old hard-coded default (before the 0 = auto sentinel).
+  // Migrate it to 0 so users get hardware-appropriate thread counts on next load.
+  if (merged.settings?.nThreads === 4) {
+    merged.settings = { ...merged.settings, nThreads: 0 };
+  }
   return merged as AppState;
 }
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { DeviceInfo, DownloadedModel, ModelRecommendation, ONNXImageModel, ImageGenerationMode, AutoDetectMethod, ModelLoadingStrategy, CacheType, InferenceBackend, GeneratedImage, PersistedDownloadInfo } from '../types';
+import { DeviceInfo, DownloadedModel, ModelRecommendation, ONNXImageModel, ImageGenerationMode, AutoDetectMethod, ModelLoadingStrategy, CacheType, InferenceBackend, INFERENCE_BACKENDS, GeneratedImage, PersistedDownloadInfo } from '../types';
 
 type DownloadProgressInfo = { progress: number; bytesDownloaded: number; totalBytes: number; reason?: string };
 
@@ -123,7 +123,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   enhanceImagePrompts: false,
   modelLoadingStrategy: 'performance' as ModelLoadingStrategy,
   enableGpu: Platform.OS === 'ios',
-  inferenceBackend: Platform.OS === 'ios' ? 'metal' : 'cpu' as InferenceBackend,
+  inferenceBackend: Platform.OS === 'ios' ? INFERENCE_BACKENDS.METAL : INFERENCE_BACKENDS.CPU,
   gpuLayers: 99,
   flashAttn: true,
   cacheType: 'q8_0' as CacheType,
@@ -153,7 +153,7 @@ function migratePersistedState(persistedState: any, currentState: AppState): App
   if (persistedState?.settings && !persistedState.settings.inferenceBackend) {
     merged.settings = {
       ...merged.settings,
-      inferenceBackend: Platform.OS === 'ios' ? 'metal' : 'cpu',
+      inferenceBackend: Platform.OS === 'ios' ? INFERENCE_BACKENDS.METAL : INFERENCE_BACKENDS.CPU,
     };
   }
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { DeviceInfo, DownloadedModel, ModelRecommendation, ONNXImageModel, ImageGenerationMode, AutoDetectMethod, ModelLoadingStrategy, CacheType, GeneratedImage, PersistedDownloadInfo } from '../types';
+import { DeviceInfo, DownloadedModel, ModelRecommendation, ONNXImageModel, ImageGenerationMode, AutoDetectMethod, ModelLoadingStrategy, CacheType, InferenceBackend, GeneratedImage, PersistedDownloadInfo } from '../types';
 
 type DownloadProgressInfo = { progress: number; bytesDownloaded: number; totalBytes: number; reason?: string };
 
@@ -22,6 +22,7 @@ type AppSettings = {
   enableGpu: boolean; gpuLayers: number; flashAttn: boolean;
   cacheType: CacheType; showGenerationDetails: boolean; enabledTools: string[];
   thinkingEnabled: boolean;
+  inferenceBackend: InferenceBackend;
 };
 
 type ThemeMode = 'system' | 'light' | 'dark';
@@ -122,6 +123,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   enhanceImagePrompts: false,
   modelLoadingStrategy: 'performance' as ModelLoadingStrategy,
   enableGpu: Platform.OS === 'ios',
+  inferenceBackend: Platform.OS === 'ios' ? 'metal' : 'cpu' as InferenceBackend,
   gpuLayers: 99,
   flashAttn: true,
   cacheType: 'q8_0' as CacheType,
@@ -148,6 +150,13 @@ function migratePersistedState(persistedState: any, currentState: AppState): App
   if (persistedState?.settings && !persistedState.settings.cacheType) {
     merged.settings = { ...merged.settings, cacheType: persistedState.settings.flashAttn ? 'q8_0' : 'f16', flashAttn: true };
   }
+  if (persistedState?.settings && !persistedState.settings.inferenceBackend) {
+    merged.settings = {
+      ...merged.settings,
+      inferenceBackend: Platform.OS === 'ios' ? 'metal' : 'cpu',
+    };
+  }
+
   if (typeof merged.imageModelDownloadId === 'number') {
     const ids: Record<string, number> = {};
     if (Array.isArray(merged.imageModelDownloading) && merged.imageModelDownloading.length > 0) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -281,6 +281,7 @@ export type ImageGenerationMode = 'auto' | 'manual';
 export type AutoDetectMethod = 'pattern' | 'llm';
 export type ModelLoadingStrategy = 'performance' | 'memory';
 export type CacheType = 'f16' | 'q8_0' | 'q4_0';
+export type InferenceBackend = 'cpu' | 'opencl' | 'htp' | 'metal';
 /** 'auto' = smart detect, 'force' = always generate image, 'disabled' = never */
 export type ImageModeState = 'auto' | 'force' | 'disabled';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -282,6 +282,12 @@ export type AutoDetectMethod = 'pattern' | 'llm';
 export type ModelLoadingStrategy = 'performance' | 'memory';
 export type CacheType = 'f16' | 'q8_0' | 'q4_0';
 export type InferenceBackend = 'cpu' | 'opencl' | 'htp' | 'metal';
+export const INFERENCE_BACKENDS = {
+  CPU: 'cpu' as InferenceBackend,
+  OPENCL: 'opencl' as InferenceBackend,
+  HTP: 'htp' as InferenceBackend,
+  METAL: 'metal' as InferenceBackend,
+} as const;
 /** 'auto' = smart detect, 'force' = always generate image, 'disabled' = never */
 export type ImageModeState = 'auto' | 'force' | 'disabled';
 


### PR DESCRIPTION
## Summary

This PR enables Hexagon HTP/NPU acceleration for text inference on Qualcomm Snapdragon devices and delivers a set of performance improvements and fixes that reduce TTFT and eliminate redundant model initialisation overhead.

### Core feature: HTP/NPU acceleration
- Replace the binary GPU toggle with an explicit inference backend selector: **CPU / OpenCL / HTP / Metal**
- HTP routes inference to the Snapdragon Hexagon NPU via `llama.rn`'s `devices: ['HTP0']` parameter, with QNN variant detection (8gen2 / 8gen1 / min) for correct driver selection
- HTP init timeout raised from 8s → 30s to accommodate NPU warm-up
- KV cache no longer forced to f16 on HTP — quantized cache (q8_0) is supported
- 'Needs repair' badge shown for vision models with a broken mmproj link

### Performance improvements
- **Default context raised 2048 → 4096**: the old default triggered a two-phase init (load, detect, release, reload), doubling first-load time on Android CPU. Starting at 4096 means the scaling check is always satisfied and the model loads exactly once
- **Tool schema thinning**: trimmed all tool description strings and collapsed the text hint to reduce the Jinja-rendered schema block from ~1723 tokens to a fraction of that, cutting TTFT on first-message tool calls dramatically
- **Skip double tool injection**: when the loaded model's Jinja template natively handles tool schemas, the redundant text hint is skipped. Falls back to text hint for models without Jinja tool-calling support
- **Dynamic thread scaling**: `nThreads = 0` is now the sentinel for "auto" — substitutes `hardwareService.getRecommendedThreadCount()` at load time. Any explicit user choice (1–12) is passed through unchanged. Migration converts the old hard-coded default of 4 → 0 on upgrade

### Correctness fixes
- **Flash attention**: restored for Android CPU — only disabled for OpenCL and HTP backends where it causes crashes with quantized KV cache
- **GPU layer caps**: HTP and OpenCL both now respect the RAM-based safety floor from `getGpuLayersForDevice` (0 on ≤4GB devices) instead of unconditionally overriding `safeGpuLayers`
- **OpenCL detection**: narrowed to `qcom` (Adreno) and `mali` only — `arm` was a false positive matching the CPU architecture string `arm64-v8a`, not the GPU vendor
- **InferenceBackend constants**: replaced all scattered `'cpu'/'opencl'/'htp'/'metal'` string literals with `INFERENCE_BACKENDS.*` constants across services, stores, hooks, and UI components
- **Download watchdog**: re-enqueue downloads stuck in `PAUSED_WAITING_TO_RETRY` with a freshly resolved URL after 2 watchdog cycles — prevents infinite pause loops caused by expired signed CDN URLs (e.g. `cas-bridge.xethub.hf.co`)

## Test plan
- [ ] Load a text model on a Snapdragon 8 Gen 2 device, switch to HTP backend, verify NPU is used and TTFT is fast
- [ ] Load a text model on CPU, verify flash attention is active and TTFT is not regressed vs baseline
- [ ] Verify first model load completes in a single init pass (no double-init in logs)
- [ ] Send a message with tools enabled — verify tool schemas are not double-injected (check token count in debug sheet)
- [ ] Set nThreads explicitly via slider (e.g. 2), reload model, verify 2 threads are used, not the recommended count
- [ ] On a device with ≤4GB RAM, confirm HTP and OpenCL backends set gpuLayers = 0
- [ ] Start a large model download, simulate a stale CDN URL scenario, verify watchdog re-enqueues with fresh URL
- [ ] Run full test suite: `npm test` — 5155 passing, 2 pre-existing failures (DebugSheet, DocumentService)