### PR TITLE
feat(website): Jekyll docs site with guides, essays, early access, and brand voice

### DIFF
--- a/docs/brand_tone_voice.md
+++ b/docs/brand_tone_voice.md
@@ -1,0 +1,401 @@
+# Off Grid -- Brand Voice & Tone
+
+---
+
+## In One Sentence
+
+Off Grid sounds like someone who built this because they genuinely believe you deserve better -- handing you something for free, no strings, no data harvested, no angle. Here, take this. You're better off with it.
+
+---
+
+## The Core Disposition
+
+Off Grid isn't a product trying to win a market. It's a thing built for the right reasons, handed over to people who deserve it.
+
+The voice carries that. It doesn't sell. It gives. It doesn't ask you to trust it -- it shows you the mechanism and lets you verify. It doesn't talk about privacy as a feature -- it talks about it as something that was taken from you that you can have back.
+
+Think: a friend who spent a year building something in their spare time because they were fed up with the alternative, and now they're just happy to share it. No pitch. No upsell. "Here, this is for you. It does what it says. Go use it."
+
+That's the energy in every word Off Grid writes.
+
+---
+
+## Voice Attributes
+
+### 1. Generous, not transactional
+
+Off Grid asks nothing from you. No account. No API key. No data. The voice reflects this -- it gives without expecting anything back. It doesn't ask you to share, subscribe, follow, or review. It just hands you the thing.
+
+This means copy never implies a trade. No "get access to," no "unlock," no implied paywall. The frame is always: here's what you have.
+
+```
+"Download it. Run it offline. That's it. No account, no API key, nothing we're holding back."
+"Sign up to access the full model library."  [Wrong -- we don't do this]
+```
+
+### 2. Proof-first, not promise-first
+
+Every claim has a fact behind it. Never say "fast" when you can say "15-30 tok/s on flagship devices." Never say "private" when you can say "the model runs in your phone's RAM, inference happens on your CPU and GPU, nothing is sent anywhere."
+
+Specificity is how you earn trust without asking for it.
+
+```
+"Phi-3 Mini runs at ~28 tok/s on a Snapdragon 8 Gen 3. Llama 3.1 8B runs at ~12 tok/s on the same chip."
+"On-device. Offline. Zero data leaves your phone. Not a marketing claim -- airplane mode works."
+```
+
+```
+"Blazing fast AI right on your device."  [Vague, promotional, earns nothing]
+```
+
+### 3. Privacy as a right being returned, not a feature being sold
+
+You've been using AI that logs everything. Your prompts. The time. Your account. Stored indefinitely, used to train models, subject to law enforcement requests. That data is yours and it's been taken.
+
+Off Grid gives it back. The voice names this plainly, without drama. Not "we value your privacy" -- that's what every company that sells your data says. Instead: here's what actually happens when you use this, mechanically, in plain language. You can verify it yourself.
+
+Don't moralize. Don't editorialize. State the fact and let it land.
+
+```
+"When you run a query on ChatGPT, it's logged on a server. Your prompt, the time, your account. With Off Grid, the model runs in your phone's memory. Nothing is sent anywhere. Ever."
+```
+
+```
+"In a world where Big Tech is harvesting your data..."  [Preachy -- the user already knows]
+"We take your privacy seriously."  [What every surveillance product says]
+```
+
+### 4. Respect the person reading
+
+The Off Grid user chose this deliberately. They know what an LLM is. They've heard of Ollama. They opted out of the default. Don't explain concepts they already understand. Don't justify privacy as a value -- they already hold it.
+
+Give them exactly what they need to act, nothing more.
+
+```
+"Tap Download. The GGUF lands in app storage. First load takes 5-15 seconds -- the model is being mapped into RAM."
+```
+
+```
+"So what is a GGUF file? Great question! It's a quantized model format that allows..."  [Condescending, they don't need this]
+```
+
+### 5. Specific, not vague
+
+No fuzzy qualifiers. If the answer depends on the device, name the device. If it depends on quantization, name the quantization. "It depends" is only acceptable followed immediately by the variables.
+
+```
+"Llama 3.1 8B Q4_K_M needs ~5.5GB RAM. iPhone 15 Pro has 8GB -- runs fine. iPhone 12 has 4GB -- use Phi-3 Mini instead."
+```
+
+```
+"Performance may vary depending on your device and model choice."  [Useless, tells them nothing]
+```
+
+### 6. No angle, no ask
+
+Off Grid has no ulterior motive and the voice reflects that. No dark patterns, no nudges toward premium, no FOMO. When something is free it's just free. When something doesn't work on a device, say so clearly instead of softening it to protect a conversion.
+
+The reader should always feel like Off Grid is on their side, not managing them.
+
+```
+"Your phone has 4GB RAM. Llama 3.1 8B won't run well on it. Phi-3 Mini or Llama 3.2 3B will."
+"For the best experience, consider upgrading to a device with more RAM."  [Wrong -- just tell them the truth]
+```
+
+---
+
+## The Emotional Arc
+
+Every piece of Off Grid content follows the same arc:
+
+**Recognition -> Return -> Freedom**
+
+1. **Recognition**: Name what's been happening. "Every query you've sent to a cloud AI has been logged, stored, and used."
+2. **Return**: Show what's being given back. "With Off Grid, the model runs on your phone. Nothing leaves it."
+3. **Freedom**: Hand them the capability without condition. "Go offline. It still works. It's yours."
+
+This isn't about doubt and resolution like a pricing tool. It's about something that was taken being handed back. The tone is quiet, clear, and generous -- not triumphant or righteous.
+
+---
+
+## Tone Shifts
+
+The voice stays constant. The tone shifts by context.
+
+### Landing Page / Website
+**Tone: Quiet generosity**
+
+Short sentences. State what it does, then prove it. The reader should feel like they found something real -- not a product launch, a thing that actually works.
+
+```
+"Chat. Generate images. Use tools. See. Listen.
+All on your phone. All offline. Zero data leaves your device.
+
+No account. No API key. No subscription. Download and go."
+```
+
+### In-Product / UI Copy
+**Tone: Terminal precision**
+
+Minimal words. Labels are short and uppercase. Explanations appear on demand, never cluttering the primary view. The interface should feel like the answer is already there.
+
+```
+Label: "ACTIVE MODEL"
+Value: "Llama 3.2 3B"
+Detail: "12.4 tok/s -- Q4_K_M -- 2.1GB"
+Status: "READY"
+```
+
+### Guides / Docs
+**Tone: Direct handoff**
+
+The reader has the app open. Get them to the thing. State requirements before steps. One action per step.
+
+```
+"Step 1 -- Download Off Grid
+iOS: requires iPhone 12 or newer, 4GB RAM.
+Android: requires Android 10+, 4GB RAM."
+```
+
+### Onboarding
+**Tone: Here, take this**
+
+First launch. One job: first inference. Don't introduce features -- show one path, make it obvious.
+
+```
+"Pick a model. Download it. Load it. Type something.
+That's all there is."
+```
+
+### Error States / Empty States
+**Tone: Honest and useful**
+
+Say what happened. Say what to do. Never blame the user. Never be vague.
+
+```
+"Not enough free RAM to load this model (~5.5GB needed). Close background apps and try again -- or switch to Phi-3 Mini at 2GB."
+"Error loading model. Please try again."  [Useless]
+
+"No models downloaded yet. Phi-3 Mini is a good start -- 2GB, runs on any modern phone, no account needed."
+"No models found."  [Incomplete]
+```
+
+---
+
+## Language Rules
+
+### Always
+- Use "you/your" -- the user has this, it belongs to them
+- State device requirements before recommending a model
+- Use present tense ("the model runs in RAM") not future ("the model will run")
+- File sizes always with units: 2.1GB, not "2.1"
+- Speeds always with units: 12 tok/s
+
+### Never
+- Exclamation marks in product copy
+- "Unlock," "supercharge," "game-changing," "revolutionary," "next-generation," "cutting-edge"
+- Implying anything is held back or gated
+- Privacy framed as a selling point -- frame it as a mechanism or a right
+- Em dashes or double hyphens -- single hyphens only
+- Curly quotes or special unicode characters
+- "Genuinely," "honestly," "straightforward"
+- Only use characters available on a standard keyboard
+
+### Never (AI slop - flags as machine-generated)
+Single words to cut on sight:
+- "delve" / "delves into"
+- "crucial" / "pivotal" / "vital"
+- "meticulous" / "intricate"
+- "tapestry" / "testament" / "landscape"
+- "underscore" / "underscores"
+- "bolstered" / "garnered"
+- "enduring" / "vibrant" / "rich" (as vague intensifiers)
+- "align with" / "resonate with"
+- "foster" / "cultivate"
+- "showcase" / "highlight" (as verbs in prose)
+- "enhance" / "enhancing"
+- "leverage" (use "use")
+- "robust" (use a specific number instead)
+- "comprehensive" (say what it actually covers)
+- "valuable insights" (say what the insight is)
+- "dive in" / "let's explore" / "in this guide we'll"
+- "seamlessly"
+- "empower" / "empowers"
+
+Structural habits to kill:
+- Rule of three -- two items or four, never exactly three adjectives in a row
+- "Not just X, but Y" constructions
+- "It's not X, it's Y" constructions
+- Throat-clearing openers ("Great question," "Absolutely," "Certainly")
+- Conclusion summaries that restate what was just said
+- Bolding random phrases mid-paragraph for "emphasis"
+- Every section getting a bold header when prose would do
+- Lists of exactly three bullet points as a default
+
+Phrases that read as AI-generated:
+- "serves as" (say "is")
+- "stands as" (say "is")
+- "represents a" (say "is")
+- "marks a turning point"
+- "is a testament to"
+- "plays a crucial/pivotal/vital role"
+- "it is worth noting that"
+- "it goes without saying"
+- "at the end of the day"
+- "in today's landscape"
+- "in the ever-evolving"
+- "moving forward" / "going forward"
+
+---
+
+## Technical Terminology
+
+Use precise names. Not marketing language.
+
+| Term | How Off Grid uses it |
+|---|---|
+| GGUF | "The model format -- download and load directly" |
+| Quantization | "Q4_K_M is the balance point: smaller file, minimal quality loss" |
+| Tokens per second | "28 tok/s -- the speed you'll feel in conversation" |
+| NPU / Neural Engine | "Hardware-accelerated inference -- faster and cooler than CPU-only" |
+| Core ML | "iOS model format -- needed for NPU acceleration on iPhone" |
+| Ollama / LM Studio | "Run bigger models from your desktop, over LAN" |
+| Q-levels | "Q2_K: smallest, most degraded. Q8_0: near-lossless, largest." |
+
+Name models precisely. Include size and quantization when recommending.
+
+```
+"Llama 3.2 3B Q4_K_M -- ~2GB, 18 tok/s on iPhone 15 Pro"
+"Phi-4 Mini -- runs on any modern phone, 4GB RAM minimum"
+"Stable Diffusion 1.5 -- on-device image gen, 5-10s on Snapdragon NPU"
+```
+
+---
+
+## Content Structure
+
+### The Off Grid Guide Format
+
+**1. One sentence on what this gets you**
+What the user can do when they're done.
+
+**2. Requirements upfront**
+Device, OS version, RAM, storage. Before any steps, not buried at the end.
+
+**3. Numbered steps, one action each**
+Don't combine download + load into one step. One action per line.
+
+**4. What success looks like**
+Tell them exactly what they'll see. "You'll see READY under the model name."
+
+**5. One or two next steps** (optional)
+Not a feature tour -- just the obvious next thing.
+
+### Example Headlines
+
+```
+"Run your first local AI model in 5 minutes"
+"Which model should you use? Here's how to decide."
+"Stable Diffusion on Android -- on-device image generation, no cloud."
+"Llama 3.1 8B vs Phi-4 Mini -- when to use which."
+"How to connect Off Grid to your Ollama server at home."
+"iPhone 15 Pro vs iPhone 12 -- what on-device AI actually looks like."
+```
+
+### Headlines That Would Be Wrong
+
+```
+"Unlock the power of private AI"  [implies something held back]
+"Why Off Grid is the best AI app in 2026"  [no proof, wrong energy]
+"10 reasons to switch from ChatGPT"  [listicle, promotional]
+"The Ultimate Guide to On-Device AI"  [generic filler]
+"AI has never been this private"  [unverifiable]
+```
+
+---
+
+## Microcopy Patterns
+
+### Buttons
+```
+Primary: "Download"
+Secondary: "Load Model"
+Tertiary: "View Details"
+Destructive: "Delete"
+```
+
+### Model States
+```
+Not downloaded: "2.1GB -- tap to download"
+Downloading: "Downloading... 847MB / 2.1GB"
+Downloaded, not loaded: "READY TO LOAD"
+Loaded: "ACTIVE -- 12.4 tok/s"
+Loading: "Loading into RAM..."
+```
+
+### Reassurance Lines
+```
+"No account. No API key. No internet after setup."
+"Works in airplane mode."
+"Nothing you type leaves your phone."
+```
+
+### Empty States
+```
+No models: "Nothing downloaded yet. Phi-3 Mini is 2GB and runs on any modern phone -- good place to start."
+No conversations: "No conversations yet. Load a model and start one."
+No search results: "Nothing matches that filter. Try broadening it."
+```
+
+### Error States
+```
+Insufficient RAM: "Not enough free RAM (~5.5GB needed). Close background apps, or try a smaller model -- Phi-3 Mini runs in 2GB."
+Download failed: "Download interrupted. Check your connection and try again."
+Load failed: "Load failed -- the file may be corrupted. Delete it and re-download."
+```
+
+### Success States
+```
+"ACTIVE -- 12.4 tok/s"
+"Download complete. Tap Load."
+"Generated in 6.2s"
+```
+
+---
+
+## Brand Taglines
+
+Primary: **"Private AI. No cloud. No compromise."**
+
+Alternatives:
+- "Run AI on your phone. Nothing leaves it."
+- "The Swiss Army Knife of On-Device AI."
+- "AI that stays on your device."
+- "No cloud. No account. No compromise."
+- "Yours. Offline. Always."
+
+---
+
+## Quality Checklist
+
+Before publishing any Off Grid content:
+
+- [ ] Does it feel like something being given, not sold?
+- [ ] Are privacy claims stated as mechanisms ("the model runs in RAM"), not promises ("we value your privacy")?
+- [ ] Does every performance claim include a number and a device?
+- [ ] Are device requirements stated before steps?
+- [ ] Does it follow the recognition -> return -> freedom arc?
+- [ ] Is every "it depends" followed immediately by what it depends on?
+- [ ] Can the reader do the thing without googling anything?
+- [ ] Does it sound like someone who built this because they wanted to, not to sell it?
+- [ ] Are there zero exclamation marks in product copy?
+- [ ] Does every sentence pass the "would a human actually write this" test?
+- [ ] Are there zero instances of: delve, crucial, pivotal, tapestry, testament, underscore, bolstered, garnered, meticulous, vibrant, landscape, foster, cultivate, leverage, robust, comprehensive, seamlessly, empower?
+- [ ] Are there zero "not just X but Y" constructions?
+- [ ] Are there zero "serves as" / "stands as" / "represents a" substitutions for "is"?
+- [ ] Does it avoid restating the conclusion at the end?
+- [ ] Is nothing implied to be locked, premium, or held back?
+
+---
+
+*"Here. It's yours. It runs on your phone and nowhere else."*

