### PR TITLE
feat(website): pricing, plan preference, accordion fix, floating reactions, store buttons

### DIFF
--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -604,7 +604,8 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
 .ea-input::placeholder { color: var(--text-muted); }
 .ea-input:focus { border-color: var(--accent); }
 
-.ea-platform-toggle { display: flex; gap: 8px; flex-wrap: wrap; }
+.ea-form-meta { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 12px; }
+.ea-platform-toggle { display: flex; gap: 6px; flex-wrap: wrap; }
 .ea-platform-option { cursor: pointer; }
 .ea-platform-option input[type="radio"] { position: absolute; opacity: 0; width: 0; height: 0; }
 .ea-platform-option span {

--- a/website/early-access.md
+++ b/website/early-access.md
@@ -17,7 +17,7 @@ description: Join the waitlist for early access to Off Grid. Be among the first 
       <input type="email" id="eaEmail" class="ea-input" placeholder="your@email.com" autocomplete="email" required>
       <button type="submit" class="ea-submit">Join the waitlist</button>
     </div>
-    <div class="ea-field-group" style="margin-top:12px;">
+    <div class="ea-form-meta">
       <div class="ea-platform-toggle">
         <label class="ea-platform-option">
           <input type="radio" name="platform" value="ios" checked>
@@ -36,6 +36,16 @@ description: Join the waitlist for early access to Off Grid. Be among the first 
         <label class="ea-platform-option">
           <input type="radio" name="platform" value="both">
           <span>Both</span>
+        </label>
+      </div>
+      <div class="ea-platform-toggle">
+        <label class="ea-platform-option">
+          <input type="radio" name="plan" value="yearly" checked>
+          <span>$199 / year</span>
+        </label>
+        <label class="ea-platform-option">
+          <input type="radio" name="plan" value="monthly">
+          <span>$19.99 / month</span>
         </label>
       </div>
     </div>
@@ -61,7 +71,7 @@ description: Join the waitlist for early access to Off Grid. Be among the first 
     </div>
     <div>
       <div class="perk-title">6 months free</div>
-      <div class="perk-desc">When the personal AI OS ships, early access members get 6 months free. That is the return on putting your name down now.</div>
+      <div class="perk-desc">When it ships, early access members get 6 months free. After that, <strong>$199/year</strong> or <strong>$19.99/month</strong>. No surprise pricing.</div>
     </div>
   </div>
   <div class="perk-card">
@@ -94,7 +104,9 @@ It is a system where your AI understands context across every app, every convers
 
 It does not send your data anywhere. It does not train on your activity. It is entirely yours.
 
-A small number of people will run this before it ships publicly. They will see it break, watch it get fixed, and have a real say in what it becomes. If that is you, put your email in.
+A small number of people will run this before it ships publicly. They will see it break, watch it get fixed, and have a real say in what it becomes.
+
+When it ships, it will be $199/year or $19.99/month. Early access members get the first 6 months free. If that deal and that kind of access interests you, put your email in.
 
 <script>
   (function() {
@@ -111,11 +123,13 @@ A small number of people will run this before it ships publicly. They will see i
         return;
       }
       var platform = (form.querySelector('input[name="platform"]:checked') || {}).value || 'ios';
+      var plan = (form.querySelector('input[name="plan"]:checked') || {}).value || 'yearly';
       if (typeof posthog !== 'undefined') {
         posthog.identify(email, { email: email });
         posthog.capture('early_access_signup', {
           email: email,
           platform: platform,
+          plan: plan,
           source: window.location.pathname
         });
       }


### PR DESCRIPTION
## Summary

- **Explicit pricing** — $199/year or $19.99/month shown in the 6 months free perk card and closing pitch on the early access page
- **Plan preference toggle** — yearly/monthly selector added to the signup form; captured as `plan` in the PostHog `early_access_signup` event
- **Accordion fix (root cause)** — `openSearch` was scoped inside an IIFE, causing a `ReferenceError` that crashed the entire second script block and prevented accordion event listeners from being registered. Fixed by assigning `window.openSearch`
- **Floating reactions pill** — "Did this land?" thumbs moved to a fixed bottom-right pill that follows as you scroll
- **Store buttons side by side** — App Store and Google Play sit in a flex row in the sidebar footer
- **Nav reorder** — Home, Quick Start, Ethos, Early Access, Guides, Perspectives

## Test plan

- [ ] Early access form shows platform + plan toggles, both captured in PostHog on submit
- [ ] Pricing ($199/year, $19.99/month) visible in perk card and closing section
- [ ] Clicking Guides or Perspectives in sidebar toggles accordion open/closed correctly
- [ ] No `ReferenceError: openSearch is not defined` in console
- [ ] Floating reactions pill visible bottom-right on all pages
- [ ] App Store and Google Play buttons sit side by side in sidebar