### PR TITLE
feat(website): cross-link Perspectives essays and early access waitlist

### DIFF
--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -240,6 +240,16 @@
         {{ content }}
       </article>
 
+      {% if page.parent == "Perspectives" %}
+      <div class="essay-early-access" data-pagefind-ignore>
+        <div class="essay-ea-text">
+          <strong>Run the personal AI OS before anyone else.</strong>
+          Join the waitlist — early access members get 6 months free.
+        </div>
+        <a href="{{ '/early-access' | relative_url }}" class="essay-ea-btn">Join the waitlist</a>
+      </div>
+      {% endif %}
+
       {% if page.parent %}
         {% assign siblings = site.pages | where: "parent", page.parent | sort: "nav_order" %}
         {% assign current_index = 0 %}

--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -646,6 +646,76 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
 .ea-status-success { color: var(--accent); }
 .ea-status-error { color: #ef4444; }
 
+/* ─── Essay early access CTA banner ────────────────────────────────────────── */
+.essay-early-access {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 48px;
+  padding: 18px 22px;
+  background: var(--accent-subtle);
+  border: 1px solid var(--accent-subtle-border);
+  border-radius: 10px;
+}
+.essay-ea-text {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.essay-ea-text strong { color: var(--text-primary); }
+.essay-ea-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 9px 18px;
+  background: var(--accent);
+  color: #fff;
+  border-radius: var(--radius);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+.essay-ea-btn:hover { background: var(--accent-hover); color: #fff; }
+
+/* ─── Early access essay link cards ────────────────────────────────────────── */
+.ea-essay-links {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin: 16px 0 8px;
+}
+.ea-essay-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-subtle);
+  text-decoration: none;
+  transition: border-color 0.15s, background 0.15s;
+}
+.ea-essay-card:hover {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+  text-decoration: none;
+}
+.ea-essay-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+}
+.ea-essay-desc {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
 /* ─── Mobile ────────────────────────────────────────────────────────────────── */
 .mobile-topbar {
   display: none;
@@ -676,4 +746,6 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
   .btn { padding: 10px 14px; font-size: 0.8125rem; }
   .early-access-perks { grid-template-columns: 1fr; }
   .early-access-hero h1 { font-size: 1.875rem; }
+  .ea-essay-links { grid-template-columns: 1fr; }
+  .essay-early-access { flex-direction: column; align-items: flex-start; }
 }

--- a/website/early-access.md
+++ b/website/early-access.md
@@ -80,6 +80,31 @@ description: Join the waitlist for early access to Off Grid. Be among the first 
 
 ---
 
+## Read the thinking
+
+Not sure what a personal AI OS actually is? Start here.
+
+<div class="ea-essay-links">
+  <a href="{{ '/writing/what-is-personal-ai-os' | relative_url }}" class="ea-essay-card">
+    <div class="ea-essay-title">What Is a Personal AI OS?</div>
+    <div class="ea-essay-desc">The clearest explanation of what we are building and why it is different from every AI product you have already tried.</div>
+  </a>
+  <a href="{{ '/writing/phone-laptop-know-nothing' | relative_url }}" class="ea-essay-card">
+    <div class="ea-essay-title">Your Phone and Laptop Know Nothing About You</div>
+    <div class="ea-essay-desc">The core problem. Your most personal devices are also the least intelligent things you own. That is not acceptable.</div>
+  </a>
+  <a href="{{ '/writing/intelligence-should-be-personal' | relative_url }}" class="ea-essay-card">
+    <div class="ea-essay-title">Intelligence Should Be Personal</div>
+    <div class="ea-essay-desc">Why AI that runs on a server can never be truly personal — and what it means for intelligence to actually belong to you.</div>
+  </a>
+  <a href="{{ '/writing/a-day-with-personal-ai-os' | relative_url }}" class="ea-essay-card">
+    <div class="ea-essay-title">A Day With a Personal AI OS</div>
+    <div class="ea-essay-desc">What it actually looks like when your devices work together. Concrete, specific, and closer than you think.</div>
+  </a>
+</div>
+
+---
+
 ## What this is
 
 Off Grid today is a powerful on-device AI app. The personal AI OS is the next layer.


### PR DESCRIPTION
## Summary

Content and conversion now feed each other:

- **Essays → Early Access** — every Perspectives essay gets a green CTA banner at the bottom: "Run the personal AI OS before anyone else. Join the waitlist — early access members get 6 months free." Implemented in the layout so all 19 essays are covered with one change
- **Early Access → Essays** — a "Read the thinking" 2-column card grid on the early access page links to 4 foundational essays: What Is a Personal AI OS, Your Phone and Laptop Know Nothing About You, Intelligence Should Be Personal, A Day With a Personal AI OS

## Test plan

- [ ] Open any Perspectives essay — CTA banner appears at the bottom above prev/next nav
- [ ] CTA banner links to /early-access
- [ ] Early access page shows 4 essay cards under "Read the thinking"
- [ ] All 4 essay card links resolve correctly
- [ ] Banner collapses to stacked layout on mobile