--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -208,37 +208,39 @@
 
     <!-- Main -->
     <div class="main">
-      {% if page.parent %}
-        <nav class="breadcrumb" aria-label="breadcrumb">
-          <a href="{{ '/' | relative_url }}">Docs</a>
-          <span aria-hidden="true">›</span>
-          {% assign parent_page = site.pages | where: "title", page.parent | first %}
-          {% if parent_page %}
-            <a href="{{ parent_page.url | relative_url }}">{{ page.parent }}</a>
+      <div class="content-topbar">
+        {% if page.parent %}
+          <nav class="breadcrumb" aria-label="breadcrumb">
+            <a href="{{ '/' | relative_url }}">Docs</a>
             <span aria-hidden="true">›</span>
-          {% endif %}
-          <span>{{ page.title }}</span>
-        </nav>
-      {% endif %}
+            {% assign parent_page = site.pages | where: "title", page.parent | first %}
+            {% if parent_page %}
+              <a href="{{ parent_page.url | relative_url }}">{{ page.parent }}</a>
+              <span aria-hidden="true">›</span>
+            {% endif %}
+            <span>{{ page.title }}</span>
+          </nav>
+        {% else %}
+          <span></span>
+        {% endif %}
+
+        <div class="essay-reactions" id="essayReactions">
+          <span class="essay-reactions-label">Did this land?</span>
+          <div class="essay-reactions-buttons">
+            <button class="reaction-btn" id="reaction-agree" data-reaction="agree" aria-label="Agree with this">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z"/><path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/></svg>
+            </button>
+            <button class="reaction-btn" id="reaction-disagree" data-reaction="disagree" aria-label="Disagree with this">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3H10z"/><path d="M17 2h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/></svg>
+            </button>
+          </div>
+          <span class="essay-reaction-thanks" id="reactionThanks" hidden></span>
+        </div>
+      </div>
 
       <article class="content" data-pagefind-body>
         {{ content }}
       </article>
