### PR TITLE
feat(website): early access waitlist, floating reactions, nav reorder, accordion fix

### DIFF
--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -208,34 +208,30 @@
 
     <!-- Main -->
     <div class="main">
-      <div class="content-topbar">
-        {% if page.parent %}
-          <nav class="breadcrumb" aria-label="breadcrumb">
-            <a href="{{ '/' | relative_url }}">Docs</a>
+      {% if page.parent %}
+        <nav class="breadcrumb" aria-label="breadcrumb">
+          <a href="{{ '/' | relative_url }}">Docs</a>
+          <span aria-hidden="true">›</span>
+          {% assign parent_page = site.pages | where: "title", page.parent | first %}
+          {% if parent_page %}
+            <a href="{{ parent_page.url | relative_url }}">{{ page.parent }}</a>
             <span aria-hidden="true">›</span>
-            {% assign parent_page = site.pages | where: "title", page.parent | first %}
-            {% if parent_page %}
-              <a href="{{ parent_page.url | relative_url }}">{{ page.parent }}</a>
-              <span aria-hidden="true">›</span>
-            {% endif %}
-            <span>{{ page.title }}</span>
-          </nav>
-        {% else %}
-          <span></span>
-        {% endif %}
+          {% endif %}
+          <span>{{ page.title }}</span>
+        </nav>
+      {% endif %}
 
-        <div class="essay-reactions" id="essayReactions">
-          <span class="essay-reactions-label">Did this land?</span>
-          <div class="essay-reactions-buttons">
-            <button class="reaction-btn" id="reaction-agree" data-reaction="agree" aria-label="Agree with this">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z"/><path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/></svg>
-            </button>
-            <button class="reaction-btn" id="reaction-disagree" data-reaction="disagree" aria-label="Disagree with this">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3H10z"/><path d="M17 2h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/></svg>
-            </button>
-          </div>
-          <span class="essay-reaction-thanks" id="reactionThanks" hidden></span>
+      <div class="essay-reactions" id="essayReactions" data-pagefind-ignore>
+        <span class="essay-reactions-label">Did this land?</span>
+        <div class="essay-reactions-buttons">
+          <button class="reaction-btn" id="reaction-agree" data-reaction="agree" aria-label="Agree with this">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z"/><path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/></svg>
+          </button>
+          <button class="reaction-btn" id="reaction-disagree" data-reaction="disagree" aria-label="Disagree with this">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3H10z"/><path d="M17 2h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/></svg>
+          </button>
         </div>
+        <span class="essay-reaction-thanks" id="reactionThanks" hidden></span>
       </div>
 
       <article class="content" data-pagefind-body>

--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -476,21 +476,23 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
 #pagefind-search .pagefind-ui__result-excerpt { font-family: var(--font) !important; font-size: 0.8125rem !important; color: var(--text-muted) !important; margin-top: 3px !important; line-height: 1.5 !important; }
 #pagefind-search mark { background: var(--accent-subtle); color: var(--accent); border-radius: 2px; padding: 0 2px; }
 
-/* ─── Content topbar (breadcrumb + reactions row) ───────────────────────────── */
-.content-topbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 32px;
-  min-height: 32px;
-}
+/* ─── Breadcrumb margin ─────────────────────────────────────────────────────── */
+.breadcrumb { margin-bottom: 32px; }
 
-/* ─── Essay Reactions ───────────────────────────────────────────────────────── */
+/* ─── Essay Reactions — floating pill ──────────────────────────────────────── */
 .essay-reactions {
+  position: fixed;
+  bottom: 28px;
+  right: 28px;
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-shrink: 0;
+  padding: 8px 12px 8px 14px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.12);
+  z-index: 50;
 }
 .essay-reactions-label {
   font-size: 0.75rem;
@@ -508,9 +510,9 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
   width: 30px;
   height: 30px;
   padding: 0;
-  background: var(--bg-subtle);
+  background: transparent;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 50%;
   color: var(--text-muted);
   cursor: pointer;
   transition: border-color 0.15s, background 0.15s, color 0.15s;
@@ -529,6 +531,9 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
   font-size: 0.75rem;
   color: var(--text-muted);
   white-space: nowrap;
+}
+@media (max-width: 768px) {
+  .essay-reactions { bottom: 16px; right: 16px; }
 }
 
 /* ─── Early Access Page ─────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- **Early access page** — conversion-focused waitlist replacing the old nightly-builds framing. Email + CTA inline above the fold, alpha access badge, honest copy about early builds and 6 months free, direct line to team and roadmap influence
- **Floating reactions** — "Did this land?" thumbs moved to a fixed pill in the bottom-right corner so it's always visible without interrupting the content flow
- **Nav reorder** — sidebar now follows: Home, Quick Start, Ethos, Early Access, Guides, Perspectives
- **Accordion fix** — always call `preventDefault` on parent nav items so Guides/Perspectives toggle reliably closed on click regardless of active page state
- **Brand tone pass** — removed remaining em dashes and voice violations across essays and ethos
- **Docs** — brand tone and voice guidelines added to `docs/`

## Test plan

- [ ] Early access form captures `early_access_signup` in PostHog on submit
- [ ] Floating reactions pill visible and functional on all pages
- [ ] Clicking Guides or Perspectives in sidebar toggles open/closed correctly
- [ ] Sidebar nav order matches: Home, Quick Start, Ethos, Early Access, Guides, Perspectives
- [ ] Dark mode looks correct for floating reactions pill
- [ ] Mobile: reactions pill sits at bottom-right without overlapping content