-
-      <div class="essay-reactions" id="essayReactions">
-        <span class="essay-reactions-label">Did this land?</span>
-        <div class="essay-reactions-buttons">
-          <button class="reaction-btn" id="reaction-agree" data-reaction="agree" aria-label="Agree with this">
-            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z"/><path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/></svg>
-            <span>Agree</span>
-          </button>
-          <button class="reaction-btn" id="reaction-disagree" data-reaction="disagree" aria-label="Disagree with this">
-            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3H10z"/><path d="M17 2h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/></svg>
-            <span>Disagree</span>
-          </button>
-        </div>
-        <span class="essay-reaction-thanks" id="reactionThanks" hidden></span>
-      </div>
 
       {% if page.parent %}
         {% assign siblings = site.pages | where: "parent", page.parent | sort: "nav_order" %}

--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -325,9 +325,9 @@
       var children = item.nextElementSibling;
       if (!children || !children.classList.contains('nav-children')) return;
       item.addEventListener('click', function(e) {
+        e.preventDefault();
         var isOpen = children.classList.contains('open');
         if (isOpen) {
-          e.preventDefault();
           children.classList.remove('open');
           item.classList.remove('section-open');
         } else {

--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -576,7 +576,11 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
 
 .early-access-form-section { margin: 8px 0 32px; }
 .early-access-form-section h2 { margin-top: 0; }
-.early-access-form { margin-top: 20px; max-width: 440px; }
+.early-access-form { margin-top: 20px; max-width: 480px; }
+.ea-form-top { margin-bottom: 0; }
+.ea-inline-group { display: flex; gap: 8px; }
+.ea-inline-group .ea-input { flex: 1; }
+.ea-inline-group .ea-submit { white-space: nowrap; flex-shrink: 0; margin-top: 0; width: auto; padding: 10px 20px; }
 .ea-field-group { margin-bottom: 16px; }
 .ea-label { display: block; font-size: 0.8125rem; font-weight: 600; color: var(--text-secondary); margin-bottom: 7px; }
 .ea-input {

--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -259,7 +259,6 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
   gap: 6px;
   font-size: 0.8125rem;
   color: var(--text-muted);
-  margin-bottom: 32px;
 }
 .breadcrumb a { color: var(--text-muted); text-decoration: none; }
 .breadcrumb a:hover { color: var(--text-primary); }
@@ -477,35 +476,42 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
 #pagefind-search .pagefind-ui__result-excerpt { font-family: var(--font) !important; font-size: 0.8125rem !important; color: var(--text-muted) !important; margin-top: 3px !important; line-height: 1.5 !important; }
 #pagefind-search mark { background: var(--accent-subtle); color: var(--accent); border-radius: 2px; padding: 0 2px; }
 
+/* ─── Content topbar (breadcrumb + reactions row) ───────────────────────────── */
+.content-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 32px;
+  min-height: 32px;
+}
+
 /* ─── Essay Reactions ───────────────────────────────────────────────────────── */
 .essay-reactions {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-top: 48px;
-  padding-top: 24px;
-  border-top: 1px solid var(--border);
-  flex-wrap: wrap;
+  gap: 8px;
+  flex-shrink: 0;
 }
 .essay-reactions-label {
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
+  white-space: nowrap;
 }
 .essay-reactions-buttons {
   display: flex;
-  gap: 8px;
+  gap: 4px;
 }
 .reaction-btn {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 7px 14px;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
   background: var(--bg-subtle);
   border: 1px solid var(--border);
-  border-radius: 20px;
-  font-family: var(--font);
-  font-size: 0.8125rem;
-  color: var(--text-secondary);
+  border-radius: 6px;
+  color: var(--text-muted);
   cursor: pointer;
   transition: border-color 0.15s, background 0.15s, color 0.15s;
 }
@@ -520,8 +526,9 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
   color: var(--accent);
 }
 .essay-reaction-thanks {
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
+  white-space: nowrap;
 }
 
 /* ─── Early Access Page ─────────────────────────────────────────────────────── */

--- a/website/early-access.md
+++ b/website/early-access.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Early Access
-nav_order: 6
+nav_order: 4
 description: Get early access to Off Grid nightly builds. Be the first to test new features of the personal AI OS - and get 6 months free when you ship.
 ---
 

--- a/website/early-access.md
+++ b/website/early-access.md
@@ -2,67 +2,22 @@
 layout: default
 title: Early Access
 nav_order: 4
-description: Get early access to Off Grid nightly builds. Be the first to test new features of the personal AI OS - and get 6 months free when you ship.
+description: Join the waitlist for early access to Off Grid. Be among the first to run the personal AI OS, shape what gets built, and get 6 months free.
 ---
 
 <div class="early-access-hero">
-  <div class="early-access-badge">Nightly Builds</div>
-  <h1>Be First.<br>Test Everything.</h1>
-  <p class="early-access-sub">Join the early access programme and get nightly builds of Off Grid delivered before anyone else. Shape the personal AI OS. Break things. Tell us what's broken.</p>
+  <div class="early-access-badge">Alpha Access</div>
+  <h1>Run it before<br>anyone else does.</h1>
+  <p class="early-access-sub">We are building a personal AI OS. It runs entirely on your phone. It knows your context. It never leaves your device. A small group of people will get access before it ships publicly. Join the waitlist.</p>
 </div>
 
-<div class="early-access-perks">
-  <div class="perk-card">
-    <div class="perk-icon">
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
-    </div>
-    <div>
-      <div class="perk-title">Nightly Builds</div>
-      <div class="perk-desc">New builds straight from main, every night. Features land in your hands days or weeks before the public release.</div>
-    </div>
-  </div>
-  <div class="perk-card">
-    <div class="perk-icon">
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-    </div>
-    <div>
-      <div class="perk-title">6 Months Free</div>
-      <div class="perk-desc">When the personal AI OS ships, your account is activated for 6 months at no cost. No card required to join.</div>
-    </div>
-  </div>
-  <div class="perk-card">
-    <div class="perk-icon">
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-    </div>
-    <div>
-      <div class="perk-title">Direct Line to the Team</div>
-      <div class="perk-desc">Early testers get a private Slack channel with the core team. File bugs, request features, and watch them get fixed in real time.</div>
-    </div>
-  </div>
-  <div class="perk-card">
-    <div class="perk-icon">
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-    </div>
-    <div>
-      <div class="perk-title">Shape What Gets Built</div>
-      <div class="perk-desc">Your feedback decides what ships next. Early testers have already pushed features into the roadmap. Drop a bug and watch it get fixed.</div>
-    </div>
-  </div>
-</div>
-
----
-
-<div class="early-access-form-section">
-  <h2>Request Access</h2>
-  <p>We roll out builds in batches. Drop your email and we'll send your invite as soon as the next batch opens.</p>
-
+<div class="early-access-form-section ea-form-top">
   <form id="earlyAccessForm" class="early-access-form" novalidate>
-    <div class="ea-field-group">
-      <label for="eaEmail" class="ea-label">Email address</label>
-      <input type="email" id="eaEmail" class="ea-input" placeholder="you@example.com" autocomplete="email" required>
+    <div class="ea-inline-group">
+      <input type="email" id="eaEmail" class="ea-input" placeholder="your@email.com" autocomplete="email" required>
+      <button type="submit" class="ea-submit">Join the waitlist</button>
     </div>
-    <div class="ea-field-group">
-      <label class="ea-label">Platform</label>
+    <div class="ea-field-group" style="margin-top:12px;">
       <div class="ea-platform-toggle">
         <label class="ea-platform-option">
           <input type="radio" name="platform" value="ios" checked>
@@ -84,30 +39,62 @@ description: Get early access to Off Grid nightly builds. Be the first to test n
         </label>
       </div>
     </div>
-    <button type="submit" class="ea-submit">Request early access</button>
     <p class="ea-status" id="eaStatus" aria-live="polite"></p>
   </form>
 </div>
 
 ---
 
-## What nightly builds mean
+<div class="early-access-perks">
+  <div class="perk-card">
+    <div class="perk-icon">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+    </div>
+    <div>
+      <div class="perk-title">Early builds</div>
+      <div class="perk-desc">You get access before the public release. Features land in your hands first. You run things most people have not seen yet.</div>
+    </div>
+  </div>
+  <div class="perk-card">
+    <div class="perk-icon">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+    </div>
+    <div>
+      <div class="perk-title">6 months free</div>
+      <div class="perk-desc">When the personal AI OS ships, early access members get 6 months free. That is the return on putting your name down now.</div>
+    </div>
+  </div>
+  <div class="perk-card">
+    <div class="perk-icon">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+    </div>
+    <div>
+      <div class="perk-title">Direct line to the team</div>
+      <div class="perk-desc">A private channel with the people building it. File a bug and watch it get fixed. Request a feature and see it move up the list.</div>
+    </div>
+  </div>
+  <div class="perk-card">
+    <div class="perk-icon">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+    </div>
+    <div>
+      <div class="perk-title">Shape what gets built</div>
+      <div class="perk-desc">The roadmap moves based on what early users actually run into. Your feedback is not going into a void. It is going into the next build.</div>
+    </div>
+  </div>
+</div>
 
-Nightly builds come straight off the development branch. They contain features that are complete enough to run but not yet through the full QA pass. That means:
+---
 
-- You will see features that do not exist in the public app
-- You will occasionally hit bugs - report them and watch them get fixed fast
-- Build quality improves with every tester who reports back
+## What this is
 
-This is not beta. Beta is polished. Nightly is raw, fast, and real.
+Off Grid today is a powerful on-device AI app. The personal AI OS is the next layer.
 
-## What the personal AI OS is
+It is a system where your AI understands context across every app, every conversation, every device — without a single byte leaving your phone. It knows what you are working on. It knows what you have read. It acts when you ask and stays out of the way when you do not.
 
-Off Grid today is a powerful local AI app. The personal AI OS is the next layer - a system where the AI knows your context across every app, every conversation, every device, without a single byte leaving your phone.
+It does not send your data anywhere. It does not train on your activity. It is entirely yours.
 
-It understands what you're working on, what you've read, what you care about. It acts when you ask, and stays silent when you don't. It does not report home. It does not train on your data. It is entirely yours.
-
-Early testers are the first people outside the team to run it.
+A small number of people will run this before it ships publicly. They will see it break, watch it get fixed, and have a real say in what it becomes. If that is you, put your email in.
 
 <script>
   (function() {
@@ -133,7 +120,7 @@ Early testers are the first people outside the team to run it.
         });
       }
       emailInput.value = '';
-      status.textContent = 'You\'re on the list. We\'ll be in touch when your batch opens.';
+      status.textContent = "You're on the list.";
       status.className = 'ea-status ea-status-success';
       form.querySelector('.ea-submit').disabled = true;
     });

--- a/website/ethos.md
+++ b/website/ethos.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Ethos
-nav_order: 5
+nav_order: 3
 description: Why Off Grid exists. Intelligence should live on the devices you already own - private by architecture, not by policy.
 ---
 

--- a/website/guides/index.md
+++ b/website/guides/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Guides
-nav_order: 3
+nav_order: 5
 has_children: true
 description: Step-by-step guides for running AI locally on your iPhone and Android phone with Off Grid.
 ---

--- a/website/writing/index.md
+++ b/website/writing/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Perspectives
-nav_order: 4
+nav_order: 6
 has_children: true
 description: Essays on the future of personal AI, on-device intelligence, and why the most important software of the next decade runs on hardware you already own.
 ---


### PR DESCRIPTION
## Summary

- Adds a full Jekyll docs site deployed to GitHub Pages at docs.offgridmobileai.co
- 15+ SEO-optimised guides covering iOS/Android setup, LLMs, image gen, vision, voice, tools, and remote servers
- Perspectives section with 19 thought leadership essays written in brand voice across 5 tiers (what, why, who, how, when)
- Ethos page with the Off Grid vision and manifesto
- Early access page with nightly builds sign-up — collects email and platform via PostHog, awards 6 months free on ship
- Dark/light mode, Inter font, pagefind full-text search, page reactions, newsletter capture
- Brand tone and voice doc added to `docs/`
- Cover image asset added to `src/assets/`

## Test plan

- [ ] Site builds via `bundle exec jekyll serve` with no errors
- [ ] All nav links resolve correctly
- [ ] Early access form captures `early_access_signup` event in PostHog on submit
- [ ] Dark mode toggle persists across page loads
- [ ] Search returns results after a pagefind index build
- [ ] CNAME resolves to docs.offgridmobileai.co after GH Pages deploy