### PR TITLE
feat(website): full content audit + mission page + 3 new VA essays

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,30 @@
 1. Push the branch and open a PR — never `git push origin main`.
 2. If you find yourself on `main`, create a branch first: `git checkout -b <branch-name>`.
 
+## Copy & Content Standards
+
+**Any change to website copy, essays, docs text, UI strings, or marketing content must follow the brand voice guide:**
+
+- Read `docs/brand_tone_voice.md` before writing or editing any copy.
+- The full quality checklist is at the bottom of that file — run every item before committing content changes.
+
+Key rules that are easy to miss:
+
+| Rule | Wrong | Right |
+|---|---|---|
+| Proof-first | "fast" | "15-30 tok/s on flagship devices" |
+| Privacy as mechanism | "we value your privacy" | "the model runs in your phone's RAM, nothing is sent anywhere" |
+| No exclamation marks | "It works!" | "It works." |
+| No em dashes | "private — always" | "private -- always" |
+| No forbidden words | revolutionary, seamlessly, empower, leverage, robust, comprehensive, crucial, pivotal, delve, tapestry, testament, underscore, foster, cultivate, showcase, enhance | use specific, plain words instead |
+| No AI slop phrases | "serves as", "stands as", "represents a", "marks a turning point", "it is worth noting" | just say "is" |
+| No structural clichés | "Not just X, but Y" / "It's not X, it's Y" | state the thing directly |
+| No curly quotes | "private" | "private" |
+
+The emotional arc for all content: **Recognition -> Return -> Freedom**. Name what's been happening, show what's being given back, hand over the capability without condition.
+
+---
+
 ## Design Standards
 
 **Any change that touches UI (screens, components, styles) must comply with the design system:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Key rules that are easy to miss:
 | Proof-first | "fast" | "15-30 tok/s on flagship devices" |
 | Privacy as mechanism | "we value your privacy" | "the model runs in your phone's RAM, nothing is sent anywhere" |
 | No exclamation marks | "It works!" | "It works." |
-| No em dashes | "private — always" | "private -- always" |
+| No em dashes | "private — always" | "private - always" |
 | No forbidden words | revolutionary, seamlessly, empower, leverage, robust, comprehensive, crucial, pivotal, delve, tapestry, testament, underscore, foster, cultivate, showcase, enhance | use specific, plain words instead |
 | No AI slop phrases | "serves as", "stands as", "represents a", "marks a turning point", "it is worth noting" | just say "is" |
 | No structural clichés | "Not just X, but Y" / "It's not X, it's Y" | state the thing directly |

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Built on the shoulders of giants:
 
 **Off Grid** — Your AI, your device, your data.
 
-*No cloud. No subscription. No data harvesting. Just AI that works anywhere.*
+*No cloud. No data harvesting. Just AI that works anywhere.*
 
 [Join the Community on Slack](https://join.slack.com/t/off-grid-mobile/shared_invite/zt-3q7kj5gr6-rVzx5gl5LKPQh4mUE2CCvA)
 

--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -537,6 +537,29 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
   .essay-reactions { bottom: 16px; right: 16px; }
 }
 
+/* ─── Mission Page ──────────────────────────────────────────────────────────── */
+.mission-statement {
+  text-align: center;
+  padding: 48px 0 40px;
+}
+.mission-tagline {
+  font-size: 2rem;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  font-weight: 400;
+  color: var(--text-primary);
+  margin: 0 0 12px;
+}
+.mission-sub {
+  font-size: 1.0625rem;
+  color: var(--text-secondary);
+  margin: 0;
+  font-weight: 400;
+}
+@media (max-width: 640px) {
+  .mission-tagline { font-size: 1.5rem; }
+}
+
 /* ─── Early Access Page ─────────────────────────────────────────────────────── */
 .early-access-hero { margin-bottom: 40px; }
 .early-access-badge {

--- a/website/early-access.md
+++ b/website/early-access.md
@@ -95,7 +95,7 @@ Not sure what a personal AI OS actually is? Start here.
   </a>
   <a href="{{ '/writing/intelligence-should-be-personal' | relative_url }}" class="ea-essay-card">
     <div class="ea-essay-title">Intelligence Should Be Personal</div>
-    <div class="ea-essay-desc">Why AI that runs on a server can never be truly personal — and what it means for intelligence to actually belong to you.</div>
+    <div class="ea-essay-desc">Why AI that runs on a server can never be truly personal, and what it means for intelligence to actually belong to you.</div>
   </a>
   <a href="{{ '/writing/a-day-with-personal-ai-os' | relative_url }}" class="ea-essay-card">
     <div class="ea-essay-title">A Day With a Personal AI OS</div>
@@ -109,7 +109,7 @@ Not sure what a personal AI OS actually is? Start here.
 
 Off Grid today is a powerful on-device AI app. The personal AI OS is the next layer.
 
-It is a system where your AI understands context across every app, every conversation, every device — without a single byte leaving your phone. It knows what you are working on. It knows what you have read. It acts when you ask and stays out of the way when you do not.
+It is a system where your AI understands context across every app, every conversation, every device. Not a single byte leaves your phone. It knows what you are working on. It knows what you have read. It acts when you ask and stays out of the way when you do not.
 
 It does not send your data anywhere. It does not train on your activity. It is entirely yours.
 

--- a/website/early-access.md
+++ b/website/early-access.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Early Access
-nav_order: 4
+nav_order: 5
 description: Join the waitlist for early access to Off Grid. Be among the first to run the personal AI OS, shape what gets built, and get 6 months free.
 ---
 

--- a/website/early-access.md
+++ b/website/early-access.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Early Access
-nav_order: 5
+nav_order: 4
 description: Join the waitlist for early access to Off Grid. Be among the first to run the personal AI OS, shape what gets built, and get 6 months free.
 ---
 

--- a/website/ethos.md
+++ b/website/ethos.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Ethos
-nav_order: 3
+parent: Mission
+nav_order: 1
 description: Why Off Grid exists. Intelligence should live on the devices you already own - private by architecture, not by policy.
 ---
 

--- a/website/ethos.md
+++ b/website/ethos.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Ethos
-parent: Mission
-nav_order: 1
+nav_order: 3
+has_children: true
 description: Why Off Grid exists. Intelligence should live on the devices you already own - private by architecture, not by policy.
 ---
 

--- a/website/ethos.md
+++ b/website/ethos.md
@@ -18,7 +18,7 @@ The most useful AI is the one with your full context. Your messages. Your calend
 
 But getting that context today means handing it to a server you don't control and paying a subscription for the privilege. Every query leaves your device. Every response comes back from somewhere else. You don't know what's stored, for how long, or what it's used for.
 
-Privacy by policy - "we promise not to misuse your data" - is not the same as privacy by architecture - "the data never left your device."
+Privacy by policy ("we promise not to misuse your data") is not the same as privacy by architecture ("the data never left your device").
 
 ---
 
@@ -36,7 +36,7 @@ This is possible today. The models fit. The hardware is fast enough. The only th
 
 AI is the next communication infrastructure. And communication infrastructure, historically, moves toward privacy when users demand it.
 
-The market will demand it here too. Not because privacy is a talking point, but because people will eventually notice that their most personal context - the things that would make AI useful - is exactly what they're least willing to hand over.
+The market will demand it here too. Not because privacy is a talking point, but because people will eventually notice that their most personal context, the things that would make AI useful, is exactly what they're least willing to hand over.
 
 The devices people already carry will become intelligent. They will speak to each other over local networks. Context will stay on-person. That future doesn't require new hardware or new platforms. It requires software built on the right assumption from the start.
 

--- a/website/guides/index.md
+++ b/website/guides/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Guides
-nav_order: 5
+nav_order: 6
 has_children: true
 description: Step-by-step guides for running AI locally on your iPhone and Android phone with Off Grid.
 ---

--- a/website/guides/index.md
+++ b/website/guides/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Guides
-nav_order: 6
+nav_order: 5
 has_children: true
 description: Step-by-step guides for running AI locally on your iPhone and Android phone with Off Grid.
 ---

--- a/website/guides/ios-setup.md
+++ b/website/guides/ios-setup.md
@@ -33,7 +33,7 @@ The app itself is under 50MB. Models are downloaded separately inside the app.
 
 1. Open Off Grid
 2. Tap **Models** in the tab bar
-3. Select a model - if you're starting out, pick **Phi-3 Mini** (~2GB)
+3. Select a model - if you're starting out, pick **Qwen 3.5 2B** (~1.5GB)
 4. Tap **Download**
 
 The download goes to your device. This is the only step that requires internet.

--- a/website/guides/run-llms-locally-iphone.md
+++ b/website/guides/run-llms-locally-iphone.md
@@ -10,7 +10,7 @@ faq:
   - q: Which iPhones can run LLMs locally in 2026?
     a: iPhone 12 or newer (A14 chip or later). Smaller models like Qwen 3.5 0.8B and Qwen 3.5 2B run on any supported iPhone. Larger models like Qwen 3.5 9B need iPhone 15 Pro or newer with 8GB RAM.
   - q: Is running LLMs on iPhone as good as ChatGPT?
-    a: For everyday tasks - summarisation, Q&A, writing help - Qwen 3.5 9B on iPhone 15 Pro is comparable to GPT-3.5. Gemma 4 and Qwen 3.5 models also support thinking mode for complex reasoning tasks.
+    a: For everyday tasks - summarisation, Q&A, writing help - Qwen 3.5 9B on iPhone 15 Pro handles most things you'd reach for ChatGPT for. Larger cloud models still have an edge on complex multi-step reasoning, but the gap is narrower than most people expect.
 ---
 
 # How to Run LLMs Locally on Your iPhone in 2026 (Completely Offline, No Subscription)

--- a/website/guides/stable-diffusion-iphone.md
+++ b/website/guides/stable-diffusion-iphone.md
@@ -89,5 +89,4 @@ You'll see a real-time preview update as the model denoises the image step by st
 ## Related guides
 
 - [How to Run Stable Diffusion on Your Android Phone]({{ '/guides/stable-diffusion-android' | relative_url }})
-- [How to Generate AI Images Locally on Your iPhone in 2026]({{ '/guides/generate-ai-images-iphone' | relative_url }})
 - [How to Run LLMs Locally on Your iPhone in 2026]({{ '/guides/run-llms-locally-iphone' | relative_url }})

--- a/website/mission.md
+++ b/website/mission.md
@@ -4,14 +4,14 @@ title: Mission
 parent: Ethos
 nav_order: 2
 has_children: false
-description: Intelligence will become ambient. Always on, always yours, always private. We're building the architecture that makes that possible -- on the devices you already own, without asking you to trust anyone but yourself.
+description: Intelligence will become ambient. Always on, always yours, always private. We're building the architecture that makes that possible - on the devices you already own, without asking you to trust anyone but yourself.
 ---
 
 # Intelligence belongs to everyone.
 
 ---
 
-Navigation used to belong to experts. You needed a map, a compass, training. Then it became ambient -- built into the device in your pocket, free, always on, available to anyone going anywhere. You stopped thinking about navigation as a tool. It just became part of how you move through the world.
+Navigation used to belong to experts. You needed a map, a compass, training. Then it became ambient - built into the device in your pocket, free, always on, available to anyone going anywhere. You stopped thinking about navigation as a tool. It just became part of how you move through the world.
 
 Intelligence is next.
 
@@ -27,7 +27,7 @@ To use AI today, you hand your most private thoughts to someone else's infrastru
 
 Your health questions. Your relationship problems. Your financial decisions. Your half-formed ideas at 2am. All of it travelling to a server you don't control, stored under terms you didn't read, in the hands of companies whose revenue model is built around having your data and keeping you dependent on their compute.
 
-Some of them promised to do it differently. Local-first. Private by default. Yours, not theirs. They made the right noises -- and then the economics shifted. They went cloud. Then they got acquired. Then they shut down overnight. Users who had given years of their most personal context to these products woke up one day and had nothing. Lost access to their own memories. Gone.
+Some of them promised to do it differently. Local-first. Private by default. Yours, not theirs. They made the right noises - and then the economics shifted. They went cloud. Then they got acquired. Then they shut down overnight. Users who had given years of their most personal context to these products woke up one day and had nothing. Lost access to their own memories. Gone.
 
 **That's not a hypothetical. It already happened.**
 
@@ -41,7 +41,7 @@ The problem isn't the companies. The problem is the architecture.
 
 The device in your pocket is more powerful than the servers that ran the first generation of cloud AI.
 
-A current flagship phone runs AI at 30 tokens a second -- fast enough for real-time conversation, fully offline, using dedicated neural hardware that was designed for exactly this workload. That hardware has been shipping to billions of people for years. It sits mostly idle while they pay monthly fees to send their thoughts to someone else's GPU.
+A current flagship phone runs AI at 30 tokens a second - fast enough for real-time conversation, fully offline, using dedicated neural hardware that was designed for exactly this workload. That hardware has been shipping to billions of people for years. It sits mostly idle while they pay monthly fees to send their thoughts to someone else's GPU.
 
 **The infrastructure for a private, personal, ambient intelligence layer already exists. It's in the pocket of 4 billion people. What's been missing is the software that takes that seriously.**
 
@@ -59,7 +59,7 @@ The only guarantee that your data stays yours is that it never leaves your devic
 
 Not a toggle. Not a promise. Not a trust-us. **Architecture.**
 
-Open source, so anyone can verify what the software actually does. No account required. No telemetry. No analytics. No data collection of any kind. If you can't audit it, you can't trust it -- and you shouldn't.
+Open source, so anyone can verify what the software actually does. No account required. No telemetry. No analytics. No data collection of any kind. If you can't audit it, you can't trust it - and you shouldn't.
 
 We hold this as a non-negotiable. Not because it's a better marketing position. Because it's the only honest answer to the question of who owns your intelligence.
 
@@ -69,17 +69,17 @@ We hold this as a non-negotiable. Not because it's a better marketing position. 
 
 For two hundred years, the people who operated at the highest levels of consequence had something everyone else didn't: a private intelligence layer.
 
-Someone who knew their priorities, managed their correspondence, prepared them for every meeting, tracked their commitments, drafted their communications, handled the coordination overhead of a productive life -- so they could focus their attention on the work that actually required them.
+Someone who knew their priorities, managed their correspondence, prepared them for every meeting, tracked their commitments, drafted their communications, handled the coordination overhead of a productive life - so they could focus their attention on the work that actually required them.
 
 It was called a secretary. Then an executive assistant. Then a virtual assistant. Whatever the name, the function was the same: an intelligence layer available to you, handling everything except the decisions only you can make.
 
-For two hundred years, access to that layer was determined entirely by wealth and seniority. You had it if you could afford it. Everyone else managed the coordination overhead themselves -- with their own attention, their own time, their own focus.
+For two hundred years, access to that layer was determined entirely by wealth and seniority. You had it if you could afford it. Everyone else managed the coordination overhead themselves - with their own attention, their own time, their own focus.
 
 **The device in your pocket changes that equation permanently.**
 
-A Personal AI OS -- one intelligence layer, running on your hardware, spanning your phone and laptop over your own network, with no server in between. It knows your messages, your calendar, your work, your life -- because it lives with you, not above you. It preps you for meetings before you ask. It defers what can wait and surfaces what can't. It handles the coordination overhead of your day the way a great assistant has always handled it for the people who could afford one.
+A Personal AI OS - one intelligence layer, running on your hardware, spanning your phone and laptop over your own network, with no server in between. It knows your messages, your calendar, your work, your life - because it lives with you, not above you. It preps you for meetings before you ask. It defers what can wait and surfaces what can't. It handles the coordination overhead of your day the way a great assistant has always handled it for the people who could afford one.
 
-Not AI making decisions while you sleep. Not autonomous agents acting on your behalf in ways you didn't sanction. A private digital secretary -- proactive, aware, yours -- that makes your day a little easier and your attention a little freer.
+Not AI making decisions while you sleep. Not autonomous agents acting on your behalf in ways you didn't sanction. A private digital secretary - proactive, aware, yours - that makes your day a little easier and your attention a little freer.
 
 The same thing that secretaries have been doing for the powerful for 200 years. Now running on a device that billions of people already carry. On models that cost nothing to run. With data that never leaves your hands.
 

--- a/website/mission.md
+++ b/website/mission.md
@@ -1,0 +1,89 @@
+---
+layout: default
+title: Mission
+nav_order: 4
+description: Why Off Grid exists. Intelligence will become ambient - always on, always yours. We're building the architecture that makes that possible without asking you to trust anyone but yourself.
+---
+
+# Mission
+
+---
+
+<div class="mission-statement">
+  <p class="mission-tagline">Democratize intelligence on-person.</p>
+  <p class="mission-sub">Private by architecture. On the devices you already own.</p>
+</div>
+
+---
+
+## The belief
+
+Intelligence will become ambient.
+
+Just like navigation became ambient — so embedded in daily life that you no longer think about it as a separate tool — intelligence will disappear into the background. You won't "open an AI app." You'll just have an intelligence layer that's always there, always on, always yours.
+
+That's inevitable. The question is who builds it and on whose terms.
+
+---
+
+## The problem with how it's being built today
+
+Right now, to use AI, you hand your most private thoughts to someone else's server.
+
+Your health questions. Your relationship problems. Your financial decisions. Your half-formed ideas at 2am. All of it sitting on infrastructure you don't control, governed by terms you didn't read, in the hands of companies whose business model depends on having your data.
+
+The ones who promised to do it differently have had a pattern of not following through. Companies that launched with local-first, private-by-default commitments, then went cloud when the economics shifted, then got acquired, then shut down overnight. Users lost access to their own memories. That's not a hypothetical risk. It has already happened.
+
+The problem is structural. When your intelligence lives on someone else's server, you are always one acquisition, one policy change, or one pricing decision away from losing it.
+
+---
+
+## The conviction
+
+Your phone and your laptop are insanely powerful.
+
+A flagship phone today runs AI at 30 tokens a second — fast enough for real-time conversation, fully offline. These devices were designed for this workload. They have dedicated neural processing hardware that sits mostly idle while you pay monthly fees to send your queries to someone else's GPU.
+
+The infrastructure is already in your pocket. What's missing is the product that makes it intelligent and makes your devices talk to each other.
+
+We are not waiting for new hardware. We are not waiting for a new platform. The devices 4 billion people already carry are enough.
+
+---
+
+## The ethos
+
+Privacy is not a feature. It's an architecture decision.
+
+The only guarantee that your data stays yours is that it never leaves your device in the first place. Not a policy. Not a toggle. Not a promise from a company that could be acquired tomorrow.
+
+Architecture.
+
+Open source so anyone can verify it. No account required. No telemetry. No analytics. If you can't audit it, you can't trust it.
+
+We hold this as a non-negotiable. Not because it's a good marketing position — but because it's the only honest answer to the question of who owns your intelligence.
+
+---
+
+## The vision
+
+A Personal AI OS. One intelligence layer across all your devices.
+
+It knows your messages, your calendar, your work, your life — because it lives on your hardware. Your phone and your laptop talk to each other over your own network, with no server in between. It preps you for meetings before you ask. It defers your notifications when you need to focus. It creates a calendar entry when someone messages about dinner three weeks out. It surfaces what matters and lets everything else wait.
+
+Not an AI agent making decisions while you sleep. A private digital secretary that makes your life a little easier — the same thing that secretaries have been doing for the powerful for 200 years, but now running on a device that billions of people already carry, on models that cost nothing to run, with data that never leaves your hands.
+
+---
+
+## The mission
+
+For two centuries, the intelligence layer — the assistant that handles the coordination overhead of a productive life — was a privilege of wealth and seniority.
+
+The device in your pocket has changed that equation. The models are free. The hardware is there. The only thing that was missing was software that took it seriously.
+
+That's what we're building.
+
+**Democratize intelligence. Make it personal, private, and ambient. On the hardware people already own. Without asking them to trust anyone but themselves.**
+
+---
+
+*Off Grid is open source. [View on GitHub](https://github.com/alichherawalla/off-grid-mobile?utm_source=offgrid-docs&utm_medium=website&utm_campaign=github) or [join the community on Slack](https://join.slack.com/t/off-grid-mobile/shared_invite/zt-3swt3s84k-R0CHRwISaUpExV2~3qUUdQ).*

--- a/website/mission.md
+++ b/website/mission.md
@@ -4,14 +4,14 @@ title: Mission
 parent: Ethos
 nav_order: 2
 has_children: false
-description: Intelligence will become ambient. Always on, always yours, always private. We're building the architecture that makes that possible — on the devices you already own, without asking you to trust anyone but yourself.
+description: Intelligence will become ambient. Always on, always yours, always private. We're building the architecture that makes that possible -- on the devices you already own, without asking you to trust anyone but yourself.
 ---
 
 # Intelligence belongs to everyone.
 
 ---
 
-Navigation used to belong to experts. You needed a map, a compass, training. Then it became ambient — built into the device in your pocket, free, always on, available to anyone going anywhere. You stopped thinking about navigation as a tool. It just became part of how you move through the world.
+Navigation used to belong to experts. You needed a map, a compass, training. Then it became ambient -- built into the device in your pocket, free, always on, available to anyone going anywhere. You stopped thinking about navigation as a tool. It just became part of how you move through the world.
 
 Intelligence is next.
 
@@ -27,7 +27,7 @@ To use AI today, you hand your most private thoughts to someone else's infrastru
 
 Your health questions. Your relationship problems. Your financial decisions. Your half-formed ideas at 2am. All of it travelling to a server you don't control, stored under terms you didn't read, in the hands of companies whose revenue model is built around having your data and keeping you dependent on their compute.
 
-Some of them promised to do it differently. Local-first. Private by default. Yours, not theirs. They made the right noises — and then the economics shifted. They went cloud. Then they got acquired. Then they shut down overnight. Users who had given years of their most personal context to these products woke up one day and had nothing. Lost access to their own memories. Gone.
+Some of them promised to do it differently. Local-first. Private by default. Yours, not theirs. They made the right noises -- and then the economics shifted. They went cloud. Then they got acquired. Then they shut down overnight. Users who had given years of their most personal context to these products woke up one day and had nothing. Lost access to their own memories. Gone.
 
 **That's not a hypothetical. It already happened.**
 
@@ -41,7 +41,7 @@ The problem isn't the companies. The problem is the architecture.
 
 The device in your pocket is more powerful than the servers that ran the first generation of cloud AI.
 
-A current flagship phone runs AI at 30 tokens a second — fast enough for real-time conversation, fully offline, using dedicated neural hardware that was designed for exactly this workload. That hardware has been shipping to billions of people for years. It sits mostly idle while they pay monthly fees to send their thoughts to someone else's GPU.
+A current flagship phone runs AI at 30 tokens a second -- fast enough for real-time conversation, fully offline, using dedicated neural hardware that was designed for exactly this workload. That hardware has been shipping to billions of people for years. It sits mostly idle while they pay monthly fees to send their thoughts to someone else's GPU.
 
 **The infrastructure for a private, personal, ambient intelligence layer already exists. It's in the pocket of 4 billion people. What's been missing is the software that takes that seriously.**
 
@@ -59,7 +59,7 @@ The only guarantee that your data stays yours is that it never leaves your devic
 
 Not a toggle. Not a promise. Not a trust-us. **Architecture.**
 
-Open source, so anyone can verify what the software actually does. No account required. No telemetry. No analytics. No data collection of any kind. If you can't audit it, you can't trust it — and you shouldn't.
+Open source, so anyone can verify what the software actually does. No account required. No telemetry. No analytics. No data collection of any kind. If you can't audit it, you can't trust it -- and you shouldn't.
 
 We hold this as a non-negotiable. Not because it's a better marketing position. Because it's the only honest answer to the question of who owns your intelligence.
 
@@ -69,17 +69,17 @@ We hold this as a non-negotiable. Not because it's a better marketing position. 
 
 For two hundred years, the people who operated at the highest levels of consequence had something everyone else didn't: a private intelligence layer.
 
-Someone who knew their priorities, managed their correspondence, prepared them for every meeting, tracked their commitments, drafted their communications, handled the coordination overhead of a productive life — so they could focus their attention on the work that actually required them.
+Someone who knew their priorities, managed their correspondence, prepared them for every meeting, tracked their commitments, drafted their communications, handled the coordination overhead of a productive life -- so they could focus their attention on the work that actually required them.
 
 It was called a secretary. Then an executive assistant. Then a virtual assistant. Whatever the name, the function was the same: an intelligence layer available to you, handling everything except the decisions only you can make.
 
-For two hundred years, access to that layer was determined entirely by wealth and seniority. You had it if you could afford it. Everyone else managed the coordination overhead themselves — with their own attention, their own time, their own focus.
+For two hundred years, access to that layer was determined entirely by wealth and seniority. You had it if you could afford it. Everyone else managed the coordination overhead themselves -- with their own attention, their own time, their own focus.
 
 **The device in your pocket changes that equation permanently.**
 
-A Personal AI OS — one intelligence layer, running on your hardware, spanning your phone and laptop over your own network, with no server in between. It knows your messages, your calendar, your work, your life — because it lives with you, not above you. It preps you for meetings before you ask. It defers what can wait and surfaces what can't. It handles the coordination overhead of your day the way a great assistant has always handled it for the people who could afford one.
+A Personal AI OS -- one intelligence layer, running on your hardware, spanning your phone and laptop over your own network, with no server in between. It knows your messages, your calendar, your work, your life -- because it lives with you, not above you. It preps you for meetings before you ask. It defers what can wait and surfaces what can't. It handles the coordination overhead of your day the way a great assistant has always handled it for the people who could afford one.
 
-Not AI making decisions while you sleep. Not autonomous agents acting on your behalf in ways you didn't sanction. A private digital secretary — proactive, aware, yours — that makes your day a little easier and your attention a little freer.
+Not AI making decisions while you sleep. Not autonomous agents acting on your behalf in ways you didn't sanction. A private digital secretary -- proactive, aware, yours -- that makes your day a little easier and your attention a little freer.
 
 The same thing that secretaries have been doing for the powerful for 200 years. Now running on a device that billions of people already carry. On models that cost nothing to run. With data that never leaves your hands.
 

--- a/website/mission.md
+++ b/website/mission.md
@@ -4,14 +4,14 @@ title: Mission
 parent: Ethos
 nav_order: 2
 has_children: false
-description: Intelligence will become ambient. Always on, always yours, always private. We're building the architecture that makes that possible - on the devices you already own, without asking you to trust anyone but yourself.
+description: Intelligence will become ambient. Always on, always yours, always private. We're building the architecture that makes that possible on the devices you already own, without asking you to trust anyone but yourself.
 ---
 
 # Intelligence belongs to everyone.
 
 ---
 
-Navigation used to belong to experts. You needed a map, a compass, training. Then it became ambient - built into the device in your pocket, free, always on, available to anyone going anywhere. You stopped thinking about navigation as a tool. It just became part of how you move through the world.
+Navigation used to belong to experts. You needed a map, a compass, training. Then it became ambient. Built into the device in your pocket, free, always on, available to anyone going anywhere. You stopped thinking about navigation as a tool. It just became part of how you move through the world.
 
 Intelligence is next.
 
@@ -27,7 +27,7 @@ To use AI today, you hand your most private thoughts to someone else's infrastru
 
 Your health questions. Your relationship problems. Your financial decisions. Your half-formed ideas at 2am. All of it travelling to a server you don't control, stored under terms you didn't read, in the hands of companies whose revenue model is built around having your data and keeping you dependent on their compute.
 
-Some of them promised to do it differently. Local-first. Private by default. Yours, not theirs. They made the right noises - and then the economics shifted. They went cloud. Then they got acquired. Then they shut down overnight. Users who had given years of their most personal context to these products woke up one day and had nothing. Lost access to their own memories. Gone.
+Some of them promised to do it differently. Local-first. Private by default. Yours, not theirs. They made the right noises. Then the economics shifted. They went cloud. Then they got acquired. Then they shut down overnight. Users who had given years of their most personal context to these products woke up one day and had nothing. Lost access to their own memories. Gone.
 
 **That's not a hypothetical. It already happened.**
 
@@ -41,7 +41,7 @@ The problem isn't the companies. The problem is the architecture.
 
 The device in your pocket is more powerful than the servers that ran the first generation of cloud AI.
 
-A current flagship phone runs AI at 30 tokens a second - fast enough for real-time conversation, fully offline, using dedicated neural hardware that was designed for exactly this workload. That hardware has been shipping to billions of people for years. It sits mostly idle while they pay monthly fees to send their thoughts to someone else's GPU.
+A current flagship phone runs AI at 30 tokens a second. Fast enough for real-time conversation, fully offline, using dedicated neural hardware designed for exactly this workload. That hardware has been shipping to billions of people for years. It sits mostly idle while they pay monthly fees to send their thoughts to someone else's GPU.
 
 **The infrastructure for a private, personal, ambient intelligence layer already exists. It's in the pocket of 4 billion people. What's been missing is the software that takes that seriously.**
 
@@ -59,7 +59,7 @@ The only guarantee that your data stays yours is that it never leaves your devic
 
 Not a toggle. Not a promise. Not a trust-us. **Architecture.**
 
-Open source, so anyone can verify what the software actually does. No account required. No telemetry. No analytics. No data collection of any kind. If you can't audit it, you can't trust it - and you shouldn't.
+Open source, so anyone can verify what the software actually does. No account required. No telemetry. No analytics. No data collection of any kind. If you can't audit it, you can't trust it. You shouldn't.
 
 We hold this as a non-negotiable. Not because it's a better marketing position. Because it's the only honest answer to the question of who owns your intelligence.
 
@@ -69,17 +69,17 @@ We hold this as a non-negotiable. Not because it's a better marketing position. 
 
 For two hundred years, the people who operated at the highest levels of consequence had something everyone else didn't: a private intelligence layer.
 
-Someone who knew their priorities, managed their correspondence, prepared them for every meeting, tracked their commitments, drafted their communications, handled the coordination overhead of a productive life - so they could focus their attention on the work that actually required them.
+Someone who knew their priorities, managed their correspondence, prepared them for every meeting, tracked their commitments, drafted their communications, and handled the coordination overhead of a productive life. So they could focus their attention on the work that actually required them.
 
 It was called a secretary. Then an executive assistant. Then a virtual assistant. Whatever the name, the function was the same: an intelligence layer available to you, handling everything except the decisions only you can make.
 
-For two hundred years, access to that layer was determined entirely by wealth and seniority. You had it if you could afford it. Everyone else managed the coordination overhead themselves - with their own attention, their own time, their own focus.
+For two hundred years, access to that layer was determined entirely by wealth and seniority. You had it if you could afford it. Everyone else managed the coordination overhead themselves. With their own attention, their own time, their own focus.
 
 **The device in your pocket changes that equation permanently.**
 
-A Personal AI OS - one intelligence layer, running on your hardware, spanning your phone and laptop over your own network, with no server in between. It knows your messages, your calendar, your work, your life - because it lives with you, not above you. It preps you for meetings before you ask. It defers what can wait and surfaces what can't. It handles the coordination overhead of your day the way a great assistant has always handled it for the people who could afford one.
+A Personal AI OS. One intelligence layer, running on your hardware, spanning your phone and laptop over your own network, with no server in between. It knows your messages, your calendar, your work, your life. It lives with you, not above you. It preps you for meetings before you ask. It defers what can wait and surfaces what can't. It handles the coordination overhead of your day the way a great assistant has always handled it for the people who could afford one.
 
-Not AI making decisions while you sleep. Not autonomous agents acting on your behalf in ways you didn't sanction. A private digital secretary - proactive, aware, yours - that makes your day a little easier and your attention a little freer.
+Not AI making decisions while you sleep. Not autonomous agents acting on your behalf in ways you didn't sanction. A private digital secretary, proactive and aware, that makes your day a little easier and your attention a little freer.
 
 The same thing that secretaries have been doing for the powerful for 200 years. Now running on a device that billions of people already carry. On models that cost nothing to run. With data that never leaves your hands.
 

--- a/website/mission.md
+++ b/website/mission.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Mission
-nav_order: 3
-has_children: true
+parent: Ethos
+nav_order: 2
+has_children: false
 description: Intelligence will become ambient. Always on, always yours, always private. We're building the architecture that makes that possible — on the devices you already own, without asking you to trust anyone but yourself.
 ---
 

--- a/website/mission.md
+++ b/website/mission.md
@@ -2,88 +2,95 @@
 layout: default
 title: Mission
 nav_order: 4
-description: Why Off Grid exists. Intelligence will become ambient - always on, always yours. We're building the architecture that makes that possible without asking you to trust anyone but yourself.
+description: Intelligence will become ambient. Always on, always yours, always private. We're building the architecture that makes that possible — on the devices you already own, without asking you to trust anyone but yourself.
 ---
 
-# Mission
-
----
-
-<div class="mission-statement">
-  <p class="mission-tagline">Democratize intelligence on-person.</p>
-  <p class="mission-sub">Private by architecture. On the devices you already own.</p>
-</div>
+# Intelligence belongs to everyone.
 
 ---
 
-## The belief
+Navigation used to belong to experts. You needed a map, a compass, training. Then it became ambient — built into the device in your pocket, free, always on, available to anyone going anywhere. You stopped thinking about navigation as a tool. It just became part of how you move through the world.
 
-Intelligence will become ambient.
+Intelligence is next.
 
-Just like navigation became ambient — so embedded in daily life that you no longer think about it as a separate tool — intelligence will disappear into the background. You won't "open an AI app." You'll just have an intelligence layer that's always there, always on, always yours.
+Not intelligence you open an app to access. Not intelligence you pay rent to use. Not intelligence that lives on someone else's server and answers your questions when you remember to ask. **Ambient intelligence. Always on. Always yours. Woven into the fabric of your day the way navigation is woven into every journey.**
 
-That's inevitable. The question is who builds it and on whose terms.
-
----
-
-## The problem with how it's being built today
-
-Right now, to use AI, you hand your most private thoughts to someone else's server.
-
-Your health questions. Your relationship problems. Your financial decisions. Your half-formed ideas at 2am. All of it sitting on infrastructure you don't control, governed by terms you didn't read, in the hands of companies whose business model depends on having your data.
-
-The ones who promised to do it differently have had a pattern of not following through. Companies that launched with local-first, private-by-default commitments, then went cloud when the economics shifted, then got acquired, then shut down overnight. Users lost access to their own memories. That's not a hypothetical risk. It has already happened.
-
-The problem is structural. When your intelligence lives on someone else's server, you are always one acquisition, one policy change, or one pricing decision away from losing it.
+That's where this is going. The question isn't whether it happens. The question is who builds it, on whose terms, and whose data pays for it.
 
 ---
 
-## The conviction
+## The way it's being built today is wrong.
 
-Your phone and your laptop are insanely powerful.
+To use AI today, you hand your most private thoughts to someone else's infrastructure.
 
-A flagship phone today runs AI at 30 tokens a second — fast enough for real-time conversation, fully offline. These devices were designed for this workload. They have dedicated neural processing hardware that sits mostly idle while you pay monthly fees to send your queries to someone else's GPU.
+Your health questions. Your relationship problems. Your financial decisions. Your half-formed ideas at 2am. All of it travelling to a server you don't control, stored under terms you didn't read, in the hands of companies whose revenue model is built around having your data and keeping you dependent on their compute.
 
-The infrastructure is already in your pocket. What's missing is the product that makes it intelligent and makes your devices talk to each other.
+Some of them promised to do it differently. Local-first. Private by default. Yours, not theirs. They made the right noises — and then the economics shifted. They went cloud. Then they got acquired. Then they shut down overnight. Users who had given years of their most personal context to these products woke up one day and had nothing. Lost access to their own memories. Gone.
 
-We are not waiting for new hardware. We are not waiting for a new platform. The devices 4 billion people already carry are enough.
+**That's not a hypothetical. It already happened.**
 
----
+And it will happen again, to every product that builds intelligence on top of someone else's infrastructure, because the structural incentive never goes away. When your intelligence lives on a server you don't own, you are always one acquisition, one pricing change, one bad quarter away from losing it.
 
-## The ethos
-
-Privacy is not a feature. It's an architecture decision.
-
-The only guarantee that your data stays yours is that it never leaves your device in the first place. Not a policy. Not a toggle. Not a promise from a company that could be acquired tomorrow.
-
-Architecture.
-
-Open source so anyone can verify it. No account required. No telemetry. No analytics. If you can't audit it, you can't trust it.
-
-We hold this as a non-negotiable. Not because it's a good marketing position — but because it's the only honest answer to the question of who owns your intelligence.
+The problem isn't the companies. The problem is the architecture.
 
 ---
 
-## The vision
+## The infrastructure is already in your hands.
 
-A Personal AI OS. One intelligence layer across all your devices.
+The device in your pocket is more powerful than the servers that ran the first generation of cloud AI.
 
-It knows your messages, your calendar, your work, your life — because it lives on your hardware. Your phone and your laptop talk to each other over your own network, with no server in between. It preps you for meetings before you ask. It defers your notifications when you need to focus. It creates a calendar entry when someone messages about dinner three weeks out. It surfaces what matters and lets everything else wait.
+A current flagship phone runs AI at 30 tokens a second — fast enough for real-time conversation, fully offline, using dedicated neural hardware that was designed for exactly this workload. That hardware has been shipping to billions of people for years. It sits mostly idle while they pay monthly fees to send their thoughts to someone else's GPU.
 
-Not an AI agent making decisions while you sleep. A private digital secretary that makes your life a little easier — the same thing that secretaries have been doing for the powerful for 200 years, but now running on a device that billions of people already carry, on models that cost nothing to run, with data that never leaves your hands.
+**The infrastructure for a private, personal, ambient intelligence layer already exists. It's in the pocket of 4 billion people. What's been missing is the software that takes that seriously.**
 
----
-
-## The mission
-
-For two centuries, the intelligence layer — the assistant that handles the coordination overhead of a productive life — was a privilege of wealth and seniority.
-
-The device in your pocket has changed that equation. The models are free. The hardware is there. The only thing that was missing was software that took it seriously.
-
-That's what we're building.
-
-**Democratize intelligence. Make it personal, private, and ambient. On the hardware people already own. Without asking them to trust anyone but themselves.**
+We are not waiting for a new device. We are not waiting for a new platform. We are not betting on hardware that takes a decade to get adopted. The phone you already carry is enough. The laptop you already own is enough. The revolution doesn't require a purchase.
 
 ---
 
-*Off Grid is open source. [View on GitHub](https://github.com/alichherawalla/off-grid-mobile?utm_source=offgrid-docs&utm_medium=website&utm_campaign=github) or [join the community on Slack](https://join.slack.com/t/off-grid-mobile/shared_invite/zt-3swt3s84k-R0CHRwISaUpExV2~3qUUdQ).*
+## Privacy is not a feature. It's an architecture decision.
+
+You cannot solve a structural problem with a policy.
+
+"We anonymise before storing." "You can opt out in settings." "We take your privacy seriously." These are words. They describe intent, not architecture. They are revocable. They change when the company changes, when the terms change, when the acquisition happens.
+
+The only guarantee that your data stays yours is that it never leaves your device in the first place.
+
+Not a toggle. Not a promise. Not a trust-us. **Architecture.**
+
+Open source, so anyone can verify what the software actually does. No account required. No telemetry. No analytics. No data collection of any kind. If you can't audit it, you can't trust it — and you shouldn't.
+
+We hold this as a non-negotiable. Not because it's a better marketing position. Because it's the only honest answer to the question of who owns your intelligence.
+
+---
+
+## What we're building.
+
+For two hundred years, the people who operated at the highest levels of consequence had something everyone else didn't: a private intelligence layer.
+
+Someone who knew their priorities, managed their correspondence, prepared them for every meeting, tracked their commitments, drafted their communications, handled the coordination overhead of a productive life — so they could focus their attention on the work that actually required them.
+
+It was called a secretary. Then an executive assistant. Then a virtual assistant. Whatever the name, the function was the same: an intelligence layer available to you, handling everything except the decisions only you can make.
+
+For two hundred years, access to that layer was determined entirely by wealth and seniority. You had it if you could afford it. Everyone else managed the coordination overhead themselves — with their own attention, their own time, their own focus.
+
+**The device in your pocket changes that equation permanently.**
+
+A Personal AI OS — one intelligence layer, running on your hardware, spanning your phone and laptop over your own network, with no server in between. It knows your messages, your calendar, your work, your life — because it lives with you, not above you. It preps you for meetings before you ask. It defers what can wait and surfaces what can't. It handles the coordination overhead of your day the way a great assistant has always handled it for the people who could afford one.
+
+Not AI making decisions while you sleep. Not autonomous agents acting on your behalf in ways you didn't sanction. A private digital secretary — proactive, aware, yours — that makes your day a little easier and your attention a little freer.
+
+The same thing that secretaries have been doing for the powerful for 200 years. Now running on a device that billions of people already carry. On models that cost nothing to run. With data that never leaves your hands.
+
+---
+
+## The mission.
+
+**Democratize intelligence.**
+
+Make it personal. Make it private. Make it ambient. On the hardware people already own. Without asking them to trust anyone but themselves.
+
+That's what we're building with Off Grid.
+
+---
+
+*Open source. No account. No telemetry. [View on GitHub](https://github.com/alichherawalla/off-grid-mobile?utm_source=offgrid-docs&utm_medium=website&utm_campaign=github) · [Join the community](https://join.slack.com/t/off-grid-mobile/shared_invite/zt-3swt3s84k-R0CHRwISaUpExV2~3qUUdQ) · [Download the app](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=mission)*

--- a/website/mission.md
+++ b/website/mission.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Mission
-nav_order: 4
+nav_order: 3
+has_children: true
 description: Intelligence will become ambient. Always on, always yours, always private. We're building the architecture that makes that possible — on the devices you already own, without asking you to trust anyone but yourself.
 ---
 

--- a/website/vision.md
+++ b/website/vision.md
@@ -3,7 +3,7 @@ layout: default
 title: Vision
 parent: Ethos
 nav_order: 1
-description: What the world looks like when intelligence is ambient, personal, and private. One intelligence layer across all your devices — always on, always yours, never leaving your hands.
+description: What the world looks like when intelligence is ambient, personal, and private. One intelligence layer across all your devices -- always on, always yours, never leaving your hands.
 ---
 
 # The world we're building toward.
@@ -12,7 +12,7 @@ description: What the world looks like when intelligence is ambient, personal, a
 
 Imagine waking up and your devices already know your day.
 
-Not because they checked a server. Not because you opened an app and asked. Because the intelligence layer lives with you — on your hardware, across your phone and laptop, syncing over your home network while you slept. It read the messages that came in. It knows your calendar. It noticed that the meeting at 9am is with someone you haven't spoken to in three months and that the last conversation had an open item you never closed.
+Not because they checked a server. Not because you opened an app and asked. Because the intelligence layer lives with you -- on your hardware, across your phone and laptop, syncing over your home network while you slept. It read the messages that came in. It knows your calendar. It noticed that the meeting at 9am is with someone you haven't spoken to in three months and that the last conversation had an open item you never closed.
 
 By the time you pick up your phone, the briefing is ready. You didn't ask for it. It was just there.
 
@@ -24,7 +24,7 @@ Your phone and your laptop are used by one person. Today, they don't know that. 
 
 In the world we're building, that changes.
 
-Your phone knows your life — messages, location, health, the texture of your day. Your laptop knows your work — documents, email, the projects you're actually thinking about. A Personal AI OS spans both. It holds the context from every device you own, unified into a single working model of who you are and what you're doing.
+Your phone knows your life -- messages, location, health, the texture of your day. Your laptop knows your work -- documents, email, the projects you're actually thinking about. A Personal AI OS spans both. It holds the context from every device you own, unified into a single working model of who you are and what you're doing.
 
 It syncs over your own network. No cloud relay. No data leaving your home. Just two devices that finally talk to each other through the intelligence layer they share.
 
@@ -38,9 +38,9 @@ That's a fundamental mismatch with how intelligence is actually useful. A great 
 
 The Personal AI OS we're building works the same way.
 
-It sees your calendar fill up and notices when you're overcommitted. It reads an incoming message and decides whether it needs your attention now or can wait. It knows you have a meeting in 20 minutes and surfaces everything relevant — past conversations, open items, shared documents — without being asked. It hears your partner mention dinner plans in a text and creates the calendar event.
+It sees your calendar fill up and notices when you're overcommitted. It reads an incoming message and decides whether it needs your attention now or can wait. It knows you have a meeting in 20 minutes and surfaces everything relevant -- past conversations, open items, shared documents -- without being asked. It hears your partner mention dinner plans in a text and creates the calendar event.
 
-You don't pull intelligence out of it. It pushes what's relevant to you, at the right moment, on the right device. That's the shift — from reactive to proactive. From a tool you use to an intelligence that works alongside you.
+You don't pull intelligence out of it. It pushes what's relevant to you, at the right moment, on the right device. That's the shift -- from reactive to proactive. From a tool you use to an intelligence that works alongside you.
 
 ---
 
@@ -50,15 +50,15 @@ In the world we're building, privacy isn't a setting. It's not a promise. It's n
 
 It's the default output of the architecture.
 
-Your messages never leave your device. Your health data never touches a server. Your financial patterns, your relationships, your half-formed thoughts at midnight — all of it processed locally, stored locally, never transmitted. Not because we say so. Because the system has no mechanism to do otherwise.
+Your messages never leave your device. Your health data never touches a server. Your financial patterns, your relationships, your half-formed thoughts at midnight -- all of it processed locally, stored locally, never transmitted. Not because we say so. Because the system has no mechanism to do otherwise.
 
-Open source means you don't have to take our word for it. Anyone can read the code. Anyone can verify what leaves the device and what doesn't. The answer is nothing — and that's checkable.
+Open source means you don't have to take our word for it. Anyone can read the code. Anyone can verify what leaves the device and what doesn't. The answer is nothing -- and that's checkable.
 
 ---
 
 ## Intelligence for everyone.
 
-For two hundred years, having a personal intelligence layer — someone who managed your correspondence, prepared your meetings, tracked your commitments, handled the coordination overhead of a consequential life — was a privilege reserved for the powerful.
+For two hundred years, having a personal intelligence layer -- someone who managed your correspondence, prepared your meetings, tracked your commitments, handled the coordination overhead of a consequential life -- was a privilege reserved for the powerful.
 
 Not anymore.
 
@@ -72,4 +72,4 @@ The same intelligence layer that made some people more effective for two centuri
 
 ---
 
-*[Download Off Grid for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision). Open source — [view on GitHub](https://github.com/alichherawalla/off-grid-mobile?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision).*
+*[Download Off Grid for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision). Open source -- [view on GitHub](https://github.com/alichherawalla/off-grid-mobile?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision).*

--- a/website/vision.md
+++ b/website/vision.md
@@ -3,7 +3,7 @@ layout: default
 title: Vision
 parent: Ethos
 nav_order: 1
-description: What the world looks like when intelligence is ambient, personal, and private. One intelligence layer across all your devices -- always on, always yours, never leaving your hands.
+description: What the world looks like when intelligence is ambient, personal, and private. One intelligence layer across all your devices - always on, always yours, never leaving your hands.
 ---
 
 # The world we're building toward.
@@ -12,7 +12,7 @@ description: What the world looks like when intelligence is ambient, personal, a
 
 Imagine waking up and your devices already know your day.
 
-Not because they checked a server. Not because you opened an app and asked. Because the intelligence layer lives with you -- on your hardware, across your phone and laptop, syncing over your home network while you slept. It read the messages that came in. It knows your calendar. It noticed that the meeting at 9am is with someone you haven't spoken to in three months and that the last conversation had an open item you never closed.
+Not because they checked a server. Not because you opened an app and asked. Because the intelligence layer lives with you - on your hardware, across your phone and laptop, syncing over your home network while you slept. It read the messages that came in. It knows your calendar. It noticed that the meeting at 9am is with someone you haven't spoken to in three months and that the last conversation had an open item you never closed.
 
 By the time you pick up your phone, the briefing is ready. You didn't ask for it. It was just there.
 
@@ -24,7 +24,7 @@ Your phone and your laptop are used by one person. Today, they don't know that. 
 
 In the world we're building, that changes.
 
-Your phone knows your life -- messages, location, health, the texture of your day. Your laptop knows your work -- documents, email, the projects you're actually thinking about. A Personal AI OS spans both. It holds the context from every device you own, unified into a single working model of who you are and what you're doing.
+Your phone knows your life - messages, location, health, the texture of your day. Your laptop knows your work - documents, email, the projects you're actually thinking about. A Personal AI OS spans both. It holds the context from every device you own, unified into a single working model of who you are and what you're doing.
 
 It syncs over your own network. No cloud relay. No data leaving your home. Just two devices that finally talk to each other through the intelligence layer they share.
 
@@ -38,9 +38,9 @@ That's a fundamental mismatch with how intelligence is actually useful. A great 
 
 The Personal AI OS we're building works the same way.
 
-It sees your calendar fill up and notices when you're overcommitted. It reads an incoming message and decides whether it needs your attention now or can wait. It knows you have a meeting in 20 minutes and surfaces everything relevant -- past conversations, open items, shared documents -- without being asked. It hears your partner mention dinner plans in a text and creates the calendar event.
+It sees your calendar fill up and notices when you're overcommitted. It reads an incoming message and decides whether it needs your attention now or can wait. It knows you have a meeting in 20 minutes and surfaces everything relevant - past conversations, open items, shared documents - without being asked. It hears your partner mention dinner plans in a text and creates the calendar event.
 
-You don't pull intelligence out of it. It pushes what's relevant to you, at the right moment, on the right device. That's the shift -- from reactive to proactive. From a tool you use to an intelligence that works alongside you.
+You don't pull intelligence out of it. It pushes what's relevant to you, at the right moment, on the right device. That's the shift - from reactive to proactive. From a tool you use to an intelligence that works alongside you.
 
 ---
 
@@ -50,15 +50,15 @@ In the world we're building, privacy isn't a setting. It's not a promise. It's n
 
 It's the default output of the architecture.
 
-Your messages never leave your device. Your health data never touches a server. Your financial patterns, your relationships, your half-formed thoughts at midnight -- all of it processed locally, stored locally, never transmitted. Not because we say so. Because the system has no mechanism to do otherwise.
+Your messages never leave your device. Your health data never touches a server. Your financial patterns, your relationships, your half-formed thoughts at midnight - all of it processed locally, stored locally, never transmitted. Not because we say so. Because the system has no mechanism to do otherwise.
 
-Open source means you don't have to take our word for it. Anyone can read the code. Anyone can verify what leaves the device and what doesn't. The answer is nothing -- and that's checkable.
+Open source means you don't have to take our word for it. Anyone can read the code. Anyone can verify what leaves the device and what doesn't. The answer is nothing - and that's checkable.
 
 ---
 
 ## Intelligence for everyone.
 
-For two hundred years, having a personal intelligence layer -- someone who managed your correspondence, prepared your meetings, tracked your commitments, handled the coordination overhead of a consequential life -- was a privilege reserved for the powerful.
+For two hundred years, having a personal intelligence layer - someone who managed your correspondence, prepared your meetings, tracked your commitments, handled the coordination overhead of a consequential life - was a privilege reserved for the powerful.
 
 Not anymore.
 
@@ -72,4 +72,4 @@ The same intelligence layer that made some people more effective for two centuri
 
 ---
 
-*[Download Off Grid for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision). Open source -- [view on GitHub](https://github.com/alichherawalla/off-grid-mobile?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision).*
+*[Download Off Grid for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision). Open source - [view on GitHub](https://github.com/alichherawalla/off-grid-mobile?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision).*

--- a/website/vision.md
+++ b/website/vision.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: Vision
+parent: Mission
+nav_order: 2
+description: What the world looks like when intelligence is ambient, personal, and private. One intelligence layer across all your devices — always on, always yours, never leaving your hands.
+---
+
+# The world we're building toward.
+
+---
+
+Imagine waking up and your devices already know your day.
+
+Not because they checked a server. Not because you opened an app and asked. Because the intelligence layer lives with you — on your hardware, across your phone and laptop, syncing over your home network while you slept. It read the messages that came in. It knows your calendar. It noticed that the meeting at 9am is with someone you haven't spoken to in three months and that the last conversation had an open item you never closed.
+
+By the time you pick up your phone, the briefing is ready. You didn't ask for it. It was just there.
+
+---
+
+## One brain. All your devices.
+
+Your phone and your laptop are used by one person. Today, they don't know that. Each device holds a fragment of your context. Neither has the full picture. The intelligence they contain is isolated, sandboxed, unable to reason across both.
+
+In the world we're building, that changes.
+
+Your phone knows your life — messages, location, health, the texture of your day. Your laptop knows your work — documents, email, the projects you're actually thinking about. A Personal AI OS spans both. It holds the context from every device you own, unified into a single working model of who you are and what you're doing.
+
+It syncs over your own network. No cloud relay. No data leaving your home. Just two devices that finally talk to each other through the intelligence layer they share.
+
+---
+
+## Proactive, not reactive.
+
+Every AI product today waits for you to open it.
+
+That's a fundamental mismatch with how intelligence is actually useful. A great assistant doesn't wait to be asked. They notice things. They prepare you before you know you need it. They surface what matters and handle what doesn't require you.
+
+The Personal AI OS we're building works the same way.
+
+It sees your calendar fill up and notices when you're overcommitted. It reads an incoming message and decides whether it needs your attention now or can wait. It knows you have a meeting in 20 minutes and surfaces everything relevant — past conversations, open items, shared documents — without being asked. It hears your partner mention dinner plans in a text and creates the calendar event.
+
+You don't pull intelligence out of it. It pushes what's relevant to you, at the right moment, on the right device. That's the shift — from reactive to proactive. From a tool you use to an intelligence that works alongside you.
+
+---
+
+## Private by architecture. Always.
+
+In the world we're building, privacy isn't a setting. It's not a promise. It's not something you configure.
+
+It's the default output of the architecture.
+
+Your messages never leave your device. Your health data never touches a server. Your financial patterns, your relationships, your half-formed thoughts at midnight — all of it processed locally, stored locally, never transmitted. Not because we say so. Because the system has no mechanism to do otherwise.
+
+Open source means you don't have to take our word for it. Anyone can read the code. Anyone can verify what leaves the device and what doesn't. The answer is nothing — and that's checkable.
+
+---
+
+## Intelligence for everyone.
+
+For two hundred years, having a personal intelligence layer — someone who managed your correspondence, prepared your meetings, tracked your commitments, handled the coordination overhead of a consequential life — was a privilege reserved for the powerful.
+
+Not anymore.
+
+The device that 4 billion people already carry in their pocket has enough compute to run a capable AI model, fully offline, at real-time speed. The models are open-weight and free. The infrastructure costs nothing to run.
+
+The only thing standing between a billion people and their own private intelligence layer is software that takes it seriously.
+
+That's what we're building. Not for executives. Not for knowledge workers above a certain income threshold. For anyone with a phone. For anyone who has ever needed help thinking through a hard problem, tracking a commitment they made, preparing for a conversation that mattered, or just finding the message they know they received three weeks ago.
+
+The same intelligence layer that made some people more effective for two centuries. Now ambient, private, and in everyone's hands.
+
+---
+
+*[Download Off Grid for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision). Open source — [view on GitHub](https://github.com/alichherawalla/off-grid-mobile?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision).*

--- a/website/vision.md
+++ b/website/vision.md
@@ -3,7 +3,7 @@ layout: default
 title: Vision
 parent: Ethos
 nav_order: 1
-description: What the world looks like when intelligence is ambient, personal, and private. One intelligence layer across all your devices - always on, always yours, never leaving your hands.
+description: What the world looks like when intelligence is ambient, personal, and private. One intelligence layer across all your devices, always on, always yours, never leaving your hands.
 ---
 
 # The world we're building toward.
@@ -12,7 +12,7 @@ description: What the world looks like when intelligence is ambient, personal, a
 
 Imagine waking up and your devices already know your day.
 
-Not because they checked a server. Not because you opened an app and asked. Because the intelligence layer lives with you - on your hardware, across your phone and laptop, syncing over your home network while you slept. It read the messages that came in. It knows your calendar. It noticed that the meeting at 9am is with someone you haven't spoken to in three months and that the last conversation had an open item you never closed.
+Not because they checked a server. Not because you opened an app and asked. Because the intelligence layer lives with you. On your hardware, across your phone and laptop, syncing over your home network while you slept. It read the messages that came in. It knows your calendar. It noticed that the meeting at 9am is with someone you haven't spoken to in three months and that the last conversation had an open item you never closed.
 
 By the time you pick up your phone, the briefing is ready. You didn't ask for it. It was just there.
 
@@ -24,7 +24,7 @@ Your phone and your laptop are used by one person. Today, they don't know that. 
 
 In the world we're building, that changes.
 
-Your phone knows your life - messages, location, health, the texture of your day. Your laptop knows your work - documents, email, the projects you're actually thinking about. A Personal AI OS spans both. It holds the context from every device you own, unified into a single working model of who you are and what you're doing.
+Your phone knows your life: messages, location, health, the texture of your day. Your laptop knows your work: documents, email, the projects you're actually thinking about. A Personal AI OS spans both. It holds the context from every device you own, unified into a single working model of who you are and what you're doing.
 
 It syncs over your own network. No cloud relay. No data leaving your home. Just two devices that finally talk to each other through the intelligence layer they share.
 
@@ -38,9 +38,9 @@ That's a fundamental mismatch with how intelligence is actually useful. A great 
 
 The Personal AI OS we're building works the same way.
 
-It sees your calendar fill up and notices when you're overcommitted. It reads an incoming message and decides whether it needs your attention now or can wait. It knows you have a meeting in 20 minutes and surfaces everything relevant - past conversations, open items, shared documents - without being asked. It hears your partner mention dinner plans in a text and creates the calendar event.
+It sees your calendar fill up and notices when you're overcommitted. It reads an incoming message and decides whether it needs your attention now or can wait. It knows you have a meeting in 20 minutes and surfaces everything relevant without being asked: past conversations, open items, shared documents. It hears your partner mention dinner plans in a text and creates the calendar event.
 
-You don't pull intelligence out of it. It pushes what's relevant to you, at the right moment, on the right device. That's the shift - from reactive to proactive. From a tool you use to an intelligence that works alongside you.
+You don't pull intelligence out of it. It pushes what's relevant to you, at the right moment, on the right device. From reactive to proactive. From a tool you use to an intelligence that works alongside you.
 
 ---
 
@@ -50,15 +50,15 @@ In the world we're building, privacy isn't a setting. It's not a promise. It's n
 
 It's the default output of the architecture.
 
-Your messages never leave your device. Your health data never touches a server. Your financial patterns, your relationships, your half-formed thoughts at midnight - all of it processed locally, stored locally, never transmitted. Not because we say so. Because the system has no mechanism to do otherwise.
+Your messages never leave your device. Your health data never touches a server. Your financial patterns, your relationships, your half-formed thoughts at midnight. All of it processed locally, stored locally, never transmitted. Not because we say so. Because the system has no mechanism to do otherwise.
 
-Open source means you don't have to take our word for it. Anyone can read the code. Anyone can verify what leaves the device and what doesn't. The answer is nothing - and that's checkable.
+Open source means you don't have to take our word for it. Anyone can read the code. Anyone can verify what leaves the device and what doesn't. The answer is nothing. Checkable by anyone.
 
 ---
 
 ## Intelligence for everyone.
 
-For two hundred years, having a personal intelligence layer - someone who managed your correspondence, prepared your meetings, tracked your commitments, handled the coordination overhead of a consequential life - was a privilege reserved for the powerful.
+For two hundred years, having a personal intelligence layer was a privilege reserved for the powerful. Someone who managed your correspondence, prepared your meetings, tracked your commitments, and handled the coordination overhead of a consequential life.
 
 Not anymore.
 
@@ -72,4 +72,4 @@ The same intelligence layer that made some people more effective for two centuri
 
 ---
 
-*[Download Off Grid for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision). Open source - [view on GitHub](https://github.com/alichherawalla/off-grid-mobile?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision).*
+*[Download Off Grid for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision). Open source. [View on GitHub](https://github.com/alichherawalla/off-grid-mobile?utm_source=offgrid-docs&utm_medium=website&utm_campaign=vision).*

--- a/website/vision.md
+++ b/website/vision.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Vision
-parent: Mission
-nav_order: 2
+parent: Ethos
+nav_order: 1
 description: What the world looks like when intelligence is ambient, personal, and private. One intelligence layer across all your devices — always on, always yours, never leaving your hands.
 ---
 

--- a/website/writing/200-year-secretary.md
+++ b/website/writing/200-year-secretary.md
@@ -10,7 +10,7 @@ description: For two centuries, having a personal secretary was the defining adv
 
 For most of human history, if you wanted to get things done at scale, you needed people around you to handle the parts that didn't require your direct judgment.
 
-You needed someone to manage your correspondence. To prepare you before important meetings. To track your commitments and remind you of what was outstanding. To handle the administrative surface area of a productive life — the triage, the follow-up, the scheduling, the note-taking — so that your attention could go where it was most valuable.
+You needed someone to manage your correspondence. To prepare you before important meetings. To track your commitments and remind you of what was outstanding. To handle the administrative surface area of a productive life -- the triage, the follow-up, the scheduling, the note-taking -- so that your attention could go where it was most valuable.
 
 This role has existed for as long as there have been powerful people. It has had different names across different eras. But its function has been constant: a private intelligence layer, available to you, that handles everything except the decisions only you can make.
 
@@ -20,7 +20,7 @@ For two hundred years, that intelligence layer came in human form. And for two h
 
 ## The era of the private secretary
 
-Before the 20th century, a private secretary was the essential tool of anyone with significant responsibilities — a statesman, a business magnate, a senior military officer. They maintained correspondence, prepared briefings, tracked obligations, drafted communications, and organised the flow of information so that the principal could focus on the work that actually required their capabilities.
+Before the 20th century, a private secretary was the essential tool of anyone with significant responsibilities -- a statesman, a business magnate, a senior military officer. They maintained correspondence, prepared briefings, tracked obligations, drafted communications, and organised the flow of information so that the principal could focus on the work that actually required their capabilities.
 
 This was not a luxury. It was infrastructure. The people who operated at the highest levels of consequence understood that their most scarce resource was focused attention, and they built systems to protect it.
 
@@ -30,7 +30,7 @@ Access to that system required employing a person full-time. It was expensive, p
 
 ## The corporate era and the EA
 
-The 20th century industrialised the secretary function. As organisations scaled, the personal secretary became the executive assistant. Large organisations employed entire administrative departments. Access expanded — but only within the corporate hierarchy.
+The 20th century industrialised the secretary function. As organisations scaled, the personal secretary became the executive assistant. Large organisations employed entire administrative departments. Access expanded -- but only within the corporate hierarchy.
 
 If you were a senior executive, you had an assistant. If you were a manager, you shared one. If you were an individual contributor, you had none. The intelligence layer was distributed according to organisational status.
 
@@ -42,7 +42,7 @@ This solved the scaling problem for corporations but left the fundamental access
 
 The last two decades introduced a new model: the virtual assistant. Remote workers who could provide administrative support across time zones, at lower cost than hiring locally.
 
-The virtual assistant model genuinely expanded access. For the first time, individuals outside large organisations — entrepreneurs, independent professionals, small business owners — could afford a version of the intelligence layer that had historically been reserved for executives.
+The virtual assistant model genuinely expanded access. For the first time, individuals outside large organisations -- entrepreneurs, independent professionals, small business owners -- could afford a version of the intelligence layer that had historically been reserved for executives.
 
 But the model had hard limits. A human VA costs hundreds to thousands of dollars a month. They work business hours. They need onboarding. They can't be in the middle of a task and instantly available for another. And most critically: they require you to share the full context of your work and life with another person, in ongoing detail.
 
@@ -54,7 +54,7 @@ Access expanded. The inequality remained.
 
 A Personal AI OS changes the equation permanently.
 
-The tasks that defined the secretary, the executive assistant, and the virtual assistant — triage, preparation, drafting, tracking, retrieval — are exactly the tasks that a system with your full context can handle automatically.
+The tasks that defined the secretary, the executive assistant, and the virtual assistant -- triage, preparation, drafting, tracking, retrieval -- are exactly the tasks that a system with your full context can handle automatically.
 
 It knows which messages require a response and when. It prepares you for every meeting with the relevant history, open items, and context from your recent communications. It drafts the follow-up after a call using your tone and the specifics of what was discussed. It surfaces the document you need before you know you need it. It notices that you've over-committed next week and that something will have to give.
 
@@ -68,11 +68,11 @@ The intelligence layer that was reserved for the powerful for two centuries is n
 
 The productivity gap between people with strong administrative support and those without is not a trivial efficiency difference. It is a compounding structural advantage.
 
-The person with a great EA arrives at every meeting prepared. They never drop a commitment. They respond to important things quickly and let the rest wait appropriately. They protect their focused time. They don't spend cognitive resources on the administrative surface area of their work — they spend it on the work itself.
+The person with a great EA arrives at every meeting prepared. They never drop a commitment. They respond to important things quickly and let the rest wait appropriately. They protect their focused time. They don't spend cognitive resources on the administrative surface area of their work -- they spend it on the work itself.
 
-Over time, that difference compounds. Better prepared means more effective. More effective means more trusted. More trusted means more responsibility. The administrative support doesn't just save time — it changes outcomes.
+Over time, that difference compounds. Better prepared means more effective. More effective means more trusted. More trusted means more responsibility. The administrative support doesn't just save time -- it changes outcomes.
 
-For two hundred years, that compounding advantage accrued only to people who could afford to employ it. The Personal AI OS breaks that exclusivity — not by making the rich secretary available to everyone, but by making the function available on hardware that 4 billion people already own.
+For two hundred years, that compounding advantage accrued only to people who could afford to employ it. The Personal AI OS breaks that exclusivity -- not by making the rich secretary available to everyone, but by making the function available on hardware that 4 billion people already own.
 
 That's a bigger change than it looks.
 

--- a/website/writing/200-year-secretary.md
+++ b/website/writing/200-year-secretary.md
@@ -10,7 +10,7 @@ description: For two centuries, having a personal secretary was the defining adv
 
 For most of human history, if you wanted to get things done at scale, you needed people around you to handle the parts that didn't require your direct judgment.
 
-You needed someone to manage your correspondence. To prepare you before important meetings. To track your commitments and remind you of what was outstanding. To handle the administrative surface area of a productive life - the triage, the follow-up, the scheduling, the note-taking - so that your attention could go where it was most valuable.
+You needed someone to manage your correspondence. To prepare you before important meetings. To track your commitments and remind you of what was outstanding. To handle the administrative surface area of a productive life: the triage, the follow-up, the scheduling, the note-taking. So that your attention could go where it was most valuable.
 
 This role has existed for as long as there have been powerful people. It has had different names across different eras. But its function has been constant: a private intelligence layer, available to you, that handles everything except the decisions only you can make.
 
@@ -20,7 +20,7 @@ For two hundred years, that intelligence layer came in human form. And for two h
 
 ## The era of the private secretary
 
-Before the 20th century, a private secretary was the essential tool of anyone with significant responsibilities - a statesman, a business magnate, a senior military officer. They maintained correspondence, prepared briefings, tracked obligations, drafted communications, and organised the flow of information so that the principal could focus on the work that actually required their capabilities.
+Before the 20th century, a private secretary was the essential tool of anyone with significant responsibilities: a statesman, a business magnate, a senior military officer. They maintained correspondence, prepared briefings, tracked obligations, drafted communications, and organised the flow of information so that the principal could focus on the work that actually required their capabilities.
 
 This was not a luxury. It was infrastructure. The people who operated at the highest levels of consequence understood that their most scarce resource was focused attention, and they built systems to protect it.
 
@@ -30,7 +30,7 @@ Access to that system required employing a person full-time. It was expensive, p
 
 ## The corporate era and the EA
 
-The 20th century industrialised the secretary function. As organisations scaled, the personal secretary became the executive assistant. Large organisations employed entire administrative departments. Access expanded - but only within the corporate hierarchy.
+The 20th century industrialised the secretary function. As organisations scaled, the personal secretary became the executive assistant. Large organisations employed entire administrative departments. Access expanded. But only within the corporate hierarchy.
 
 If you were a senior executive, you had an assistant. If you were a manager, you shared one. If you were an individual contributor, you had none. The intelligence layer was distributed according to organisational status.
 
@@ -42,7 +42,7 @@ This solved the scaling problem for corporations but left the fundamental access
 
 The last two decades introduced a new model: the virtual assistant. Remote workers who could provide administrative support across time zones, at lower cost than hiring locally.
 
-The virtual assistant model genuinely expanded access. For the first time, individuals outside large organisations - entrepreneurs, independent professionals, small business owners - could afford a version of the intelligence layer that had historically been reserved for executives.
+The virtual assistant model genuinely expanded access. For the first time, individuals outside large organisations could afford a version of the intelligence layer that had historically been reserved for executives: entrepreneurs, independent professionals, small business owners.
 
 But the model had hard limits. A human VA costs hundreds to thousands of dollars a month. They work business hours. They need onboarding. They can't be in the middle of a task and instantly available for another. And most critically: they require you to share the full context of your work and life with another person, in ongoing detail.
 
@@ -54,7 +54,7 @@ Access expanded. The inequality remained.
 
 A Personal AI OS changes the equation permanently.
 
-The tasks that defined the secretary, the executive assistant, and the virtual assistant - triage, preparation, drafting, tracking, retrieval - are exactly the tasks that a system with your full context can handle automatically.
+The tasks that defined the secretary, the executive assistant, and the virtual assistant are exactly the tasks a system with your full context can handle automatically: triage, preparation, drafting, tracking, retrieval.
 
 It knows which messages require a response and when. It prepares you for every meeting with the relevant history, open items, and context from your recent communications. It drafts the follow-up after a call using your tone and the specifics of what was discussed. It surfaces the document you need before you know you need it. It notices that you've over-committed next week and that something will have to give.
 
@@ -68,14 +68,14 @@ The intelligence layer that was reserved for the powerful for two centuries is n
 
 The productivity gap between people with strong administrative support and those without is not a trivial efficiency difference. It is a compounding structural advantage.
 
-The person with a great EA arrives at every meeting prepared. They never drop a commitment. They respond to important things quickly and let the rest wait appropriately. They protect their focused time. They don't spend cognitive resources on the administrative surface area of their work - they spend it on the work itself.
+The person with a great EA arrives at every meeting prepared. They never drop a commitment. They respond to important things quickly and let the rest wait appropriately. They protect their focused time. They don't spend cognitive resources on the administrative surface area of their work. They spend it on the work itself.
 
-Over time, that difference compounds. Better prepared means more effective. More effective means more trusted. More trusted means more responsibility. The administrative support doesn't just save time - it changes outcomes.
+Over time, that difference compounds. Better prepared means more effective. More effective means more trusted. More trusted means more responsibility. The administrative support doesn't just save time. It changes outcomes.
 
-For two hundred years, that compounding advantage accrued only to people who could afford to employ it. The Personal AI OS breaks that exclusivity - not by making the rich secretary available to everyone, but by making the function available on hardware that 4 billion people already own.
+For two hundred years, that compounding advantage accrued only to people who could afford to employ it. The Personal AI OS breaks that exclusivity. Not by replicating the expensive model, but by making the function available on hardware that 4 billion people already own.
 
 That's a bigger change than it looks.
 
 ---
 
-*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone - the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*
+*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone, the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*

--- a/website/writing/200-year-secretary.md
+++ b/website/writing/200-year-secretary.md
@@ -1,0 +1,81 @@
+---
+layout: default
+title: "The 200-Year Secretary: How AI Finally Democratizes the World's Oldest Productivity Tool"
+parent: Perspectives
+nav_order: 26
+description: For two centuries, having a personal secretary was the defining advantage of wealth and power. A Personal AI OS running on the device in your pocket changes that equation permanently.
+---
+
+# The 200-Year Secretary: How AI Finally Democratizes the World's Oldest Productivity Tool
+
+For most of human history, if you wanted to get things done at scale, you needed people around you to handle the parts that didn't require your direct judgment.
+
+You needed someone to manage your correspondence. To prepare you before important meetings. To track your commitments and remind you of what was outstanding. To handle the administrative surface area of a productive life — the triage, the follow-up, the scheduling, the note-taking — so that your attention could go where it was most valuable.
+
+This role has existed for as long as there have been powerful people. It has had different names across different eras. But its function has been constant: a private intelligence layer, available to you, that handles everything except the decisions only you can make.
+
+For two hundred years, that intelligence layer came in human form. And for two hundred years, access to it was determined by one thing: wealth.
+
+---
+
+## The era of the private secretary
+
+Before the 20th century, a private secretary was the essential tool of anyone with significant responsibilities — a statesman, a business magnate, a senior military officer. They maintained correspondence, prepared briefings, tracked obligations, drafted communications, and organised the flow of information so that the principal could focus on the work that actually required their capabilities.
+
+This was not a luxury. It was infrastructure. The people who operated at the highest levels of consequence understood that their most scarce resource was focused attention, and they built systems to protect it.
+
+Access to that system required employing a person full-time. It was expensive, personal, and completely unavailable to anyone outside a narrow economic stratum.
+
+---
+
+## The corporate era and the EA
+
+The 20th century industrialised the secretary function. As organisations scaled, the personal secretary became the executive assistant. Large organisations employed entire administrative departments. Access expanded — but only within the corporate hierarchy.
+
+If you were a senior executive, you had an assistant. If you were a manager, you shared one. If you were an individual contributor, you had none. The intelligence layer was distributed according to organisational status.
+
+This solved the scaling problem for corporations but left the fundamental access inequality intact. The assistance went to those already at the top.
+
+---
+
+## The outsourcing era and the virtual assistant
+
+The last two decades introduced a new model: the virtual assistant. Remote workers who could provide administrative support across time zones, at lower cost than hiring locally.
+
+The virtual assistant model genuinely expanded access. For the first time, individuals outside large organisations — entrepreneurs, independent professionals, small business owners — could afford a version of the intelligence layer that had historically been reserved for executives.
+
+But the model had hard limits. A human VA costs hundreds to thousands of dollars a month. They work business hours. They need onboarding. They can't be in the middle of a task and instantly available for another. And most critically: they require you to share the full context of your work and life with another person, in ongoing detail.
+
+Access expanded. The inequality remained.
+
+---
+
+## What the AI changes
+
+A Personal AI OS changes the equation permanently.
+
+The tasks that defined the secretary, the executive assistant, and the virtual assistant — triage, preparation, drafting, tracking, retrieval — are exactly the tasks that a system with your full context can handle automatically.
+
+It knows which messages require a response and when. It prepares you for every meeting with the relevant history, open items, and context from your recent communications. It drafts the follow-up after a call using your tone and the specifics of what was discussed. It surfaces the document you need before you know you need it. It notices that you've over-committed next week and that something will have to give.
+
+None of this requires a server. None of it requires sharing your data with a third party. It runs on the device in your pocket, using models that cost nothing to run, with context that stays entirely in your hands.
+
+The intelligence layer that was reserved for the powerful for two centuries is now available to anyone with a flagship phone.
+
+---
+
+## Why this matters more than it sounds
+
+The productivity gap between people with strong administrative support and those without is not a trivial efficiency difference. It is a compounding structural advantage.
+
+The person with a great EA arrives at every meeting prepared. They never drop a commitment. They respond to important things quickly and let the rest wait appropriately. They protect their focused time. They don't spend cognitive resources on the administrative surface area of their work — they spend it on the work itself.
+
+Over time, that difference compounds. Better prepared means more effective. More effective means more trusted. More trusted means more responsibility. The administrative support doesn't just save time — it changes outcomes.
+
+For two hundred years, that compounding advantage accrued only to people who could afford to employ it. The Personal AI OS breaks that exclusivity — not by making the rich secretary available to everyone, but by making the function available on hardware that 4 billion people already own.
+
+That's a bigger change than it looks.
+
+---
+
+*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone - the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*

--- a/website/writing/200-year-secretary.md
+++ b/website/writing/200-year-secretary.md
@@ -10,7 +10,7 @@ description: For two centuries, having a personal secretary was the defining adv
 
 For most of human history, if you wanted to get things done at scale, you needed people around you to handle the parts that didn't require your direct judgment.
 
-You needed someone to manage your correspondence. To prepare you before important meetings. To track your commitments and remind you of what was outstanding. To handle the administrative surface area of a productive life -- the triage, the follow-up, the scheduling, the note-taking -- so that your attention could go where it was most valuable.
+You needed someone to manage your correspondence. To prepare you before important meetings. To track your commitments and remind you of what was outstanding. To handle the administrative surface area of a productive life - the triage, the follow-up, the scheduling, the note-taking - so that your attention could go where it was most valuable.
 
 This role has existed for as long as there have been powerful people. It has had different names across different eras. But its function has been constant: a private intelligence layer, available to you, that handles everything except the decisions only you can make.
 
@@ -20,7 +20,7 @@ For two hundred years, that intelligence layer came in human form. And for two h
 
 ## The era of the private secretary
 
-Before the 20th century, a private secretary was the essential tool of anyone with significant responsibilities -- a statesman, a business magnate, a senior military officer. They maintained correspondence, prepared briefings, tracked obligations, drafted communications, and organised the flow of information so that the principal could focus on the work that actually required their capabilities.
+Before the 20th century, a private secretary was the essential tool of anyone with significant responsibilities - a statesman, a business magnate, a senior military officer. They maintained correspondence, prepared briefings, tracked obligations, drafted communications, and organised the flow of information so that the principal could focus on the work that actually required their capabilities.
 
 This was not a luxury. It was infrastructure. The people who operated at the highest levels of consequence understood that their most scarce resource was focused attention, and they built systems to protect it.
 
@@ -30,7 +30,7 @@ Access to that system required employing a person full-time. It was expensive, p
 
 ## The corporate era and the EA
 
-The 20th century industrialised the secretary function. As organisations scaled, the personal secretary became the executive assistant. Large organisations employed entire administrative departments. Access expanded -- but only within the corporate hierarchy.
+The 20th century industrialised the secretary function. As organisations scaled, the personal secretary became the executive assistant. Large organisations employed entire administrative departments. Access expanded - but only within the corporate hierarchy.
 
 If you were a senior executive, you had an assistant. If you were a manager, you shared one. If you were an individual contributor, you had none. The intelligence layer was distributed according to organisational status.
 
@@ -42,7 +42,7 @@ This solved the scaling problem for corporations but left the fundamental access
 
 The last two decades introduced a new model: the virtual assistant. Remote workers who could provide administrative support across time zones, at lower cost than hiring locally.
 
-The virtual assistant model genuinely expanded access. For the first time, individuals outside large organisations -- entrepreneurs, independent professionals, small business owners -- could afford a version of the intelligence layer that had historically been reserved for executives.
+The virtual assistant model genuinely expanded access. For the first time, individuals outside large organisations - entrepreneurs, independent professionals, small business owners - could afford a version of the intelligence layer that had historically been reserved for executives.
 
 But the model had hard limits. A human VA costs hundreds to thousands of dollars a month. They work business hours. They need onboarding. They can't be in the middle of a task and instantly available for another. And most critically: they require you to share the full context of your work and life with another person, in ongoing detail.
 
@@ -54,7 +54,7 @@ Access expanded. The inequality remained.
 
 A Personal AI OS changes the equation permanently.
 
-The tasks that defined the secretary, the executive assistant, and the virtual assistant -- triage, preparation, drafting, tracking, retrieval -- are exactly the tasks that a system with your full context can handle automatically.
+The tasks that defined the secretary, the executive assistant, and the virtual assistant - triage, preparation, drafting, tracking, retrieval - are exactly the tasks that a system with your full context can handle automatically.
 
 It knows which messages require a response and when. It prepares you for every meeting with the relevant history, open items, and context from your recent communications. It drafts the follow-up after a call using your tone and the specifics of what was discussed. It surfaces the document you need before you know you need it. It notices that you've over-committed next week and that something will have to give.
 
@@ -68,11 +68,11 @@ The intelligence layer that was reserved for the powerful for two centuries is n
 
 The productivity gap between people with strong administrative support and those without is not a trivial efficiency difference. It is a compounding structural advantage.
 
-The person with a great EA arrives at every meeting prepared. They never drop a commitment. They respond to important things quickly and let the rest wait appropriately. They protect their focused time. They don't spend cognitive resources on the administrative surface area of their work -- they spend it on the work itself.
+The person with a great EA arrives at every meeting prepared. They never drop a commitment. They respond to important things quickly and let the rest wait appropriately. They protect their focused time. They don't spend cognitive resources on the administrative surface area of their work - they spend it on the work itself.
 
-Over time, that difference compounds. Better prepared means more effective. More effective means more trusted. More trusted means more responsibility. The administrative support doesn't just save time -- it changes outcomes.
+Over time, that difference compounds. Better prepared means more effective. More effective means more trusted. More trusted means more responsibility. The administrative support doesn't just save time - it changes outcomes.
 
-For two hundred years, that compounding advantage accrued only to people who could afford to employ it. The Personal AI OS breaks that exclusivity -- not by making the rich secretary available to everyone, but by making the function available on hardware that 4 billion people already own.
+For two hundred years, that compounding advantage accrued only to people who could afford to employ it. The Personal AI OS breaks that exclusivity - not by making the rich secretary available to everyone, but by making the function available on hardware that 4 billion people already own.
 
 That's a bigger change than it looks.
 

--- a/website/writing/7-principles-personal-ai-os.md
+++ b/website/writing/7-principles-personal-ai-os.md
@@ -3,10 +3,10 @@ layout: default
 title: "The 7 Principles of a Personal AI OS"
 parent: Perspectives
 nav_order: 6
-description: The rules that define the category. Runs on-device, never phones home, works across devices, acts on your behalf, remembers your context, open and auditable, no subscription required.
+description: The rules that define the category. Runs on-device, never phones home, works across devices, acts on your behalf, remembers your context, open and auditable, no cloud compute rent.
 faq:
   - q: What are the principles of a Personal AI OS?
-    a: "A Personal AI OS must: run on-device, never phone home, maintain persistent context, act on your behalf with consent, work across your devices over a local network, be open and auditable, and require no subscription. Any system missing one of these properties is not a Personal AI OS - it is a cloud AI assistant with some local features."
+    a: "A Personal AI OS must: run on-device, never phone home, maintain persistent context, act on your behalf with consent, work across your devices over a local network, be open and auditable, and charge no ongoing fees for AI compute. Any system missing one of these properties is not a Personal AI OS - it is a cloud AI assistant with some local features."
   - q: Why does a Personal AI OS need to be open source?
     a: Because the only meaningful privacy guarantee is one you can verify. A closed system asks you to trust the vendor's claims. An open system lets you inspect what the software actually does with your data. For a system with access to your messages, health data, and files, auditability is not optional.
 ---
@@ -81,13 +81,15 @@ Auditable by default means: build logs, no hidden endpoints, no obfuscated data 
 
 ---
 
-## 7. No subscription required
+## 7. No cloud compute rent
 
-You own the software. You run the model. You pay once, or you run open-source software for free.
+You do not pay ongoing fees for someone else's servers to process your queries.
 
-A subscription model for personal AI recreates the cloud dependency through economics. Even if inference runs locally, a subscription gives the vendor ongoing leverage - they can change terms, reduce capabilities, or discontinue the product and take your assistant with them.
+Cloud AI subscriptions exist because cloud AI has real ongoing costs - GPU inference, storage, engineers to run the infrastructure. Those costs are real and the subscription is the right model for recovering them.
 
-Intelligence should be a tool you own, like your calculator or your contacts app. The economics of on-device AI support this. There is no server cost to recover. The model runs on your hardware. The marginal cost of inference is your electricity bill.
+On-device AI has no such costs. The model runs on your hardware. There is no server invoice. The marginal cost of each inference is your electricity bill. A fee for that compute would be rent on hardware you already own.
+
+Software may have a cost - building a good application takes real work, and sustainable development requires revenue. But that is a different thing. You are paying for the application layer, not renting access to intelligence. The AI itself - the model, the inference, the context - is not metered, not throttled, and not subject to a price change by a company whose server you depend on.
 
 ---
 

--- a/website/writing/7-principles-personal-ai-os.md
+++ b/website/writing/7-principles-personal-ai-os.md
@@ -6,14 +6,14 @@ nav_order: 6
 description: The rules that define the category. Runs on-device, never phones home, works across devices, acts on your behalf, remembers your context, open and auditable, no cloud compute rent.
 faq:
   - q: What are the principles of a Personal AI OS?
-    a: "A Personal AI OS must: run on-device, never phone home, maintain persistent context, act on your behalf with consent, work across your devices over a local network, be open and auditable, and charge no ongoing fees for AI compute. Any system missing one of these properties is not a Personal AI OS - it is a cloud AI assistant with some local features."
+    a: "A Personal AI OS must: run on-device, never phone home, maintain persistent context, act on your behalf with consent, work across your devices over a local network, be open and auditable, and charge no ongoing fees for AI compute. Any system missing one of these properties is not a Personal AI OS. It is a cloud AI assistant with some local features."
   - q: Why does a Personal AI OS need to be open source?
     a: Because the only meaningful privacy guarantee is one you can verify. A closed system asks you to trust the vendor's claims. An open system lets you inspect what the software actually does with your data. For a system with access to your messages, health data, and files, auditability is not optional.
 ---
 
 # The 7 Principles of a Personal AI OS
 
-Every new software category needs a definition sharp enough to be useful - precise enough to include what belongs and exclude what doesn't.
+Every new software category needs a definition sharp enough to be useful: precise enough to include what belongs and exclude what doesn't.
 
 Personal AI OS is still being defined. Vendors will claim it. Analysts will debate it. Products will market toward it without meeting its actual requirements.
 
@@ -23,7 +23,7 @@ These are the 7 principles. They are not aspirational guidelines. They are the s
 
 ## 1. Runs on-device
 
-Inference happens on your hardware. Not on a server you access via API, not on a cloud instance provisioned on your behalf - on the device in your hand or on your desk.
+Inference happens on your hardware. Not on a server you access via API, not on a cloud instance provisioned on your behalf. On the device in your hand or on your desk.
 
 This is the foundational property. Everything else in this list depends on it. If inference runs on a server, the data had to get there somehow, which means the other properties cannot be guaranteed by architecture.
 
@@ -37,7 +37,7 @@ No telemetry. No usage logging. No data collection of any kind.
 
 Not "we anonymise before sending." Not "you can opt out in settings." Nothing leaves your device related to your queries, your context, or your usage.
 
-This is a binary property. Either the software sends data to external servers or it doesn't. Partial compliance - "we only collect aggregate statistics" - is not compliance. The architecture must be designed from the start to produce no outbound data.
+This is a binary property. Either the software sends data to external servers or it doesn't. Partial compliance ("we only collect aggregate statistics") is not compliance. The architecture must be designed from the start to produce no outbound data.
 
 ---
 
@@ -45,7 +45,7 @@ This is a binary property. Either the software sends data to external servers or
 
 The AI maintains a working model of your life between sessions.
 
-A system that forgets everything when you close it is not a Personal AI OS. It is a local chatbot. The defining capability of a Personal AI OS is that it knows you - not from a single conversation, but from accumulated context built over time.
+A system that forgets everything when you close it is not a Personal AI OS. It is a local chatbot. The defining capability of a Personal AI OS is that it knows you: not from a single conversation, but from accumulated context built over time.
 
 This means your calendar, your messages, your files, your work patterns, your preferences. Stored locally. Queryable by the model. Updated continuously as your life changes.
 
@@ -55,7 +55,7 @@ This means your calendar, your messages, your files, your work patterns, your pr
 
 The AI can take actions, not just answer questions.
 
-Drafting messages. Setting reminders. Summarising documents. Searching your files. Preparing you for a meeting. The output is not just text to read - it is action taken on your behalf, with your consent as the operating principle.
+Drafting messages. Setting reminders. Summarising documents. Searching your files. Preparing you for a meeting. The output is not just text to read. It is action taken on your behalf, with your consent as the operating principle.
 
 The line between helpful and intrusive is consent. A Personal AI OS acts when you ask, suggests when relevant, and defers when uncertain. It does not take consequential actions without your approval.
 
@@ -65,7 +65,7 @@ The line between helpful and intrusive is consent. A Personal AI OS acts when yo
 
 Your phone and laptop are used by the same person. The AI should have a unified view of both.
 
-Context built on your phone - messages, location, health - should be available on your laptop. Context from your laptop - files, email, work patterns - should be available on your phone. This sync happens over your local network, not through a cloud relay.
+Context built on your phone (messages, location, health) should be available on your laptop. Context from your laptop (files, email, work patterns) should be available on your phone. This sync happens over your local network, not through a cloud relay.
 
 No server in between. No data leaving your home. One person, one intelligence layer, two devices.
 
@@ -77,7 +77,7 @@ The model weights are open. The application code is open. Anyone can inspect wha
 
 This is not a nice-to-have. For a system with access to your messages, health data, calendar, and files, the privacy guarantee must be verifiable. A closed system asks you to trust the vendor. An open system lets you verify.
 
-Auditable by default means: build logs, no hidden endpoints, no obfuscated data paths. The architecture should be transparent enough that a technical user can confirm what leaves the device and what doesn't - and the answer should be nothing.
+Auditable by default means: build logs, no hidden endpoints, no obfuscated data paths. The architecture should be transparent enough that a technical user can confirm what leaves the device and what doesn't. The answer should be nothing.
 
 ---
 
@@ -85,11 +85,11 @@ Auditable by default means: build logs, no hidden endpoints, no obfuscated data 
 
 You do not pay ongoing fees for someone else's servers to process your queries.
 
-Cloud AI subscriptions exist because cloud AI has real ongoing costs - GPU inference, storage, engineers to run the infrastructure. Those costs are real and the subscription is the right model for recovering them.
+Cloud AI subscriptions exist because cloud AI has real ongoing costs: GPU inference, storage, engineers to run the infrastructure. Those costs are real and the subscription is the right model for recovering them.
 
 On-device AI has no such costs. The model runs on your hardware. There is no server invoice. The marginal cost of each inference is your electricity bill. A fee for that compute would be rent on hardware you already own.
 
-Software may have a cost - building a good application takes real work, and sustainable development requires revenue. But that is a different thing. You are paying for the application layer, not renting access to intelligence. The AI itself - the model, the inference, the context - is not metered, not throttled, and not subject to a price change by a company whose server you depend on.
+Software may have a cost, because building a good application takes real work and sustainable development requires revenue. But that is a different thing. You are paying for the application layer, not renting access to intelligence. The AI itself (the model, the inference, the context) is not metered, not throttled, and not subject to a price change by a company whose server you depend on.
 
 ---
 

--- a/website/writing/a-day-with-personal-ai-os.md
+++ b/website/writing/a-day-with-personal-ai-os.md
@@ -22,7 +22,7 @@ This is not a search feature. Searching requires you to remember that you need t
 
 ## 9:10am
 
-You are on a corporate network that blocks external traffic. No ChatGPT. No Copilot. No cloud anything.
+You are on a corporate network that blocks external traffic. No cloud AI. No external APIs. Nothing.
 
 Your AI still works. It is running on your phone. It does not need a server. You ask it to summarise a long PDF you received this morning. It does.
 

--- a/website/writing/a-day-with-personal-ai-os.md
+++ b/website/writing/a-day-with-personal-ai-os.md
@@ -8,73 +8,67 @@ description: From morning to night - a narrative walkthrough of what your day lo
 
 # A Day With a Personal AI OS: What It Looks Like When Your Devices Actually Work Together
 
-The best way to understand what a Personal AI OS changes is to walk through a day with one.
+The best way to understand what a personal AI OS changes is to walk through a day with one.
 
-This is not science fiction. Every capability described here is technically achievable today. Some of it Off Grid already does. The rest is a near-term roadmap.
+Not the features. The actual texture of the day.
 
-## 7:15am - You wake up
+## 7:20am
 
-Your phone has been running quietly through the night. It knows you slept 6 hours and 20 minutes, which is below your recent average. It noticed three messages arrive between midnight and 7am - one from a colleague in a different timezone, one from a group chat, one from your partner's family.
+You open a voice memo app on your phone, say three sentences about a problem you were thinking about in the shower, and put it down.
 
-Before you look at your phone, the AI has already classified them. The colleague's message is about a deliverable due today - it's surfaced at the top, flagged as requiring your attention this morning. The group chat is social - it's there but not demanding. The family message will wait.
+Later today, when you open a document related to that problem, those three sentences are already there as a note. You did not paste them. You did not search for them. The AI connected the voice memo to the project context it already knew about.
 
-You didn't ask for any of this. You don't see a dashboard or a summary view. You just open your messages and the most important one is at the top, because the AI already knew which one mattered.
+This is not a search feature. Searching requires you to remember that you need to search. This surfaced because the AI understood what you were working on.
 
-## 8:30am - You get to your laptop
+## 9:10am
 
-Your laptop's AI now has the context your phone built overnight. It knows the message that needs a response. It knows you slept short. It knows what's on your calendar today.
+You are on a corporate network that blocks external traffic. No ChatGPT. No Copilot. No cloud anything.
 
-Before you open your email, it surfaces one thing: "You have a 10am with Sarah. You last discussed the Q3 timeline in a message thread three weeks ago. The relevant notes are here."
+Your AI still works. It is running on your phone. It does not need a server. You ask it to summarise a long PDF you received this morning. It does.
 
-You hadn't thought to prepare. Now you're prepared. Four minutes of reading instead of fifteen minutes of searching.
+This is unremarkable to you. You have stopped thinking about whether you have a connection.
 
-## 9:45am - A conflict surfaces
+## 11:00am
 
-Your calendar shows a hard conflict you missed when you accepted two invites on different devices. The AI catches it and flags it: "You have two meetings at 2pm. One was added on your phone last night, one was already on your calendar. Do you want to resolve this?"
+A colleague asks you in a message what you discussed with a client six weeks ago. You do not remember the specifics.
 
-One tap to decline the less important one with a note. Done in thirty seconds.
+You ask your AI. It finds the relevant thread, pulls out the key points, and gives you a two-sentence summary. The entire interaction takes twenty seconds.
 
-Without the AI, this surfaces as a problem when both meetings start and you're already on one call.
+The important part: none of that conversation history was ever sent to a server to be indexed or searched. It was processed locally, on your device, by a model that has been building an understanding of your work for months. The client never consented to their words being uploaded to a third-party service. They did not have to.
 
-## 11:20am - You need to draft something difficult
+## 1:30pm
 
-You have to send a message to a client that involves delivering unwelcome news about a timeline. You open the AI, describe the situation in a few sentences, and ask for a draft.
+You record a voice note during a walk - three action items from a call you just finished. You are not near your laptop. You are not in an app. You just speak.
 
-Because the AI has your communication style from months of context, the draft sounds like you. The tone is right. The framing is yours. You edit two sentences and send it.
+By the time you sit back down forty minutes later, those action items are transcribed, associated with the right project, and waiting. Not in a separate notes app. In context, where they belong.
 
-Total time: four minutes. On your own: twenty-five minutes and three rewrites.
+The transcription ran on your phone. Nothing went anywhere.
 
-## 1:15pm - You're eating and your phone is in your pocket
+## 3:15pm
 
-A Slack message comes in tagged urgent. The AI, running on your phone with Do Not Disturb active for the next 45 minutes, reads it. It's actually urgent - a production issue needs your attention.
+You switch from your phone to your laptop. The document you were annotating on your phone is ready to continue. The context from your morning - the voice note, the client summary, the action items - is there.
 
-It overrides the DND and sends you a notification.
+It synced over your local WiFi while you walked between rooms. No account. No cloud intermediary. You are one person with two devices, and both devices now know that.
 
-The next message tagged urgent is from someone who marks everything urgent. It waits.
+This is the thing that does not exist yet in any mainstream tool. Every current sync mechanism routes through a server. Someone else holds your context. Here, the context is yours. The sync is local. The model is yours.
 
-You didn't configure specific rules for these two people. The AI built a model of what "actually urgent" means to you from observing how you've responded in the past.
+## 6:00pm
 
-## 3:40pm - Context crosses devices again
+You ask your AI to draft a difficult message - one where you have to tell someone their timeline is not going to hold.
 
-You were working on your phone for the past hour - reviewing documents, sending messages, taking notes on a voice memo. You sit back down at your laptop.
+The draft does not sound like a generic AI response. It sounds like you, because the AI has been reading how you write for months and has built a model of your tone entirely on-device. You change one sentence. You send it.
 
-The context synced over your local WiFi while you walked between rooms. Your laptop AI has your afternoon's work context already. The document you annotated on your phone is ready to continue on your laptop. The voice memo has been transcribed and attached to the relevant project.
+The uncomfortable part of that task - figuring out what to say, how to frame it, how to stay direct without being cold - was still yours. That required judgment. The AI handled the mechanical part: translating your intent into words that sound like you.
 
-No manual sync. No "continue on this device" button. It just happened, because you're one person and both devices know that.
+## What the day actually felt like
 
-## 6:30pm - Winding down
+You did not have a conversation with an AI assistant. You did not open a chat interface. You did not think "I should ask the AI about this."
 
-You're done for the day. You pick up your phone and the AI surfaces the close-of-day view: three things that didn't get resolved today, one commitment that needs to move to tomorrow, and a brief on what's coming in the morning.
+The AI was operating below your attention threshold. Connecting things. Remembering things. Handling the infrastructure of your day so you could spend your attention on the things that required it.
 
-You review it in two minutes. You close three things and move one. Your tomorrow is already set up.
+The difference between this and what exists today is not speed. It is not convenience. It is that your context, your patterns, your history - none of it left your device. You were not paying for productivity with your privacy.
 
-## What this is actually like to use
-
-None of the above interactions required you to open a separate app, talk to a chat interface, or think about what to ask. The AI was surface-level present - doing things you would have done, at moments when your attention was elsewhere.
-
-The experience is not "I have an AI assistant I talk to." It's "my devices work significantly better than they used to."
-
-The friction that disappeared was all low-value work. The things you spent attention on today - the difficult message, the client conversation, the decisions that actually required your judgment - remained yours. The AI handled the infrastructure of your day, not the substance of it.
+That is what a personal AI OS is. Not a smarter assistant. A layer of intelligence that is entirely, actually yours.
 
 ---
 

--- a/website/writing/case-against-ai-subscriptions.md
+++ b/website/writing/case-against-ai-subscriptions.md
@@ -1,20 +1,22 @@
 ---
 layout: default
-title: "The Case Against AI Subscriptions: Why Intelligence Should Be a One-Time Investment"
+title: "The Case Against Cloud AI Subscriptions: Why You Shouldn't Pay to Rent Your Own Intelligence"
 parent: Perspectives
 nav_order: 19
-description: You don't pay a monthly fee to use your calculator. You don't subscribe to access your contacts. Intelligence - the most useful tool in your personal software stack - should work the same way.
+description: Cloud AI subscriptions charge you a monthly fee to access compute on someone else's server. When that intelligence can run on hardware you already own, the rent stops making sense.
 ---
 
-# The Case Against AI Subscriptions: Why Intelligence Should Be a One-Time Investment
+# The Case Against Cloud AI Subscriptions: Why You Shouldn't Pay to Rent Your Own Intelligence
 
-Your calculator doesn't have a subscription tier.
+Your calculator doesn't bill you monthly for arithmetic.
 
 You don't pay $20 a month to access your contacts app. Your notes app doesn't throttle you to 100 notes unless you upgrade. Your camera doesn't limit you to 50 photos per month on the free plan.
 
-These tools work because you own them. You paid once, or they came with your device, and they work indefinitely without any ongoing relationship with the company that made them.
+These tools work because the compute that powers them lives on your device. You paid once, or they came with your hardware, and they work indefinitely without any ongoing relationship with the company that made them.
 
-AI is the most significant tool added to personal computing in a generation. The subscription model being applied to it is not inevitable. It's a choice - one that creates dependency, limits access by income, and is fundamentally mismatched with what the technology actually requires.
+Cloud AI subscriptions are different. They charge you monthly because the compute is theirs, not yours - every query runs on their GPU, their infrastructure, their electricity bill. That cost has to come from somewhere, and the subscription is how they recover it.
+
+That model made sense when running a capable AI model required a data centre. It makes less sense every year as the hardware in your pocket becomes more powerful. AI is the most significant tool added to personal computing in a generation. Paying monthly to rent access to it - when the intelligence can run on hardware you already own - is a choice worth questioning.
 
 ## Why AI subscriptions exist
 
@@ -68,6 +70,6 @@ The models are open-weight. The software runs on your device. The core capabilit
 
 We may offer optional paid features. But the model - the intelligence layer itself - runs locally, is not metered, and is not subject to a price change by a third party.
 
-Your calculator doesn't have a subscription. Your AI shouldn't either.
+You should pay for software. You shouldn't pay rent for intelligence that runs on hardware you already own.
 
 *[Download Off Grid for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*

--- a/website/writing/case-against-ai-subscriptions.md
+++ b/website/writing/case-against-ai-subscriptions.md
@@ -48,7 +48,7 @@ In the 1970s, calculators were expensive enough that access to one was a genuine
 
 AI capability is following the same arc. The models are getting smaller and more capable at the same time. The hardware to run them is becoming standard on every new device. The cost of running a capable AI locally is approaching zero.
 
-The subscription model tries to maintain a paid gate on a tool whose cost structure no longer justifies it. It's the equivalent of charging a monthly fee for a calculator in 2024.
+The cloud AI subscription model tries to maintain a paid gate on compute that you increasingly own yourself. You are paying a monthly fee not for the intelligence - the open-weight models are free - but to rent access to someone else's hardware to run it on. As local hardware catches up, that rent becomes harder to justify.
 
 ## The open source alternative
 

--- a/website/writing/context-gap.md
+++ b/website/writing/context-gap.md
@@ -8,11 +8,11 @@ description: Your phone could know your tone, your schedule, your health, your l
 
 # The Context Gap: Why Your Most Personal Devices Are the Least Intelligent Things You Own
 
-Your refrigerator knows nothing about you. That is fine - a refrigerator does not need to.
+Your refrigerator knows nothing about you. That is fine. A refrigerator does not need to.
 
 Your phone is different. It has been with you, awake, for every hour of every day for years. It has recorded your location continuously. It has your complete message history. It knows your health data, your calendar, your photos. It contains more information about you than any other object you own.
 
-And yet your phone's intelligence layer - the AI that is supposed to help you - can set a timer, look up the weather, and play a song on request. That is approximately the capability level of a 1990s voice-activated toy.
+And yet your phone's intelligence layer (the AI that is supposed to help you) can set a timer, look up the weather, and play a song on request. That is approximately the capability level of a 1990s voice-activated toy.
 
 This is the context gap: the distance between what your devices know about you and what they do with that knowledge.
 
@@ -22,19 +22,19 @@ This is the context gap: the distance between what your devices know about you a
 
 Consider the data that exists on a typical phone:
 
-**Communication.** Every message sent and received across every app - iMessage, WhatsApp, email, Slack. The full text, the timestamps, the contacts, the tone of each exchange.
+**Communication.** Every message sent and received across every app: iMessage, WhatsApp, email, Slack. The full text, the timestamps, the contacts, the tone of each exchange.
 
-**Location.** Where you have been, when, and for how long - continuously, for years. Your home, your office, the places you visit regularly, the trips you have taken.
+**Location.** Where you have been, when, and for how long. Continuously, for years. Your home, your office, the places you visit regularly, the trips you have taken.
 
-**Calendar.** Your schedule and its history - what you agreed to, what you cancelled, what you moved, how you spend your weeks.
+**Calendar.** Your schedule and its history: what you agreed to, what you cancelled, what you moved, how you spend your weeks.
 
 **Health.** Steps, sleep, heart rate, workouts. The physical patterns of your life over time.
 
 **Apps.** What you open, when, how long you spend in each. The shape of your digital behaviour.
 
-**Photos.** A visual record of your life - where you have been, who you have been with, what you have done.
+**Photos.** A visual record of your life: where you have been, who you have been with, what you have done.
 
-This is an extraordinary amount of context. No other system - not your doctor, not your closest friends, not your employer - has access to this volume and variety of information about you.
+This is an extraordinary amount of context. No other system, not your doctor, not your closest friends, not your employer, has access to this volume and variety of information about you.
 
 What does the AI on your phone do with it? Almost nothing.
 
@@ -42,9 +42,9 @@ What does the AI on your phone do with it? Almost nothing.
 
 ## What your laptop knows
 
-Your laptop has different context - less personal, more professional.
+Your laptop has different context: less personal, more professional.
 
-It has the documents you have written, the code you have committed, the emails you have drafted. It has your browser history - the research you have done, the articles you have read, the tabs you have left open for three weeks. It has the files that represent your active work.
+It has the documents you have written, the code you have committed, the emails you have drafted. It has your browser history: the research you have done, the articles you have read, the tabs you have left open for three weeks. It has the files that represent your active work.
 
 The AI on your laptop can autocomplete text in some contexts and answer questions about the current document in others. It cannot tell you what you have been working on for the past month. It cannot notice that you have been avoiding a particular task. It cannot connect the research you did two weeks ago to the question you are trying to answer today.
 
@@ -56,9 +56,9 @@ The context gap is not a technical failure. The technology to close it exists. L
 
 The gap exists because of architecture and incentives.
 
-**Architecture.** The dominant platforms - iOS, Android - are built on an app model. Each app runs in a sandbox. Intelligence at the platform level has had to work within the constraints of that app model rather than operating as a true cross-context layer. The data is there, in hundreds of separate silos. The intelligence layer does not have a single coherent view of it.
+**Architecture.** The dominant platforms (iOS, Android) are built on an app model. Each app runs in a sandbox. Intelligence at the platform level has had to work within the constraints of that app model rather than operating as a true cross-context layer. The data is there, in hundreds of separate silos. The intelligence layer does not have a single coherent view of it.
 
-**Incentives.** A platform AI that truly knew you - your patterns, your health, your relationships - would be extraordinarily valuable. It would also create significant privacy exposure and regulatory risk. Platform companies have been cautious about building systems with this level of personal knowledge, partly because of the risk and partly because the resulting system would need to be trusted at a level that is difficult to earn under current cloud architectures.
+**Incentives.** A platform AI that truly knew you (your patterns, your health, your relationships) would be extraordinarily valuable. It would also create significant privacy exposure and regulatory risk. Platform companies have been cautious about building systems with this level of personal knowledge, partly because of the risk and partly because the resulting system would need to be trusted at a level that is difficult to earn under current cloud architectures.
 
 The result is devices full of personal context with almost no intelligence built on top of it.
 
@@ -72,7 +72,7 @@ The context gap is closable. It requires three things.
 
 **A unified context layer.** Software that aggregates context from multiple apps and data sources into a single model the AI can query, rather than the fragmented, sandboxed access model of current platform AI.
 
-**An architecture that earns trust.** The reason platforms have been cautious about building systems with deep personal knowledge is that cloud architectures create real privacy risk. On-device architecture removes that risk - the data stays local, the model runs in your phone's memory, nothing leaves the device.
+**An architecture that earns trust.** The reason platforms have been cautious about building systems with deep personal knowledge is that cloud architectures create real privacy risk. On-device architecture removes that risk. The data stays local, the model runs in your phone's memory, and nothing leaves the device.
 
 All three are available now. The context gap is not a technology problem waiting for a breakthrough. It is a product and architecture problem waiting for someone to build the right thing.
 

--- a/website/writing/cross-device-sync-without-server.md
+++ b/website/writing/cross-device-sync-without-server.md
@@ -12,7 +12,7 @@ The standard model for cross-device sync involves a server in the middle.
 
 Your phone sends data up. Your laptop pulls data down. The server is the source of truth, the conflict resolver, and the thing that makes the system work when your devices aren't on the same network.
 
-This model works well for apps where the data is low-risk - notes, bookmarks, photos. For a Personal AI OS, where the data is your messages, health records, and working context, routing everything through a server is the wrong architecture.
+This model works well for apps where the data is low-risk: notes, bookmarks, photos. For a Personal AI OS, where the data is your messages, health records, and working context, routing everything through a server is the wrong architecture.
 
 There is a better model.
 
@@ -22,7 +22,7 @@ A Personal AI OS on your phone builds context from your life: messages, location
 
 A Personal AI OS on your laptop builds context from your work: files, email, browser history, the documents you're writing, the meetings you're preparing for.
 
-Both kinds of context are useful on both devices. When you pick up your phone before a meeting, you want access to the work context your laptop built. When you open your laptop in the morning, you want the phone's context from the previous evening - what you had to deal with, how you slept, what's urgent.
+Both kinds of context are useful on both devices. When you pick up your phone before a meeting, you want access to the work context your laptop built. When you open your laptop in the morning, you want the phone's context from the previous evening: what you had to deal with, how you slept, what's urgent.
 
 The goal is one intelligence layer that spans both devices, with context flowing between them in real time.
 
@@ -30,7 +30,7 @@ The goal is one intelligence layer that spans both devices, with context flowing
 
 A cloud relay for context sync has the same structural problems as cloud AI generally, amplified.
 
-Your context is more sensitive than your queries. Individual AI queries can be argued to be low-risk in isolation. Your full context - message patterns, health data, work files, location history - is a detailed model of your life. The server that holds it, even temporarily during sync, is a single point of exposure.
+Your context is more sensitive than your queries. Individual AI queries can be argued to be low-risk in isolation. Your full context (message patterns, health data, work files, location history) is a detailed model of your life. The server that holds it, even temporarily during sync, is a single point of exposure.
 
 It also introduces a dependency. If the sync server is unavailable, your context stops flowing between devices. If the service is discontinued, your cross-device sync stops working. If the terms change, the entity that controlled the relay now controls the most sensitive data you've handed to any system.
 
@@ -40,15 +40,15 @@ A Personal AI OS should not have these properties.
 
 The alternative is direct device-to-device sync over your local network.
 
-When your phone and laptop are on the same WiFi network - at home, at an office - they communicate directly. Context built on your phone transfers to your laptop over the local network connection. Context built on your laptop transfers back. No server involved. No data leaves your network perimeter.
+When your phone and laptop are on the same WiFi network, at home or at an office, they communicate directly. Context built on your phone transfers to your laptop over the local network connection. Context built on your laptop transfers back. No server involved. No data leaves your network perimeter.
 
-This is not a theoretical future capability. The protocols exist. Local network discovery (mDNS/Bonjour), direct device communication, encrypted transport - all of this is standard infrastructure on modern platforms.
+This is not a theoretical future capability. The protocols exist. Local network discovery (mDNS/Bonjour), direct device communication, encrypted transport: all of this is standard infrastructure on modern platforms.
 
 The implementation requires designing the Personal AI OS as a distributed system rather than a client-server system. Context is stored on your devices and synced between them directly, not stored in the cloud and pushed down to clients.
 
 ## What this looks like in practice
 
-You finish work on your laptop at 7pm. The context from your day - the document you were editing, the email thread you were working through, the meeting notes from this afternoon - transfers to your phone over your home WiFi as you close the lid.
+You finish work on your laptop at 7pm. The context from your day transfers to your phone over your home WiFi as you close the lid: the document you were editing, the email thread you were working through, the meeting notes from this afternoon.
 
 You pick up your phone at 8pm. The AI on your phone has your work context. When you decide to respond to a message that references the document you were working on, the AI has the context to help you.
 
@@ -64,7 +64,7 @@ Two answers.
 
 First, each device carries its own full context. Your phone has its context. Your laptop has its context. They are both useful independently. They don't become useless when they can't sync.
 
-Second, for users who want sync across networks, the right solution is a private tunnel - Tailscale, WireGuard, or similar - that connects your devices securely without routing through a third-party server. You run the infrastructure. You control the relay. The data stays yours.
+Second, for users who want sync across networks, the right solution is a private tunnel (Tailscale, WireGuard, or similar) that connects your devices securely without routing through a third-party server. You run the infrastructure. You control the relay. The data stays yours.
 
 This is more setup than a cloud service. It is also the only architecture that keeps your full context under your control regardless of where you are.
 
@@ -74,7 +74,7 @@ Current personal AI products are designed around the cloud sync model because it
 
 As on-device AI becomes the default assumption for a growing number of products, the infrastructure for local sync becomes more practical to build and more expected by users. The category will move toward it for the same reason it will move toward privacy generally: users who understand the alternatives will prefer them.
 
-The Personal AI OS that gets this right - context that flows between your devices privately, reliably, without a server in the middle - closes the last gap between what personal computing can do and what it should do.
+The Personal AI OS that gets this right closes the last gap between what personal computing can do and what it should do: context that flows between your devices privately, reliably, without a server in the middle.
 
 ---
 

--- a/website/writing/how-personal-ai-should-act.md
+++ b/website/writing/how-personal-ai-should-act.md
@@ -8,7 +8,7 @@ description: Proactive AI assistance is useful. But the line between helpful and
 
 # How a Personal AI OS Should Act on Your Behalf - Without Becoming Your Boss
 
-There is a version of personal AI that is useful - one that handles the low-value work you repeat every day and gives you back the mental space it was consuming. And there is a version that is suffocating - one that takes over decisions you wanted to make yourself, surfaces information you didn't want surfaced, and makes you feel monitored rather than helped.
+There is a version of personal AI that is useful: one that handles the low-value work you repeat every day and gives you back the mental space it was consuming. And there is a version that is suffocating, one that takes over decisions you wanted to make yourself, surfaces information you didn't want surfaced, and makes you feel monitored rather than helped.
 
 The difference is not capability. It's design philosophy.
 
@@ -30,7 +30,7 @@ These actions are useful because they happen within a clear boundary: the AI is 
 
 The line between helpful and creepy is consent and transparency.
 
-An AI that defers a notification is helpful if you set up that rule and know it's happening. An AI that starts suppressing notifications on its own judgement - even if that judgement is usually right - is one that's making decisions about your information diet without your input.
+An AI that defers a notification is helpful if you set up that rule and know it's happening. An AI that starts suppressing notifications on its own judgement, even if that judgement is usually right, is one that's making decisions about your information diet without your input.
 
 An AI that suggests a reply to a message is helpful if you asked for it. An AI that learns your communication style and generates pre-written replies for you to approve is useful. An AI that starts sending messages without showing them to you first is something else entirely.
 
@@ -58,7 +58,7 @@ Proactive assistance means the AI notices things, surfaces them, and makes the n
 
 Autonomous action means the AI takes the action without asking. It resolves the calendar conflict by declining one invite. It responds to messages. It rearranges your day.
 
-Proactive is good. Autonomous requires explicit delegation - tasks where you've clearly said "handle this without asking me."
+Proactive is good. Autonomous requires explicit delegation: tasks where you've clearly said "handle this without asking me."
 
 The default should be proactive. Autonomy should be the exception, granted task by task, with full transparency about what the AI is doing and the ability to review its actions.
 
@@ -74,7 +74,7 @@ A Personal AI OS with good defaults:
 - Prepares context before meetings rather than summarising after without being asked
 - Tells you what it's doing when it takes action in the background
 
-The goal is to be the assistant who handles the work you'd delegate to a smart person who knows your priorities - not the one who starts making calls on your behalf before you've decided you trust them that much.
+The goal is to be the assistant who handles the work you'd delegate to a smart person who knows your priorities. Not the one who starts making calls on your behalf before you've decided you trust them that much.
 
 Trust is earned incrementally. A Personal AI OS should behave the same way.
 

--- a/website/writing/index.md
+++ b/website/writing/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Perspectives
-nav_order: 6
+nav_order: 7
 has_children: true
 description: Essays on the future of personal AI, on-device intelligence, and why the most important software of the next decade runs on hardware you already own.
 ---
@@ -21,11 +21,11 @@ Essays on where personal AI is going, how it should work, and why it matters.
   </a>
   <a href="{{ '/writing/7-principles-personal-ai-os' | relative_url }}" class="guide-card">
     <div class="guide-card-title">The 7 Principles of a Personal AI OS</div>
-    <div class="guide-card-desc">On-device. No telemetry. Persistent context. Acts on your behalf. Cross-device. Open and auditable. No subscription. The rules that define the category.</div>
+    <div class="guide-card-desc">On-device. No telemetry. Persistent context. Acts on your behalf. Cross-device. Open and auditable. No cloud compute rent. The rules that define the category.</div>
   </a>
   <a href="{{ '/writing/personal-ai-os-vs-assistant-vs-agent' | relative_url }}" class="guide-card">
     <div class="guide-card-title">Personal AI OS vs AI Assistant vs AI Agent</div>
-    <div class="guide-card-desc">Siri answers questions. ChatGPT generates text. Autonomous agents take actions. A Personal AI OS does something different from all three.</div>
+    <div class="guide-card-desc">Voice assistants answer questions. Cloud chatbots generate text. Autonomous agents take actions. A Personal AI OS does something different from all three.</div>
   </a>
   <a href="{{ '/writing/why-personal-ai-should-never-live-in-cloud' | relative_url }}" class="guide-card">
     <div class="guide-card-title">Why Your Personal AI Should Never Live in the Cloud</div>
@@ -85,8 +85,8 @@ Essays on where personal AI is going, how it should work, and why it matters.
 
 <div class="guide-grid">
   <a href="{{ '/writing/whatsapp-moment-for-ai' | relative_url }}" class="guide-card">
-    <div class="guide-card-title">The WhatsApp Moment for AI</div>
-    <div class="guide-card-desc">WhatsApp adopted end-to-end encryption because the market demanded it. AI is next. The arc is the same.</div>
+    <div class="guide-card-title">The Encrypted Messaging Moment for AI</div>
+    <div class="guide-card-desc">Encrypted messaging went mainstream because the market demanded it. AI is next. The arc is the same.</div>
   </a>
   <a href="{{ '/writing/walled-garden-problem' | relative_url }}" class="guide-card">
     <div class="guide-card-title">The Walled Garden Problem</div>
@@ -94,7 +94,26 @@ Essays on where personal AI is going, how it should work, and why it matters.
   </a>
   <a href="{{ '/writing/regulatory-case-for-on-device-ai' | relative_url }}" class="guide-card">
     <div class="guide-card-title">The Regulatory Case for On-Device AI</div>
-    <div class="guide-card-desc">Every major privacy regulation - GDPR, DPDP, EU AI Act - is a tailwind for on-device AI. The architecture that's right for users ages well with regulators.</div>
+    <div class="guide-card-desc">Every major privacy regulation passed in the last five years is a tailwind for on-device AI. The architecture that's right for users ages well with regulators.</div>
+  </a>
+</div>
+
+---
+
+## The democratization of intelligence
+
+<div class="guide-grid">
+  <a href="{{ '/writing/200-year-secretary' | relative_url }}" class="guide-card">
+    <div class="guide-card-title">The 200-Year Secretary</div>
+    <div class="guide-card-desc">For two centuries, having a personal secretary was the defining advantage of wealth and power. A Personal AI OS running on the device in your pocket changes that equation permanently.</div>
+  </a>
+  <a href="{{ '/writing/next-virtual-assistant' | relative_url }}" class="guide-card">
+    <div class="guide-card-title">Your Next Virtual Assistant Won't Be a Person</div>
+    <div class="guide-card-desc">The VA model built a billion-dollar industry on human judgment at low cost. On-device AI undercuts that model - and delivers something human VAs structurally cannot: your full context, always available, private by architecture.</div>
+  </a>
+  <a href="{{ '/writing/va-industry-disruption' | relative_url }}" class="guide-card">
+    <div class="guide-card-title">Why the VA Industry Is About to Be Disrupted by On-Device AI</div>
+    <div class="guide-card-desc">The VA market is billions and growing. On-device AI competes on a dimension the human model can't match: full personal context, available at any hour, private by design.</div>
   </a>
 </div>
 
@@ -136,7 +155,7 @@ Essays on where personal AI is going, how it should work, and why it matters.
   </a>
   <a href="{{ '/writing/platform-intelligence-doesnt-exist' | relative_url }}" class="guide-card">
     <div class="guide-card-title">Why Platform Intelligence Doesn't Exist Yet</div>
-    <div class="guide-card-desc">iOS and Android are app-centric operating systems. The AI bolted onto that model can't be a true intelligence layer. Here's what it would take to build one.</div>
+    <div class="guide-card-desc">Mobile platforms are app-centric operating systems. The AI bolted onto that model can't be a true intelligence layer. Here's what it would take to build one.</div>
   </a>
   <a href="{{ '/writing/phone-laptop-know-nothing' | relative_url }}" class="guide-card">
     <div class="guide-card-title">Your Phone and Laptop Know Nothing About You</div>

--- a/website/writing/index.md
+++ b/website/writing/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Perspectives
-nav_order: 7
+nav_order: 6
 has_children: true
 description: Essays on the future of personal AI, on-device intelligence, and why the most important software of the next decade runs on hardware you already own.
 ---

--- a/website/writing/index.md
+++ b/website/writing/index.md
@@ -77,6 +77,10 @@ Essays on where personal AI is going, how it should work, and why it matters.
     <div class="guide-card-title">The Personal AI OS for Knowledge Workers</div>
     <div class="guide-card-desc">Email triage, meeting prep, deep work protection, status updates. What reclaiming 2+ hours a day actually looks like.</div>
   </a>
+  <a href="{{ '/writing/the-small-things' | relative_url }}" class="guide-card">
+    <div class="guide-card-title">It's Not About Productivity. It's About the 35 Tabs.</div>
+    <div class="guide-card-desc">Hiring a secretary doesn't 5x your business. It just means life is easier. We spend 90% of our time on digital devices and almost none of that time is actually easy.</div>
+  </a>
 </div>
 
 ---

--- a/website/writing/next-virtual-assistant.md
+++ b/website/writing/next-virtual-assistant.md
@@ -1,0 +1,91 @@
+---
+layout: default
+title: "Your Next Virtual Assistant Won't Be a Person — And That's the Point"
+parent: Perspectives
+nav_order: 27
+description: The virtual assistant industry built a model on human judgment at low cost. On-device AI undercuts that model entirely - and delivers something human VAs structurally cannot.
+---
+
+# Your Next Virtual Assistant Won't Be a Person — And That's the Point
+
+The virtual assistant industry exists because of a simple insight: a lot of the work that consumes a knowledge worker's day doesn't actually require that specific knowledge worker.
+
+Email triage. Meeting scheduling. Research summaries. Follow-up messages. Calendar management. Travel coordination. Document formatting. Status updates. The administrative surface area of modern professional life is enormous — and most of it is templated, repetitive, and executable by someone with context and good judgment, regardless of whether they have the specific expertise of the person they're assisting.
+
+Human virtual assistants filled that gap. Remote workers who could handle the coordination overhead so that their clients could focus on the work that required their actual expertise. The model worked. The industry grew to billions in annual spend.
+
+But the model has a structural ceiling. And on-device AI is what breaks through it.
+
+---
+
+## What human VAs do well
+
+Human virtual assistants are genuinely good at several things that matter.
+
+They understand nuance. A human VA who has worked with you for six months understands your communication style, your priorities, your pet peeves, and your implicit preferences in ways that are hard to specify in advance and easier to observe over time.
+
+They can make judgment calls. When an edge case comes up that doesn't fit the instructions, a good VA uses judgment. They know when to act and when to ask.
+
+They handle ambiguity. The world of professional communication is full of things that require reading context, not just executing instructions. A human VA can tell when a message is more loaded than it appears.
+
+These are real capabilities. They're also increasingly replicable — and in some ways surpassable — by a system that has more context than any human assistant can have.
+
+---
+
+## What human VAs can't do
+
+Human virtual assistants have structural limits that no amount of skill or dedication can overcome.
+
+**They don't have your full context.** A human VA sees what you share with them. They don't see your calendar, your messages, your files, your health data, your location, and your work patterns simultaneously. The context that would make the intelligence layer most useful is also the context that's hardest to hand to another person.
+
+**They work business hours.** A VA in a different time zone can extend coverage, but nobody is available at 11pm when you need to prepare for an 8am meeting and want to know what the open items were from the last discussion with that client.
+
+**They cost ongoing money.** A competent VA is not cheap. A skilled EA-level VA less so. The model prices many of the people who could most benefit from administrative support out of the market.
+
+**They require trust and coordination overhead.** Working with a human VA requires explaining context, reviewing output, managing the relationship, and handling the inevitable edge cases where communication breaks down. This overhead is real and recurring.
+
+**They scale linearly.** One VA can handle a bounded amount of work. When your administrative surface area grows, the cost grows with it.
+
+None of these are criticisms of human VAs. They are properties of any system where the intelligence layer is a person with finite time, bounded access to your context, and a cost structure tied to human labour.
+
+---
+
+## What on-device AI delivers differently
+
+A Personal AI OS running locally on your device changes the calculus on every one of these dimensions.
+
+It has your full context. Your messages, your calendar, your files, your patterns — all of it, all at once, all the time. The intelligence it can apply to your inbox or your upcoming meeting is informed by everything you have, not just what you've chosen to share.
+
+It's available at any hour. There's no time zone, no business hours, no response delay. When you're prepping for a morning meeting the night before, the context is there.
+
+It has no ongoing cost tied to your usage. The model runs on your device. The marginal cost of the hundredth email triage is the same as the first.
+
+It requires no relationship management. The context is built from your data, not from a working relationship that needs tending. The system knows you from what you actually do, not from what you've explained.
+
+It scales with your needs. More emails, more meetings, more complexity — the system handles it without renegotiating terms.
+
+---
+
+## What it still doesn't replace
+
+On-device AI is not a complete replacement for everything a skilled human assistant does.
+
+Human judgment in genuinely novel situations — where the right move isn't derivable from past patterns — is still a human edge. Complex relationship management that requires emotional intelligence and interpersonal calibration is still a human capability. Tasks that require physical presence or real-world interaction are still human territory.
+
+But the vast majority of what makes administrative support valuable is not in those categories. Most of it is pattern recognition applied to communication, scheduling, and coordination — exactly the domain where a system with full context and no time constraints outperforms a person with bounded access and a limited workday.
+
+---
+
+## Who this actually helps
+
+The human VA model helped people who could afford it. Typically knowledge workers at senior levels, entrepreneurs with enough revenue to justify the cost, executives at organisations that provided support as a benefit.
+
+The people below that threshold — the ones with just as much administrative overhead but without the revenue or seniority to justify dedicated support — got nothing. They managed it themselves, which meant it consumed the same focused attention they needed for the work that actually required them.
+
+On-device AI doesn't just improve on the VA model for existing customers. It makes the function available to people the model never reached in the first place.
+
+That's the more interesting story. Not that a faster or cheaper virtual assistant exists. But that the intelligence layer — the thing that made executives more effective for a century — is now in the pocket of anyone who wants it.
+
+---
+
+*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone - the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*

--- a/website/writing/next-virtual-assistant.md
+++ b/website/writing/next-virtual-assistant.md
@@ -1,16 +1,16 @@
 ---
 layout: default
-title: "Your Next Virtual Assistant Won't Be a Person — And That's the Point"
+title: "Your Next Virtual Assistant Won't Be a Person -- And That's the Point"
 parent: Perspectives
 nav_order: 27
 description: The virtual assistant industry built a model on human judgment at low cost. On-device AI undercuts that model entirely - and delivers something human VAs structurally cannot.
 ---
 
-# Your Next Virtual Assistant Won't Be a Person — And That's the Point
+# Your Next Virtual Assistant Won't Be a Person -- And That's the Point
 
 The virtual assistant industry exists because of a simple insight: a lot of the work that consumes a knowledge worker's day doesn't actually require that specific knowledge worker.
 
-Email triage. Meeting scheduling. Research summaries. Follow-up messages. Calendar management. Travel coordination. Document formatting. Status updates. The administrative surface area of modern professional life is enormous — and most of it is templated, repetitive, and executable by someone with context and good judgment, regardless of whether they have the specific expertise of the person they're assisting.
+Email triage. Meeting scheduling. Research summaries. Follow-up messages. Calendar management. Travel coordination. Document formatting. Status updates. The administrative surface area of modern professional life is enormous -- and most of it is templated, repetitive, and executable by someone with context and good judgment, regardless of whether they have the specific expertise of the person they're assisting.
 
 Human virtual assistants filled that gap. Remote workers who could handle the coordination overhead so that their clients could focus on the work that required their actual expertise. The model worked. The industry grew to billions in annual spend.
 
@@ -28,7 +28,7 @@ They can make judgment calls. When an edge case comes up that doesn't fit the in
 
 They handle ambiguity. The world of professional communication is full of things that require reading context, not just executing instructions. A human VA can tell when a message is more loaded than it appears.
 
-These are real capabilities. They're also increasingly replicable — and in some ways surpassable — by a system that has more context than any human assistant can have.
+These are real capabilities. They're also increasingly replicable -- and in some ways surpassable -- by a system that has more context than any human assistant can have.
 
 ---
 
@@ -54,7 +54,7 @@ None of these are criticisms of human VAs. They are properties of any system whe
 
 A Personal AI OS running locally on your device changes the calculus on every one of these dimensions.
 
-It has your full context. Your messages, your calendar, your files, your patterns — all of it, all at once, all the time. The intelligence it can apply to your inbox or your upcoming meeting is informed by everything you have, not just what you've chosen to share.
+It has your full context. Your messages, your calendar, your files, your patterns -- all of it, all at once, all the time. The intelligence it can apply to your inbox or your upcoming meeting is informed by everything you have, not just what you've chosen to share.
 
 It's available at any hour. There's no time zone, no business hours, no response delay. When you're prepping for a morning meeting the night before, the context is there.
 
@@ -62,7 +62,7 @@ It has no ongoing cost tied to your usage. The model runs on your device. The ma
 
 It requires no relationship management. The context is built from your data, not from a working relationship that needs tending. The system knows you from what you actually do, not from what you've explained.
 
-It scales with your needs. More emails, more meetings, more complexity — the system handles it without renegotiating terms.
+It scales with your needs. More emails, more meetings, more complexity -- the system handles it without renegotiating terms.
 
 ---
 
@@ -70,9 +70,9 @@ It scales with your needs. More emails, more meetings, more complexity — the s
 
 On-device AI is not a complete replacement for everything a skilled human assistant does.
 
-Human judgment in genuinely novel situations — where the right move isn't derivable from past patterns — is still a human edge. Complex relationship management that requires emotional intelligence and interpersonal calibration is still a human capability. Tasks that require physical presence or real-world interaction are still human territory.
+Human judgment in genuinely novel situations -- where the right move isn't derivable from past patterns -- is still a human edge. Complex relationship management that requires emotional intelligence and interpersonal calibration is still a human capability. Tasks that require physical presence or real-world interaction are still human territory.
 
-But the vast majority of what makes administrative support valuable is not in those categories. Most of it is pattern recognition applied to communication, scheduling, and coordination — exactly the domain where a system with full context and no time constraints outperforms a person with bounded access and a limited workday.
+But the vast majority of what makes administrative support valuable is not in those categories. Most of it is pattern recognition applied to communication, scheduling, and coordination -- exactly the domain where a system with full context and no time constraints outperforms a person with bounded access and a limited workday.
 
 ---
 
@@ -80,11 +80,11 @@ But the vast majority of what makes administrative support valuable is not in th
 
 The human VA model helped people who could afford it. Typically knowledge workers at senior levels, entrepreneurs with enough revenue to justify the cost, executives at organisations that provided support as a benefit.
 
-The people below that threshold — the ones with just as much administrative overhead but without the revenue or seniority to justify dedicated support — got nothing. They managed it themselves, which meant it consumed the same focused attention they needed for the work that actually required them.
+The people below that threshold -- the ones with just as much administrative overhead but without the revenue or seniority to justify dedicated support -- got nothing. They managed it themselves, which meant it consumed the same focused attention they needed for the work that actually required them.
 
 On-device AI doesn't just improve on the VA model for existing customers. It makes the function available to people the model never reached in the first place.
 
-That's the more interesting story. Not that a faster or cheaper virtual assistant exists. But that the intelligence layer — the thing that made executives more effective for a century — is now in the pocket of anyone who wants it.
+That's the more interesting story. Not that a faster or cheaper virtual assistant exists. But that the intelligence layer -- the thing that made executives more effective for a century -- is now in the pocket of anyone who wants it.
 
 ---
 

--- a/website/writing/next-virtual-assistant.md
+++ b/website/writing/next-virtual-assistant.md
@@ -1,20 +1,20 @@
 ---
 layout: default
-title: "Your Next Virtual Assistant Won't Be a Person - And That's the Point"
+title: "Your Next Virtual Assistant Won't Be a Person. And That's the Point."
 parent: Perspectives
 nav_order: 27
-description: The virtual assistant industry built a model on human judgment at low cost. On-device AI undercuts that model entirely - and delivers something human VAs structurally cannot.
+description: The virtual assistant industry built a model on human judgment at low cost. On-device AI undercuts that model entirely and delivers something human VAs structurally cannot.
 ---
 
-# Your Next Virtual Assistant Won't Be a Person - And That's the Point
+# Your Next Virtual Assistant Won't Be a Person. And That's the Point.
 
 The virtual assistant industry exists because of a simple insight: a lot of the work that consumes a knowledge worker's day doesn't actually require that specific knowledge worker.
 
-Email triage. Meeting scheduling. Research summaries. Follow-up messages. Calendar management. Travel coordination. Document formatting. Status updates. The administrative surface area of modern professional life is enormous - and most of it is templated, repetitive, and executable by someone with context and good judgment, regardless of whether they have the specific expertise of the person they're assisting.
+Email triage. Meeting scheduling. Research summaries. Follow-up messages. Calendar management. Travel coordination. Document formatting. Status updates. The administrative surface area of modern professional life is enormous, and most of it is templated, repetitive, and executable by someone with context and good judgment, regardless of whether they have the specific expertise of the person they're assisting.
 
 Human virtual assistants filled that gap. Remote workers who could handle the coordination overhead so that their clients could focus on the work that required their actual expertise. The model worked. The industry grew to billions in annual spend.
 
-But the model has a structural ceiling. And on-device AI is what breaks through it.
+But the model has a structural ceiling. On-device AI is what breaks through it.
 
 ---
 
@@ -28,7 +28,7 @@ They can make judgment calls. When an edge case comes up that doesn't fit the in
 
 They handle ambiguity. The world of professional communication is full of things that require reading context, not just executing instructions. A human VA can tell when a message is more loaded than it appears.
 
-These are real capabilities. They're also increasingly replicable - and in some ways surpassable - by a system that has more context than any human assistant can have.
+These are real capabilities. They're also increasingly replicable by a system that has more context than any human assistant can have. In some ways, surpassable.
 
 ---
 
@@ -54,7 +54,7 @@ None of these are criticisms of human VAs. They are properties of any system whe
 
 A Personal AI OS running locally on your device changes the calculus on every one of these dimensions.
 
-It has your full context. Your messages, your calendar, your files, your patterns - all of it, all at once, all the time. The intelligence it can apply to your inbox or your upcoming meeting is informed by everything you have, not just what you've chosen to share.
+It has your full context. Your messages, your calendar, your files, your patterns. All of it, all at once, all the time. The intelligence it can apply to your inbox or your upcoming meeting is informed by everything you have, not just what you've chosen to share.
 
 It's available at any hour. There's no time zone, no business hours, no response delay. When you're prepping for a morning meeting the night before, the context is there.
 
@@ -62,7 +62,7 @@ It has no ongoing cost tied to your usage. The model runs on your device. The ma
 
 It requires no relationship management. The context is built from your data, not from a working relationship that needs tending. The system knows you from what you actually do, not from what you've explained.
 
-It scales with your needs. More emails, more meetings, more complexity - the system handles it without renegotiating terms.
+It scales with your needs. More emails, more meetings, more complexity. The system handles it without renegotiating terms.
 
 ---
 
@@ -70,9 +70,9 @@ It scales with your needs. More emails, more meetings, more complexity - the sys
 
 On-device AI is not a complete replacement for everything a skilled human assistant does.
 
-Human judgment in genuinely novel situations - where the right move isn't derivable from past patterns - is still a human edge. Complex relationship management that requires emotional intelligence and interpersonal calibration is still a human capability. Tasks that require physical presence or real-world interaction are still human territory.
+Human judgment in genuinely novel situations, where the right move isn't derivable from past patterns, is still a human edge. Complex relationship management that requires emotional intelligence and interpersonal calibration is still a human capability. Tasks that require physical presence or real-world interaction are still human territory.
 
-But the vast majority of what makes administrative support valuable is not in those categories. Most of it is pattern recognition applied to communication, scheduling, and coordination - exactly the domain where a system with full context and no time constraints outperforms a person with bounded access and a limited workday.
+But the vast majority of what makes administrative support valuable is not in those categories. Most of it is pattern recognition applied to communication, scheduling, and coordination. Exactly the domain where a system with full context and no time constraints outperforms a person with bounded access and a limited workday.
 
 ---
 
@@ -80,12 +80,12 @@ But the vast majority of what makes administrative support valuable is not in th
 
 The human VA model helped people who could afford it. Typically knowledge workers at senior levels, entrepreneurs with enough revenue to justify the cost, executives at organisations that provided support as a benefit.
 
-The people below that threshold - the ones with just as much administrative overhead but without the revenue or seniority to justify dedicated support - got nothing. They managed it themselves, which meant it consumed the same focused attention they needed for the work that actually required them.
+The people below that threshold had just as much administrative overhead but without the revenue or seniority to justify dedicated support. They managed it themselves, which meant it consumed the same focused attention they needed for the work that actually required them.
 
 On-device AI doesn't just improve on the VA model for existing customers. It makes the function available to people the model never reached in the first place.
 
-That's the more interesting story. Not that a faster or cheaper virtual assistant exists. But that the intelligence layer - the thing that made executives more effective for a century - is now in the pocket of anyone who wants it.
+That's the more interesting story. Not that a faster or cheaper virtual assistant exists. But that the intelligence layer that made executives more effective for a century is now in the pocket of anyone who wants it.
 
 ---
 
-*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone - the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*
+*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone, the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*

--- a/website/writing/next-virtual-assistant.md
+++ b/website/writing/next-virtual-assistant.md
@@ -1,16 +1,16 @@
 ---
 layout: default
-title: "Your Next Virtual Assistant Won't Be a Person -- And That's the Point"
+title: "Your Next Virtual Assistant Won't Be a Person - And That's the Point"
 parent: Perspectives
 nav_order: 27
 description: The virtual assistant industry built a model on human judgment at low cost. On-device AI undercuts that model entirely - and delivers something human VAs structurally cannot.
 ---
 
-# Your Next Virtual Assistant Won't Be a Person -- And That's the Point
+# Your Next Virtual Assistant Won't Be a Person - And That's the Point
 
 The virtual assistant industry exists because of a simple insight: a lot of the work that consumes a knowledge worker's day doesn't actually require that specific knowledge worker.
 
-Email triage. Meeting scheduling. Research summaries. Follow-up messages. Calendar management. Travel coordination. Document formatting. Status updates. The administrative surface area of modern professional life is enormous -- and most of it is templated, repetitive, and executable by someone with context and good judgment, regardless of whether they have the specific expertise of the person they're assisting.
+Email triage. Meeting scheduling. Research summaries. Follow-up messages. Calendar management. Travel coordination. Document formatting. Status updates. The administrative surface area of modern professional life is enormous - and most of it is templated, repetitive, and executable by someone with context and good judgment, regardless of whether they have the specific expertise of the person they're assisting.
 
 Human virtual assistants filled that gap. Remote workers who could handle the coordination overhead so that their clients could focus on the work that required their actual expertise. The model worked. The industry grew to billions in annual spend.
 
@@ -28,7 +28,7 @@ They can make judgment calls. When an edge case comes up that doesn't fit the in
 
 They handle ambiguity. The world of professional communication is full of things that require reading context, not just executing instructions. A human VA can tell when a message is more loaded than it appears.
 
-These are real capabilities. They're also increasingly replicable -- and in some ways surpassable -- by a system that has more context than any human assistant can have.
+These are real capabilities. They're also increasingly replicable - and in some ways surpassable - by a system that has more context than any human assistant can have.
 
 ---
 
@@ -54,7 +54,7 @@ None of these are criticisms of human VAs. They are properties of any system whe
 
 A Personal AI OS running locally on your device changes the calculus on every one of these dimensions.
 
-It has your full context. Your messages, your calendar, your files, your patterns -- all of it, all at once, all the time. The intelligence it can apply to your inbox or your upcoming meeting is informed by everything you have, not just what you've chosen to share.
+It has your full context. Your messages, your calendar, your files, your patterns - all of it, all at once, all the time. The intelligence it can apply to your inbox or your upcoming meeting is informed by everything you have, not just what you've chosen to share.
 
 It's available at any hour. There's no time zone, no business hours, no response delay. When you're prepping for a morning meeting the night before, the context is there.
 
@@ -62,7 +62,7 @@ It has no ongoing cost tied to your usage. The model runs on your device. The ma
 
 It requires no relationship management. The context is built from your data, not from a working relationship that needs tending. The system knows you from what you actually do, not from what you've explained.
 
-It scales with your needs. More emails, more meetings, more complexity -- the system handles it without renegotiating terms.
+It scales with your needs. More emails, more meetings, more complexity - the system handles it without renegotiating terms.
 
 ---
 
@@ -70,9 +70,9 @@ It scales with your needs. More emails, more meetings, more complexity -- the sy
 
 On-device AI is not a complete replacement for everything a skilled human assistant does.
 
-Human judgment in genuinely novel situations -- where the right move isn't derivable from past patterns -- is still a human edge. Complex relationship management that requires emotional intelligence and interpersonal calibration is still a human capability. Tasks that require physical presence or real-world interaction are still human territory.
+Human judgment in genuinely novel situations - where the right move isn't derivable from past patterns - is still a human edge. Complex relationship management that requires emotional intelligence and interpersonal calibration is still a human capability. Tasks that require physical presence or real-world interaction are still human territory.
 
-But the vast majority of what makes administrative support valuable is not in those categories. Most of it is pattern recognition applied to communication, scheduling, and coordination -- exactly the domain where a system with full context and no time constraints outperforms a person with bounded access and a limited workday.
+But the vast majority of what makes administrative support valuable is not in those categories. Most of it is pattern recognition applied to communication, scheduling, and coordination - exactly the domain where a system with full context and no time constraints outperforms a person with bounded access and a limited workday.
 
 ---
 
@@ -80,11 +80,11 @@ But the vast majority of what makes administrative support valuable is not in th
 
 The human VA model helped people who could afford it. Typically knowledge workers at senior levels, entrepreneurs with enough revenue to justify the cost, executives at organisations that provided support as a benefit.
 
-The people below that threshold -- the ones with just as much administrative overhead but without the revenue or seniority to justify dedicated support -- got nothing. They managed it themselves, which meant it consumed the same focused attention they needed for the work that actually required them.
+The people below that threshold - the ones with just as much administrative overhead but without the revenue or seniority to justify dedicated support - got nothing. They managed it themselves, which meant it consumed the same focused attention they needed for the work that actually required them.
 
 On-device AI doesn't just improve on the VA model for existing customers. It makes the function available to people the model never reached in the first place.
 
-That's the more interesting story. Not that a faster or cheaper virtual assistant exists. But that the intelligence layer -- the thing that made executives more effective for a century -- is now in the pocket of anyone who wants it.
+That's the more interesting story. Not that a faster or cheaper virtual assistant exists. But that the intelligence layer - the thing that made executives more effective for a century - is now in the pocket of anyone who wants it.
 
 ---
 

--- a/website/writing/one-person-two-devices.md
+++ b/website/writing/one-person-two-devices.md
@@ -29,7 +29,7 @@ Your phone is with you 16 hours a day. In that time it collects an extraordinary
 
 This is a detailed record of your life. The phone has all of it. The platform does almost nothing with it.
 
-Siri can set a timer. It can call a contact. It cannot tell you that you have had three difficult conversations this week and your calendar tomorrow is unrealistic given how your Monday went.
+The built-in assistant can set a timer or call a contact. It cannot tell you that you have had three difficult conversations this week and your calendar tomorrow is unrealistic given how your Monday went.
 
 ---
 
@@ -75,7 +75,7 @@ This is what makes the Personal AI OS a new category rather than a smarter assis
 
 The obstacle is not hardware. Modern phones and laptops have enough compute to run capable local models. The obstacle is the assumption that built modern software platforms.
 
-iOS and Android are app-centric operating systems. The primitive is the app, and apps are sandboxed from each other. Intelligence - to the extent the platforms attempt it - is bolt-on, not foundational.
+Mobile platforms are app-centric operating systems. The primitive is the app, and apps are sandboxed from each other. Intelligence - to the extent the platforms attempt it - is bolt-on, not foundational.
 
 A Personal AI OS requires inverting that model. Context is the primitive. Apps are sources of context. The intelligence layer sits above the apps, not inside any one of them, and operates across all your devices as a single system.
 

--- a/website/writing/personal-ai-os-for-knowledge-workers.md
+++ b/website/writing/personal-ai-os-for-knowledge-workers.md
@@ -14,7 +14,7 @@ Email triage. Meeting preparation. Status updates. Follow-up drafts. Summary not
 
 These tasks are not trivial - they require understanding your priorities, your communication style, your work context. But they don't require your creative output or your domain expertise. They are infrastructure work, and they are consuming an enormous amount of the most expensive resource in a knowledge worker's day: focused attention.
 
-A Personal AI OS that runs locally, with access to your full context, is the first system capable of handling this work reliably.
+A Personal AI OS that runs locally, with access to your full context, is the first system capable of handling this work reliably. This is where the category is going. Some of it is close. None of the current cloud tools can do it the right way, because doing it the right way requires your data to stay on your device.
 
 ## Email triage
 
@@ -82,4 +82,4 @@ The output is not just the same work in less time. It is better work, done with 
 
 ---
 
-*Off Grid runs entirely on your device. Your messages, files, and context stay local. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*
+*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone - the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*

--- a/website/writing/personal-ai-os-for-knowledge-workers.md
+++ b/website/writing/personal-ai-os-for-knowledge-workers.md
@@ -8,17 +8,17 @@ description: 800 million knowledge workers spend large parts of their day on wor
 
 # The Personal AI OS for Knowledge Workers: From Email Triage to Meeting Prep to Deep Work
 
-There are roughly 800 million knowledge workers in the world. Each of them spends a significant portion of their working day on tasks that require judgment but not their judgment specifically - tasks that a system with the right context could handle as well as or better than they can.
+There are roughly 800 million knowledge workers in the world. Each of them spends a significant portion of their working day on tasks that require judgment but not their judgment specifically. A system with the right context could handle these as well as or better than they can.
 
 Email triage. Meeting preparation. Status updates. Follow-up drafts. Summary notes after calls. Finding the document you know you wrote three weeks ago. Checking whether a commitment you made has been fulfilled.
 
-These tasks are not trivial - they require understanding your priorities, your communication style, your work context. But they don't require your creative output or your domain expertise. They are infrastructure work, and they are consuming an enormous amount of the most expensive resource in a knowledge worker's day: focused attention.
+These tasks are not trivial. They require understanding your priorities, your communication style, your work context. But they don't require your creative output or your domain expertise. They are infrastructure work, and they are consuming an enormous amount of the most expensive resource in a knowledge worker's day: focused attention.
 
 A Personal AI OS that runs locally, with access to your full context, is the first system capable of handling this work reliably. This is where the category is going. Some of it is close. None of the current cloud tools can do it the right way, because doing it the right way requires your data to stay on your device.
 
 ## Email triage
 
-The average knowledge worker spends over two hours a day on email. The vast majority of that time is triage - reading enough of each message to decide whether it needs a response, when, and what kind.
+The average knowledge worker spends over two hours a day on email. The vast majority of that time is triage: reading enough of each message to decide whether it needs a response, when, and what kind.
 
 A Personal AI OS with access to your email history and your patterns can do this triage automatically.
 
@@ -32,21 +32,21 @@ You spend 20 minutes on email instead of two hours, and you make fewer mistakes 
 
 Knowledge workers average 10-12 hours of meetings per week. A significant fraction of those meetings are ones where attendees arrive underprepared.
 
-Not because the preparation would have been hard. Because the preparation required finding context from four different places - previous meeting notes, the relevant email thread, the document shared last time, the last Slack exchange with this person - and nobody had the 15 minutes to do it.
+Not because the preparation would have been hard. Because the preparation required finding context from four different places: previous meeting notes, the relevant email thread, the document shared last time, the last Slack exchange with this person. Nobody had the 15 minutes to do it.
 
 A Personal AI OS does this preparation automatically.
 
 Two minutes before your meeting starts, it surfaces: the last three things you discussed with this person or group, the open items from the last meeting, any relevant documents that have been shared, and anything from recent messages that's relevant to the agenda.
 
-You arrive prepared for every meeting, every time, with no additional effort on your part. The compounding effect over a week - arriving prepared for 12 meetings instead of 4 - is significant.
+You arrive prepared for every meeting, every time, with no additional effort on your part. The compounding effect over a week is significant: arriving prepared for 12 meetings instead of 4.
 
 ## Deep work protection
 
-Deep work - the focused, uninterrupted time where knowledge workers produce their highest-value output - is fragile. A single interruption breaks concentration that takes 20 minutes to rebuild.
+Deep work is fragile. It is the focused, uninterrupted time where knowledge workers produce their highest-value output. A single interruption breaks concentration that takes 20 minutes to rebuild.
 
 A Personal AI OS that manages your notifications intelligently can protect deep work in a way that static Do Not Disturb settings cannot.
 
-It knows you're in a focused session. It reads incoming notifications and classifies them by your definition of urgency - which it has built from observing your responses over months. It surfaces urgent things immediately. Everything else waits.
+It knows you're in a focused session. It reads incoming notifications and classifies them by your definition of urgency, which it has built from observing your responses over months. It surfaces urgent things immediately. Everything else waits.
 
 When your focused session ends, it presents a consolidated view of what came in, already prioritised. You haven't missed anything important. You also haven't been interrupted six times by things that could have waited.
 
@@ -58,11 +58,11 @@ These messages are necessary. They are also templated, repetitive, and draining 
 
 A Personal AI OS that knows your communication style and your open commitments can draft these automatically. You review and send. You don't write them from scratch.
 
-Over a week, this compounds into hours of writing time reclaimed - not writing that required your creativity, but writing that required your attention to exist.
+Over a week, this compounds into hours of writing time reclaimed. Not writing that required your creativity, but writing that required your attention to exist.
 
 ## Finding things
 
-Knowledge workers spend an average of 20% of their time searching for information they already have. Documents, emails, notes, messages - the context is there, but the retrieval is manual and slow.
+Knowledge workers spend an average of 20% of their time searching for information they already have. Documents, emails, notes, messages: the context is there, but the retrieval is manual and slow.
 
 A Personal AI OS with access to your files and communications can answer natural language queries against your own data.
 
@@ -74,7 +74,7 @@ The information you already have becomes as accessible as information you can lo
 
 ## The compound effect
 
-Each of these improvements - triage, preparation, protection, drafting, retrieval - is meaningful on its own. Together, they compound.
+Each of these improvements (triage, preparation, protection, drafting, retrieval) is meaningful on its own. Together, they compound.
 
 A knowledge worker using a Personal AI OS that handles this infrastructure work doesn't just save hours per week. They change the quality of how they work. They arrive prepared. They respond faster. They protect their focused time. They don't drop things.
 
@@ -82,4 +82,4 @@ The output is not just the same work in less time. It is better work, done with 
 
 ---
 
-*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone - the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*
+*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone: the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*

--- a/website/writing/personal-ai-os-for-knowledge-workers.md
+++ b/website/writing/personal-ai-os-for-knowledge-workers.md
@@ -18,7 +18,7 @@ A Personal AI OS that runs locally, with access to your full context, is the fir
 
 ## Email triage
 
-The average knowledge worker receives 120 emails per day and spends over two hours processing them. The vast majority of that time is spent on triage - reading enough of each email to decide whether it needs a response, when, and what kind.
+The average knowledge worker spends over two hours a day on email. The vast majority of that time is triage - reading enough of each message to decide whether it needs a response, when, and what kind.
 
 A Personal AI OS with access to your email history and your patterns can do this triage automatically.
 

--- a/website/writing/personal-ai-os-vs-assistant-vs-agent.md
+++ b/website/writing/personal-ai-os-vs-assistant-vs-agent.md
@@ -3,14 +3,14 @@ layout: default
 title: "Personal AI OS vs AI Assistant vs AI Agent: What's the Difference and Why It Matters"
 parent: Perspectives
 nav_order: 7
-description: Siri answers questions. ChatGPT generates text. Autonomous agents take actions. A Personal AI OS does something different from all three - and the distinction is worth understanding precisely.
+description: Voice assistants answer questions. Cloud chatbots generate text. Autonomous agents take actions. A Personal AI OS does something different from all three - and the distinction is worth understanding precisely.
 faq:
   - q: What is the difference between a Personal AI OS and an AI assistant?
-    a: An AI assistant (Siri, Alexa, Google Assistant) answers isolated questions using cloud infrastructure. It has minimal persistent context and no ability to act across your apps. A Personal AI OS runs on-device, maintains persistent context about your life, and can act on your behalf - it's a system, not a query interface.
+    a: Platform voice assistants answer isolated questions using cloud infrastructure. They have minimal persistent context and no ability to act across your apps. A Personal AI OS runs on-device, maintains persistent context about your life, and can act on your behalf - it's a system, not a query interface.
   - q: What is the difference between a Personal AI OS and an AI agent?
     a: AI agents are autonomous systems that make decisions and take actions with minimal human oversight, often connected to external APIs and services. A Personal AI OS is explicitly not autonomous - it acts with your consent, stays within your local hardware, and defers decisions to you. The operating principle is assistance, not autonomy.
-  - q: What is the difference between a Personal AI OS and ChatGPT?
-    a: ChatGPT is a cloud-based generative AI product. It has no persistent knowledge of you between sessions (unless you opt into memory features), runs on OpenAI's servers, and is a general-purpose text interface. A Personal AI OS is specific to you, runs locally, maintains your context over time, and is designed to act on your behalf across your apps and devices.
+  - q: What is the difference between a Personal AI OS and a cloud chatbot?
+    a: Cloud generative AI products have no persistent knowledge of you between sessions, run on remote servers, and are general-purpose text interfaces. A Personal AI OS is specific to you, runs locally, maintains your context over time, and is designed to act on your behalf across your apps and devices.
 ---
 
 # Personal AI OS vs AI Assistant vs AI Agent: What's the Difference and Why It Matters
@@ -23,7 +23,7 @@ These are not the same thing. The differences matter - for what you can trust wi
 
 ## AI Assistants: the query interface
 
-Siri, Alexa, Google Assistant, and Cortana are the original consumer AI products. They share a common architecture and a common set of limitations.
+The voice AI assistants built into major platform operating systems were the first consumer AI products. They share a common architecture and a common set of limitations.
 
 **How they work:** You issue a voice or text command. The query goes to a cloud server. The server processes it and returns a response. The assistant executes a narrow set of device actions (set timer, play music, call contact) based on pre-defined integrations.
 
@@ -39,7 +39,7 @@ AI assistants are useful for simple, isolated tasks. They are not intelligence l
 
 ## Generative AI products: the capable chatbot
 
-ChatGPT, Claude, Gemini (in their standard forms) are a step up in capability but share a similar architecture to assistants in the ways that matter most.
+Cloud generative AI products are a step up in capability but share a similar architecture to assistants in the ways that matter most.
 
 **How they work:** You send messages to a cloud-hosted model. The model generates responses. Context exists within a session but typically doesn't persist across sessions in a way that builds a long-term model of you.
 

--- a/website/writing/platform-intelligence-doesnt-exist.md
+++ b/website/writing/platform-intelligence-doesnt-exist.md
@@ -3,7 +3,7 @@ layout: default
 title: "Why Platform Intelligence Doesn't Exist Yet - And What It Would Take to Build It"
 parent: Perspectives
 nav_order: 22
-description: iOS and Android are still app-centric operating systems. The AI features built into them are bolted onto that model. A true Personal AI OS requires a fundamentally different architecture where context is the primitive, not apps.
+description: Mobile platforms are still app-centric operating systems. The AI features built into them are bolted onto that model. A true Personal AI OS requires a fundamentally different architecture where context is the primitive, not apps.
 ---
 
 # Why Platform Intelligence Doesn't Exist Yet - And What It Would Take to Build It
@@ -18,7 +18,7 @@ The distinction matters because the architecture determines the ceiling.
 
 ## The app-centric model
 
-iOS and Android are app-centric operating systems. The fundamental unit of the platform is the app. Apps are:
+Mobile platforms are app-centric operating systems. The fundamental unit of the platform is the app. Apps are:
 
 - **Sandboxed.** Each app has access only to the data it has been explicitly granted. Your calendar app cannot read your messages. Your AI assistant cannot, by default, access the files in your notes app.
 - **Isolated.** Apps do not share state with each other except through explicit, narrow API integrations. The mental model is a collection of independent tools, not a unified system.
@@ -32,7 +32,7 @@ But it creates a fundamental limitation for personal AI: there is no coherent vi
 
 ## What current platform AI actually is
 
-Current platform AI - Apple Intelligence, Google Gemini on Android - is AI built within the constraints of the existing app-centric model.
+Current platform AI is built within the constraints of the existing app-centric model.
 
 It can summarise notifications because the notification system already exposes text from all apps in one place. It can generate text in keyboards because the keyboard already operates across apps at the system level. It can answer questions about the current document because it is running in the context of the document editor.
 
@@ -62,7 +62,7 @@ The platforms have the engineering capability to build platform intelligence. Th
 
 **Privacy and regulatory risk.** A system with the depth of context that true platform intelligence requires would face significant scrutiny. The same capabilities that make it useful - knowing your messages, health, files, and location at once - create regulatory exposure in jurisdictions with strong privacy frameworks.
 
-**Ecosystem conflict.** Many of the most valuable sources of personal context live in apps built by competitors. Building intelligence that spans Google Maps, iMessage, Spotify, and your bank's app requires those apps to contribute context to a platform-level model. The companies behind those apps have no incentive to help the platform build a model that aggregates their users' data.
+**Ecosystem conflict.** Many of the most valuable sources of personal context live in apps built by third parties. Building intelligence that spans mapping apps, messaging services, streaming platforms, and banking apps requires those apps to contribute context to a platform-level model. The companies behind those apps have no incentive to help the platform build a model that aggregates their users' data.
 
 **Openness.** True platform intelligence, to be trustworthy, needs to be auditable. The platforms are closed by design. A closed intelligence layer with access to your full context is one you have to trust on faith.
 

--- a/website/writing/privacy-is-not-a-feature.md
+++ b/website/writing/privacy-is-not-a-feature.md
@@ -31,7 +31,7 @@ The privacy feature model treats collection as the default and user control as t
 
 A different model starts with a different assumption: the data should never leave the device.
 
-The model runs in your phone's memory. Your query never becomes a network request. Your calendar and messages are never transmitted. Inference runs on your hardware, on your device - nothing reaches an external server.
+The model runs in your phone's memory. Your query never becomes a network request. Your calendar and messages are never transmitted. Inference runs on your hardware, on your device. Nothing reaches an external server.
 
 There is nothing to delete. There is no policy to violate. There is no breach to notify you about.
 
@@ -41,9 +41,9 @@ This is not a stronger version of the privacy feature model. It is a fundamental
 
 A privacy policy is a legal document. It describes what a company promises to do with your data. It does not change what is technically possible once your data is on their servers.
 
-Architecture determines what is possible. Policy determines what is promised. A company can change its policy - by updating a terms of service, by being acquired, by responding to a government request. An architecture that never collected the data in the first place cannot be changed after the fact.
+Architecture determines what is possible. Policy determines what is promised. A company can change its policy: by updating a terms of service, by being acquired, by responding to a government request. An architecture that never collected the data in the first place cannot be changed after the fact.
 
-This distinction matters more as the data becomes more sensitive. General search queries carry limited risk. Persistent personal context - your messages, health data, financial patterns, relationship history - carries significant risk. The architecture question is not abstract when the data at stake is that personal.
+This distinction matters more as the data becomes more sensitive. General search queries carry limited risk. Persistent personal context (your messages, health data, financial patterns, relationship history) carries significant risk. The architecture question is not abstract when the data at stake is that personal.
 
 ## The consent problem
 
@@ -53,18 +53,18 @@ An AI that can help you needs to know your calendar, your messages, your work pa
 
 A cloud AI asks you to hand over that context in exchange for its capabilities. The implicit contract is: give us your data, we'll give you a useful assistant, and we promise to be responsible with it.
 
-An on-device AI inverts that contract. The context lives on your hardware. The model runs locally. The capabilities are the same - or better, because the model has more context than any cloud service would retain. But you never handed anything over.
+An on-device AI inverts that contract. The context lives on your hardware. The model runs locally. The capabilities are the same, or better, because the model has more context than any cloud service would retain. But you never handed anything over.
 
 Consent only matters when there's something to consent to. On-device AI removes the question.
 
 ## What this means for how AI should be built
 
-If privacy is an architecture decision, it has to be made at the beginning - in the choice of where inference runs, where context is stored, and what leaves the device.
+If privacy is an architecture decision, it has to be made at the beginning: in the choice of where inference runs, where context is stored, and what leaves the device.
 
 A product that runs inference in the cloud and adds privacy controls on top is a cloud AI with privacy features.
 
 A product that runs inference on-device, stores context locally, and sends nothing to external servers is a private AI by architecture. There is no feature to ship, no toggle to add, no policy to write. The privacy guarantee is in the design.
 
-This is the only version of personal AI that deserves access to your full context. Not because the company behind it is more trustworthy. But because the architecture makes trust irrelevant - the data never left your device.
+This is the only version of personal AI that deserves access to your full context. Not because the company behind it is more trustworthy. But because the architecture makes trust irrelevant. The data never left your device.
 
 *Off Grid runs every model locally. No data leaves your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*

--- a/website/writing/regulatory-case-for-on-device-ai.md
+++ b/website/writing/regulatory-case-for-on-device-ai.md
@@ -8,11 +8,11 @@ description: Every major privacy regulation passed in the last five years is a t
 
 # The Regulatory Case for On-Device AI: Why Every New Privacy Law Is a Tailwind
 
-Privacy regulation is accelerating globally. Jurisdiction after jurisdiction has passed — or is passing — laws that create obligations around the collection, processing, and transfer of personal data. More are coming.
+Privacy regulation is accelerating globally. Jurisdiction after jurisdiction has passed -- or is passing -- laws that create obligations around the collection, processing, and transfer of personal data. More are coming.
 
 Each new regulation creates compliance requirements for AI products that process personal data. Legal teams, compliance frameworks, data protection impact assessments, consent management systems. The overhead is real and the risk of non-compliance is significant.
 
-On-device AI has a different relationship with this regulatory environment. Not a better compliance strategy — a fundamentally different architecture where most of the compliance questions don't arise in the first place.
+On-device AI has a different relationship with this regulatory environment. Not a better compliance strategy -- a fundamentally different architecture where most of the compliance questions don't arise in the first place.
 
 ## What regulations are trying to solve
 
@@ -26,9 +26,9 @@ On-device AI sidesteps the underlying problem. If no data leaves the device, the
 
 ## Data protection law and the personal data question
 
-The dominant framework across most jurisdictions today is triggered by the processing of personal data by a data controller — typically a company that collects and processes user information on its infrastructure.
+The dominant framework across most jurisdictions today is triggered by the processing of personal data by a data controller -- typically a company that collects and processes user information on its infrastructure.
 
-An on-device AI processes personal data, but it processes it locally, on your own hardware, under your own control. The question of whether these frameworks apply to this processing — where you are essentially processing your own data for your own purposes — is nuanced, but the core compliance risks they address (third-party access, cross-border transfer, consent for commercial processing) largely don't apply.
+An on-device AI processes personal data, but it processes it locally, on your own hardware, under your own control. The question of whether these frameworks apply to this processing -- where you are essentially processing your own data for your own purposes -- is nuanced, but the core compliance risks they address (third-party access, cross-border transfer, consent for commercial processing) largely don't apply.
 
 For a cloud AI product, compliance requires data processing agreements, consent management, data subject rights infrastructure, transfer mechanisms for cross-border data flows, and breach notification processes. For an on-device AI with no telemetry and no cloud infrastructure, these requirements either don't apply or are trivially satisfied.
 
@@ -36,7 +36,7 @@ For a cloud AI product, compliance requires data processing agreements, consent 
 
 Regulators are now building on data protection frameworks with AI-specific rules. Risk-based classification for AI systems, transparency requirements for systems that interact with natural persons, obligations around training data provenance.
 
-Personal AI OS systems that act as productivity tools rather than decision-making systems in regulated domains are generally not in the highest-risk categories under these frameworks. But the transparency requirements are relevant — and on-device AI using open-weight models is well-positioned to meet them.
+Personal AI OS systems that act as productivity tools rather than decision-making systems in regulated domains are generally not in the highest-risk categories under these frameworks. But the transparency requirements are relevant -- and on-device AI using open-weight models is well-positioned to meet them.
 
 The model card, training data provenance, and architecture of open-weight models are publicly documented. The openness that's right for users is the same openness that satisfies regulatory transparency requirements. A closed proprietary model running in the cloud is harder to audit. An open model running on your hardware is auditable by anyone.
 
@@ -44,17 +44,17 @@ The model card, training data provenance, and architecture of open-weight models
 
 Privacy regulation doesn't just create compliance requirements. It creates market signal.
 
-Users in markets with strong privacy frameworks have come to expect more control over their data. Businesses operating in those markets face real consequences for non-compliance. As these frameworks expand to more jurisdictions — and as the AI-specific provisions within them become more detailed — the gap between cloud AI and on-device AI from a compliance perspective will widen.
+Users in markets with strong privacy frameworks have come to expect more control over their data. Businesses operating in those markets face real consequences for non-compliance. As these frameworks expand to more jurisdictions -- and as the AI-specific provisions within them become more detailed -- the gap between cloud AI and on-device AI from a compliance perspective will widen.
 
-Every new regulation adds to the compliance overhead of cloud AI products. Every new regulation reduces that overhead to near-zero for on-device AI. The product that can credibly offer regulatory compliance-by-architecture — without the associated cost and complexity — has a structural market advantage.
+Every new regulation adds to the compliance overhead of cloud AI products. Every new regulation reduces that overhead to near-zero for on-device AI. The product that can credibly offer regulatory compliance-by-architecture -- without the associated cost and complexity -- has a structural market advantage.
 
 ## The pattern across jurisdictions
 
 The pattern across privacy regulations globally is consistent.
 
-Each regulation defines compliance obligations triggered by third-party collection and processing of personal data. Each regulation creates overhead — consent management, data subject rights, breach notification, cross-border transfer mechanisms. Each regulation creates legal risk for products that fail to comply.
+Each regulation defines compliance obligations triggered by third-party collection and processing of personal data. Each regulation creates overhead -- consent management, data subject rights, breach notification, cross-border transfer mechanisms. Each regulation creates legal risk for products that fail to comply.
 
-On-device AI is not exempt from regulation. But the architecture dramatically reduces the surface area that regulations are targeting. The obligations that require the most compliance investment — cross-border transfers, third-party processing agreements, large-scale personal data handling — mostly don't apply to a system that processes data locally and sends nothing to external servers.
+On-device AI is not exempt from regulation. But the architecture dramatically reduces the surface area that regulations are targeting. The obligations that require the most compliance investment -- cross-border transfers, third-party processing agreements, large-scale personal data handling -- mostly don't apply to a system that processes data locally and sends nothing to external servers.
 
 Every new privacy regulation is a tailwind for on-device AI. Not because the regulatory environment is hostile to cloud AI specifically, but because the on-device architecture is inherently aligned with what regulators are trying to achieve.
 

--- a/website/writing/regulatory-case-for-on-device-ai.md
+++ b/website/writing/regulatory-case-for-on-device-ai.md
@@ -8,11 +8,11 @@ description: Every major privacy regulation passed in the last five years is a t
 
 # The Regulatory Case for On-Device AI: Why Every New Privacy Law Is a Tailwind
 
-Privacy regulation is accelerating globally. Jurisdiction after jurisdiction has passed -- or is passing -- laws that create obligations around the collection, processing, and transfer of personal data. More are coming.
+Privacy regulation is accelerating globally. Jurisdiction after jurisdiction has passed - or is passing - laws that create obligations around the collection, processing, and transfer of personal data. More are coming.
 
 Each new regulation creates compliance requirements for AI products that process personal data. Legal teams, compliance frameworks, data protection impact assessments, consent management systems. The overhead is real and the risk of non-compliance is significant.
 
-On-device AI has a different relationship with this regulatory environment. Not a better compliance strategy -- a fundamentally different architecture where most of the compliance questions don't arise in the first place.
+On-device AI has a different relationship with this regulatory environment. Not a better compliance strategy - a fundamentally different architecture where most of the compliance questions don't arise in the first place.
 
 ## What regulations are trying to solve
 
@@ -26,9 +26,9 @@ On-device AI sidesteps the underlying problem. If no data leaves the device, the
 
 ## Data protection law and the personal data question
 
-The dominant framework across most jurisdictions today is triggered by the processing of personal data by a data controller -- typically a company that collects and processes user information on its infrastructure.
+The dominant framework across most jurisdictions today is triggered by the processing of personal data by a data controller - typically a company that collects and processes user information on its infrastructure.
 
-An on-device AI processes personal data, but it processes it locally, on your own hardware, under your own control. The question of whether these frameworks apply to this processing -- where you are essentially processing your own data for your own purposes -- is nuanced, but the core compliance risks they address (third-party access, cross-border transfer, consent for commercial processing) largely don't apply.
+An on-device AI processes personal data, but it processes it locally, on your own hardware, under your own control. The question of whether these frameworks apply to this processing - where you are essentially processing your own data for your own purposes - is nuanced, but the core compliance risks they address (third-party access, cross-border transfer, consent for commercial processing) largely don't apply.
 
 For a cloud AI product, compliance requires data processing agreements, consent management, data subject rights infrastructure, transfer mechanisms for cross-border data flows, and breach notification processes. For an on-device AI with no telemetry and no cloud infrastructure, these requirements either don't apply or are trivially satisfied.
 
@@ -36,7 +36,7 @@ For a cloud AI product, compliance requires data processing agreements, consent 
 
 Regulators are now building on data protection frameworks with AI-specific rules. Risk-based classification for AI systems, transparency requirements for systems that interact with natural persons, obligations around training data provenance.
 
-Personal AI OS systems that act as productivity tools rather than decision-making systems in regulated domains are generally not in the highest-risk categories under these frameworks. But the transparency requirements are relevant -- and on-device AI using open-weight models is well-positioned to meet them.
+Personal AI OS systems that act as productivity tools rather than decision-making systems in regulated domains are generally not in the highest-risk categories under these frameworks. But the transparency requirements are relevant - and on-device AI using open-weight models is well-positioned to meet them.
 
 The model card, training data provenance, and architecture of open-weight models are publicly documented. The openness that's right for users is the same openness that satisfies regulatory transparency requirements. A closed proprietary model running in the cloud is harder to audit. An open model running on your hardware is auditable by anyone.
 
@@ -44,17 +44,17 @@ The model card, training data provenance, and architecture of open-weight models
 
 Privacy regulation doesn't just create compliance requirements. It creates market signal.
 
-Users in markets with strong privacy frameworks have come to expect more control over their data. Businesses operating in those markets face real consequences for non-compliance. As these frameworks expand to more jurisdictions -- and as the AI-specific provisions within them become more detailed -- the gap between cloud AI and on-device AI from a compliance perspective will widen.
+Users in markets with strong privacy frameworks have come to expect more control over their data. Businesses operating in those markets face real consequences for non-compliance. As these frameworks expand to more jurisdictions - and as the AI-specific provisions within them become more detailed - the gap between cloud AI and on-device AI from a compliance perspective will widen.
 
-Every new regulation adds to the compliance overhead of cloud AI products. Every new regulation reduces that overhead to near-zero for on-device AI. The product that can credibly offer regulatory compliance-by-architecture -- without the associated cost and complexity -- has a structural market advantage.
+Every new regulation adds to the compliance overhead of cloud AI products. Every new regulation reduces that overhead to near-zero for on-device AI. The product that can credibly offer regulatory compliance-by-architecture - without the associated cost and complexity - has a structural market advantage.
 
 ## The pattern across jurisdictions
 
 The pattern across privacy regulations globally is consistent.
 
-Each regulation defines compliance obligations triggered by third-party collection and processing of personal data. Each regulation creates overhead -- consent management, data subject rights, breach notification, cross-border transfer mechanisms. Each regulation creates legal risk for products that fail to comply.
+Each regulation defines compliance obligations triggered by third-party collection and processing of personal data. Each regulation creates overhead - consent management, data subject rights, breach notification, cross-border transfer mechanisms. Each regulation creates legal risk for products that fail to comply.
 
-On-device AI is not exempt from regulation. But the architecture dramatically reduces the surface area that regulations are targeting. The obligations that require the most compliance investment -- cross-border transfers, third-party processing agreements, large-scale personal data handling -- mostly don't apply to a system that processes data locally and sends nothing to external servers.
+On-device AI is not exempt from regulation. But the architecture dramatically reduces the surface area that regulations are targeting. The obligations that require the most compliance investment - cross-border transfers, third-party processing agreements, large-scale personal data handling - mostly don't apply to a system that processes data locally and sends nothing to external servers.
 
 Every new privacy regulation is a tailwind for on-device AI. Not because the regulatory environment is hostile to cloud AI specifically, but because the on-device architecture is inherently aligned with what regulators are trying to achieve.
 

--- a/website/writing/regulatory-case-for-on-device-ai.md
+++ b/website/writing/regulatory-case-for-on-device-ai.md
@@ -1,18 +1,18 @@
 ---
 layout: default
-title: "The EU AI Act, India's DPDP, and the Regulatory Case for On-Device AI"
+title: "The Regulatory Case for On-Device AI: Why Every New Privacy Law Is a Tailwind"
 parent: Perspectives
 nav_order: 17
 description: Every major privacy regulation passed in the last five years is a tailwind for on-device AI. The architecture that's right for users is also the architecture that's inherently regulation-proof.
 ---
 
-# The EU AI Act, India's DPDP, and the Regulatory Case for On-Device AI
+# The Regulatory Case for On-Device AI: Why Every New Privacy Law Is a Tailwind
 
-Privacy regulation is accelerating globally. GDPR in Europe. CCPA in California. India's Digital Personal Data Protection Act. The EU AI Act. Brazil's LGPD. More are coming.
+Privacy regulation is accelerating globally. Jurisdiction after jurisdiction has passed — or is passing — laws that create obligations around the collection, processing, and transfer of personal data. More are coming.
 
 Each new regulation creates compliance requirements for AI products that process personal data. Legal teams, compliance frameworks, data protection impact assessments, consent management systems. The overhead is real and the risk of non-compliance is significant.
 
-On-device AI has a different relationship with this regulatory environment. Not a better compliance strategy - a fundamentally different architecture where most of the compliance questions don't arise in the first place.
+On-device AI has a different relationship with this regulatory environment. Not a better compliance strategy — a fundamentally different architecture where most of the compliance questions don't arise in the first place.
 
 ## What regulations are trying to solve
 
@@ -24,37 +24,37 @@ These requirements make sense for systems that collect personal data on remote s
 
 On-device AI sidesteps the underlying problem. If no data leaves the device, there is no third-party collection to regulate.
 
-## GDPR and the personal data question
+## Data protection law and the personal data question
 
-GDPR's scope is triggered by the processing of personal data by a data controller - typically a company that collects and processes user information on its infrastructure.
+The dominant framework across most jurisdictions today is triggered by the processing of personal data by a data controller — typically a company that collects and processes user information on its infrastructure.
 
-An on-device AI processes personal data, but it processes it locally, on your own hardware, under your own control. The question of whether GDPR applies to this processing - where you are essentially processing your own data for your own purposes - is nuanced, but the core compliance risks that GDPR addresses (third-party access, cross-border transfer, consent for commercial processing) largely don't apply.
+An on-device AI processes personal data, but it processes it locally, on your own hardware, under your own control. The question of whether these frameworks apply to this processing — where you are essentially processing your own data for your own purposes — is nuanced, but the core compliance risks they address (third-party access, cross-border transfer, consent for commercial processing) largely don't apply.
 
-For a cloud AI product, GDPR compliance requires data processing agreements, consent management, data subject rights infrastructure, transfer mechanisms for cross-border data flows, and breach notification processes. For an on-device AI with no telemetry and no cloud infrastructure, these requirements either don't apply or are trivially satisfied.
+For a cloud AI product, compliance requires data processing agreements, consent management, data subject rights infrastructure, transfer mechanisms for cross-border data flows, and breach notification processes. For an on-device AI with no telemetry and no cloud infrastructure, these requirements either don't apply or are trivially satisfied.
 
-## The EU AI Act and high-risk classification
+## AI-specific regulation and transparency requirements
 
-The EU AI Act introduces risk-based classification for AI systems. High-risk AI - systems used in employment decisions, credit scoring, biometric identification - faces significant compliance requirements.
+Regulators are now building on data protection frameworks with AI-specific rules. Risk-based classification for AI systems, transparency requirements for systems that interact with natural persons, obligations around training data provenance.
 
-Personal AI OS systems that act as productivity tools rather than decision-making systems in regulated domains are not, in themselves, high-risk under the Act's current framework. But the Act does require transparency and explainability for AI systems that interact with natural persons, and it creates obligations around training data and model documentation.
+Personal AI OS systems that act as productivity tools rather than decision-making systems in regulated domains are generally not in the highest-risk categories under these frameworks. But the transparency requirements are relevant — and on-device AI using open-weight models is well-positioned to meet them.
 
-On-device AI using open-weight models - where the model card, training data provenance, and architecture are publicly documented - is well-positioned for these requirements. The openness that's right for users is the same openness that satisfies regulatory transparency requirements.
+The model card, training data provenance, and architecture of open-weight models are publicly documented. The openness that's right for users is the same openness that satisfies regulatory transparency requirements. A closed proprietary model running in the cloud is harder to audit. An open model running on your hardware is auditable by anyone.
 
-## India's DPDP Act
+## The market dimension
 
-India's Digital Personal Data Protection Act, passed in 2023, creates obligations for entities that process personal data of Indian citizens. Key requirements include purpose limitation (data collected for one purpose can't be used for another), data minimisation, and consent for processing.
+Privacy regulation doesn't just create compliance requirements. It creates market signal.
 
-For a cloud AI product serving Indian users, DPDP creates significant compliance architecture. For an on-device AI where data doesn't leave your device, the regulated processing by a third party largely doesn't occur.
+Users in markets with strong privacy frameworks have come to expect more control over their data. Businesses operating in those markets face real consequences for non-compliance. As these frameworks expand to more jurisdictions — and as the AI-specific provisions within them become more detailed — the gap between cloud AI and on-device AI from a compliance perspective will widen.
 
-India has 600 million smartphone users and is one of the largest markets for AI adoption globally. The DPDP Act, combined with growing AI adoption, creates a specific dynamic: the AI product that can credibly offer privacy guarantees to Indian users - without the compliance overhead of cloud AI - has a structural advantage in the market.
+Every new regulation adds to the compliance overhead of cloud AI products. Every new regulation reduces that overhead to near-zero for on-device AI. The product that can credibly offer regulatory compliance-by-architecture — without the associated cost and complexity — has a structural market advantage.
 
 ## The pattern across jurisdictions
 
 The pattern across privacy regulations globally is consistent.
 
-Each regulation defines compliance obligations triggered by third-party collection and processing of personal data. Each regulation creates overhead - consent management, data subject rights, breach notification, cross-border transfer mechanisms. Each regulation creates legal risk for products that fail to comply.
+Each regulation defines compliance obligations triggered by third-party collection and processing of personal data. Each regulation creates overhead — consent management, data subject rights, breach notification, cross-border transfer mechanisms. Each regulation creates legal risk for products that fail to comply.
 
-On-device AI is not exempt from regulation. But the architecture dramatically reduces the surface area that regulations are targeting. The obligations that require the most compliance investment - cross-border transfers, third-party processing agreements, large-scale personal data handling - mostly don't apply to a system that processes data locally and sends nothing to external servers.
+On-device AI is not exempt from regulation. But the architecture dramatically reduces the surface area that regulations are targeting. The obligations that require the most compliance investment — cross-border transfers, third-party processing agreements, large-scale personal data handling — mostly don't apply to a system that processes data locally and sends nothing to external servers.
 
 Every new privacy regulation is a tailwind for on-device AI. Not because the regulatory environment is hostile to cloud AI specifically, but because the on-device architecture is inherently aligned with what regulators are trying to achieve.
 

--- a/website/writing/regulatory-case-for-on-device-ai.md
+++ b/website/writing/regulatory-case-for-on-device-ai.md
@@ -8,11 +8,11 @@ description: Every major privacy regulation passed in the last five years is a t
 
 # The Regulatory Case for On-Device AI: Why Every New Privacy Law Is a Tailwind
 
-Privacy regulation is accelerating globally. Jurisdiction after jurisdiction has passed - or is passing - laws that create obligations around the collection, processing, and transfer of personal data. More are coming.
+Privacy regulation is accelerating globally. Jurisdiction after jurisdiction has passed, or is passing, laws that create obligations around the collection, processing, and transfer of personal data. More are coming.
 
 Each new regulation creates compliance requirements for AI products that process personal data. Legal teams, compliance frameworks, data protection impact assessments, consent management systems. The overhead is real and the risk of non-compliance is significant.
 
-On-device AI has a different relationship with this regulatory environment. Not a better compliance strategy - a fundamentally different architecture where most of the compliance questions don't arise in the first place.
+On-device AI has a different relationship with this regulatory environment. Not a better compliance strategy. A fundamentally different architecture where most of the compliance questions don't arise in the first place.
 
 ## What regulations are trying to solve
 
@@ -26,9 +26,9 @@ On-device AI sidesteps the underlying problem. If no data leaves the device, the
 
 ## Data protection law and the personal data question
 
-The dominant framework across most jurisdictions today is triggered by the processing of personal data by a data controller - typically a company that collects and processes user information on its infrastructure.
+The dominant framework across most jurisdictions today is triggered by the processing of personal data by a data controller, typically a company that collects and processes user information on its infrastructure.
 
-An on-device AI processes personal data, but it processes it locally, on your own hardware, under your own control. The question of whether these frameworks apply to this processing - where you are essentially processing your own data for your own purposes - is nuanced, but the core compliance risks they address (third-party access, cross-border transfer, consent for commercial processing) largely don't apply.
+An on-device AI processes personal data, but it processes it locally, on your own hardware, under your own control. The question of whether these frameworks apply to this processing, where you are essentially processing your own data for your own purposes, is nuanced, but the core compliance risks they address (third-party access, cross-border transfer, consent for commercial processing) largely don't apply.
 
 For a cloud AI product, compliance requires data processing agreements, consent management, data subject rights infrastructure, transfer mechanisms for cross-border data flows, and breach notification processes. For an on-device AI with no telemetry and no cloud infrastructure, these requirements either don't apply or are trivially satisfied.
 
@@ -36,7 +36,7 @@ For a cloud AI product, compliance requires data processing agreements, consent 
 
 Regulators are now building on data protection frameworks with AI-specific rules. Risk-based classification for AI systems, transparency requirements for systems that interact with natural persons, obligations around training data provenance.
 
-Personal AI OS systems that act as productivity tools rather than decision-making systems in regulated domains are generally not in the highest-risk categories under these frameworks. But the transparency requirements are relevant - and on-device AI using open-weight models is well-positioned to meet them.
+Personal AI OS systems that act as productivity tools rather than decision-making systems in regulated domains are generally not in the highest-risk categories under these frameworks. But the transparency requirements are relevant, and on-device AI using open-weight models is well-positioned to meet them.
 
 The model card, training data provenance, and architecture of open-weight models are publicly documented. The openness that's right for users is the same openness that satisfies regulatory transparency requirements. A closed proprietary model running in the cloud is harder to audit. An open model running on your hardware is auditable by anyone.
 
@@ -44,17 +44,17 @@ The model card, training data provenance, and architecture of open-weight models
 
 Privacy regulation doesn't just create compliance requirements. It creates market signal.
 
-Users in markets with strong privacy frameworks have come to expect more control over their data. Businesses operating in those markets face real consequences for non-compliance. As these frameworks expand to more jurisdictions - and as the AI-specific provisions within them become more detailed - the gap between cloud AI and on-device AI from a compliance perspective will widen.
+Users in markets with strong privacy frameworks have come to expect more control over their data. Businesses operating in those markets face real consequences for non-compliance. As these frameworks expand to more jurisdictions, and as the AI-specific provisions within them become more detailed, the gap between cloud AI and on-device AI from a compliance perspective will widen.
 
-Every new regulation adds to the compliance overhead of cloud AI products. Every new regulation reduces that overhead to near-zero for on-device AI. The product that can credibly offer regulatory compliance-by-architecture - without the associated cost and complexity - has a structural market advantage.
+Every new regulation adds to the compliance overhead of cloud AI products. Every new regulation reduces that overhead to near-zero for on-device AI. The product that can credibly offer regulatory compliance-by-architecture, without the associated cost and complexity, has a structural market advantage.
 
 ## The pattern across jurisdictions
 
 The pattern across privacy regulations globally is consistent.
 
-Each regulation defines compliance obligations triggered by third-party collection and processing of personal data. Each regulation creates overhead - consent management, data subject rights, breach notification, cross-border transfer mechanisms. Each regulation creates legal risk for products that fail to comply.
+Each regulation defines compliance obligations triggered by third-party collection and processing of personal data. Each regulation creates overhead: consent management, data subject rights, breach notification, cross-border transfer mechanisms. Each regulation creates legal risk for products that fail to comply.
 
-On-device AI is not exempt from regulation. But the architecture dramatically reduces the surface area that regulations are targeting. The obligations that require the most compliance investment - cross-border transfers, third-party processing agreements, large-scale personal data handling - mostly don't apply to a system that processes data locally and sends nothing to external servers.
+On-device AI is not exempt from regulation. But the architecture dramatically reduces the surface area that regulations are targeting. The obligations that require the most compliance investment (cross-border transfers, third-party processing agreements, large-scale personal data handling) mostly don't apply to a system that processes data locally and sends nothing to external servers.
 
 Every new privacy regulation is a tailwind for on-device AI. Not because the regulatory environment is hostile to cloud AI specifically, but because the on-device architecture is inherently aligned with what regulators are trying to achieve.
 

--- a/website/writing/the-small-things.md
+++ b/website/writing/the-small-things.md
@@ -1,0 +1,77 @@
+---
+layout: default
+title: "It's Not About Productivity. It's About the 35 Tabs."
+parent: Perspectives
+nav_order: 29
+description: Hiring a secretary doesn't 5x your business. It just means life is easier. We spend 90% of our time on digital devices and almost none of that time is actually easy.
+---
+
+# It's Not About Productivity. It's About the 35 Tabs.
+
+You have 35 tabs open right now.
+
+Not because you're disorganised. Because closing them feels like losing something. You visited a page, read something useful, and now it lives in your browser because if you close it, it's gone. Not important enough to bookmark. Not unimportant enough to let go. So it stays. Along with the 34 others.
+
+That's not a productivity problem. That's a memory problem. Your browser has no memory. You're compensating for it by keeping the tabs open as a physical reminder that the thing exists.
+
+---
+
+Nobody hires a secretary and expects to 5x their business.
+
+That's not what a secretary is for. A secretary means you never lose the thing you were looking for. It means you're prepared for your next meeting without spending 15 minutes assembling context. It means the follow-up email that should have gone out on Thursday actually went out on Thursday. It means when someone asks "did we ever resolve that?" you don't have to think about it.
+
+Life is smoother. That's it. That's the whole value proposition.
+
+We've been sold a version of AI that promises transformation. Supercharged productivity. Workflows automated. Hours reclaimed. And maybe some of that is real for some people. But for most people, most of the time, that's not what's actually broken about their day.
+
+What's broken is smaller than that. And it happens constantly.
+
+---
+
+You spend 90% of your waking hours on digital devices.
+
+Think about what that actually means. Your phone is the first thing you look at in the morning. Your laptop is open for most of the working day. Your phone is back in your hand by evening. Screen time data is consistently between 7 and 11 hours a day for knowledge workers.
+
+And almost none of that time is genuinely easy.
+
+Not in the way that physical tools are easy. A good pen writes. A good chair supports you. They don't make you search for information you already had. They don't make you reconstruct context you already assembled. They don't lose things.
+
+Your digital devices lose things constantly. They just lose them in ways you've become so accustomed to that you've stopped noticing it's happening.
+
+The tab you kept open for three weeks because you knew you'd need it. The message you sent six months ago that you need to find now and can't remember the exact words to search for. The name of the person someone mentioned in a meeting that you meant to look up after. The article you read on your phone that you want to reference on your laptop but now have no idea where it was. The document you wrote two months ago that definitely exists somewhere.
+
+Each one is a small friction. A moment where your device, which witnessed everything, offers nothing.
+
+---
+
+A good personal assistant fixes this without you noticing.
+
+Not by being smarter than you. Not by making better decisions. Just by remembering. By tracking. By being there when you need the thing, with the thing.
+
+"That article from last week about X" gets you the article. "The email where we agreed on the scope" gets you the email. "What was that company someone mentioned in our call on Tuesday" gets you the answer.
+
+None of this is impressive. None of it will appear in a product demo. It doesn't make a good headline about AI transforming your workflow. It just means your day has less friction in it. And you have 35 fewer tabs open.
+
+---
+
+That's what a Personal AI OS actually is, when you strip away the category talk.
+
+It's the thing that watched you visit that page and remembers it. It knows your browsing is part of your context just like your messages and your calendar. When you need it, you ask in plain language and it finds it. You didn't have to decide it was worth bookmarking. You don't have to remember where it was or when you saw it. You just ask.
+
+It's not surveillance. It's your memory, running locally on your hardware, available only to you. The same way a secretary keeps notes that belong to you, not to the firm they work for.
+
+The 35 tabs are open because nothing in your digital life plays this role. Not your browser. Not your operating system. Not any of the AI products that exist today, because they don't have access to your context, or they have it but it lives on a server you don't control, or they only know what you've explicitly told them in the current session.
+
+---
+
+The promise worth making is not the big one.
+
+Not "this will transform how you work." Not "you'll get hours back every week." Those might be true for some people. But they're not the promise that matters to most people most of the time.
+
+The promise that matters is: your digital life will be a little easier. The things you've already seen will be findable. The things you've already done won't need to be redone. The context you've already assembled won't need to be reassembled.
+
+That's what a good assistant gives you. Not transformation. Smoothness. And after 20 years of digital devices that constantly lose things you gave them, smoothness is not a small thing.
+
+---
+
+*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone, the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*

--- a/website/writing/two-devices-zero-context.md
+++ b/website/writing/two-devices-zero-context.md
@@ -20,11 +20,11 @@ Not at the intelligence layer. Not in a way that means anything.
 
 Your laptop sees your work.
 
-It knows what you are writing, what you are reading, what research you are doing. It knows your email - the threads you are managing, the commitments you have made, the conversations in progress. It has your files, your code, your documents. It is the most accurate record of your professional output that has ever existed.
+It knows what you are writing, what you are reading, what research you are doing. It knows your email: the threads you are managing, the commitments you have made, the conversations in progress. It has your files, your code, your documents. It is the most accurate record of your professional output that has ever existed.
 
 Your phone sees your life.
 
-It knows your personal messages, your relationships, your social context. It knows your health - sleep, activity, physical patterns. It knows your location - where you go, how often, for how long. It knows your calendar commitments in the context of everything else competing for your time.
+It knows your personal messages, your relationships, your social context. It knows your health: sleep, activity, physical patterns. It knows your location: where you go, how often, for how long. It knows your calendar commitments in the context of everything else competing for your time.
 
 Neither device has access to what the other sees. The intelligence built into each operates in isolation.
 
@@ -38,7 +38,7 @@ You hold all of this yourself. In your head. Across two separate devices, two se
 
 The split creates a specific kind of overhead that knowledge workers carry constantly without fully recognising it as a structural problem.
 
-**Context assembly.** Before every significant task - a meeting, a difficult message, a decision - you assemble context manually. You check your calendar on your laptop, your messages on your phone, your notes somewhere else. The information exists. Gathering it is work you do.
+**Context assembly.** Before every significant task (a meeting, a difficult message, a decision) you assemble context manually. You check your calendar on your laptop, your messages on your phone, your notes somewhere else. The information exists. Gathering it is work you do.
 
 **Cross-device triage.** A notification arrives on your phone while you are working on your laptop. You pick up your phone, switch context, assess it, decide how to respond, put the phone down, and try to reconstruct your train of thought. This happens many times a day.
 
@@ -50,7 +50,7 @@ The split creates a specific kind of overhead that knowledge workers carry const
 
 A Personal AI OS treats both devices as part of a single intelligence system.
 
-Context built on your phone - messages, health, location, personal calendar - is available on your laptop. Context built on your laptop - files, email, work calendar, current projects - is available on your phone. Not through a cloud relay. Over your local network, privately, between devices you own.
+Context built on your phone (messages, health, location, personal calendar) is available on your laptop. Context built on your laptop (files, email, work calendar, current projects) is available on your phone. Not through a cloud relay. Over your local network, privately, between devices you own.
 
 The AI on either device has a unified view of you. When you ask it to help you prepare for a meeting, it draws on your phone's knowledge of the recent conversation with that person and your laptop's knowledge of the last document you shared with them. When it surfaces a notification, it knows whether you are in the middle of focused work on your laptop and can defer accordingly.
 
@@ -62,9 +62,9 @@ You are one person. The intelligence layer knows that.
 
 Cross-device context sharing at the intelligence layer is not a feature you can add to existing products. It requires different architecture from the ground up.
 
-Cloud sync gives you the same data on both devices - your calendar is on your phone and your laptop. Data sync is not intelligence sync. Having the same calendar on both devices does not give either device's AI a unified view of your context. Each AI still operates in isolation.
+Cloud sync gives you the same data on both devices: your calendar is on your phone and your laptop. Data sync is not intelligence sync. Having the same calendar on both devices does not give either device's AI a unified view of your context. Each AI still operates in isolation.
 
-True cross-device intelligence requires a context model - a representation of who you are and what is happening in your life - that spans both devices and is updated continuously from both. That context model has to live somewhere. The right place is your devices, synced over your local network. A cloud server that receives your most personal data as a side effect of providing coordination is the wrong place.
+True cross-device intelligence requires a context model that spans both devices and is updated continuously from both. That model is a representation of who you are and what is happening in your life. That context model has to live somewhere. The right place is your devices, synced over your local network. A cloud server that receives your most personal data as a side effect of providing coordination is the wrong place.
 
 The architecture that solves the two-device problem is the same architecture that solves the privacy problem. On-device context. Local network sync. No server in between.
 
@@ -74,7 +74,7 @@ The architecture that solves the two-device problem is the same architecture tha
 
 Off Grid's thesis starts here.
 
-The most fundamental thing broken about personal computing today is the gap between what your devices know about you and what they do with it - specifically, the gap between two devices that serve the same person but operate in isolation.
+The most fundamental thing broken about personal computing today is the gap between what your devices know about you and what they do with it. Specifically: two devices that serve the same person but operate in isolation.
 
 Closing that gap, privately, without requiring you to hand your most personal context to external infrastructure, is what the Personal AI OS is built to do.
 

--- a/website/writing/va-industry-disruption.md
+++ b/website/writing/va-industry-disruption.md
@@ -8,9 +8,9 @@ description: The VA market is worth billions and growing. On-device AI doesn't c
 
 # Why the Virtual Assistant Industry Is About to Be Disrupted by On-Device AI
 
-The market for virtual assistance -- human remote workers who handle the administrative work of knowledge workers and small businesses -- is a multi-billion dollar industry and growing.
+The market for virtual assistance - human remote workers who handle the administrative work of knowledge workers and small businesses - is a multi-billion dollar industry and growing.
 
-The growth makes sense. There is a genuine and expanding need for administrative intelligence at the individual level. The knowledge worker's day is full of work that requires judgment but not their specific judgment -- coordination, triage, drafting, scheduling, research. Offloading that work to a capable assistant makes the principal demonstrably more effective. The value proposition is not in question.
+The growth makes sense. There is a genuine and expanding need for administrative intelligence at the individual level. The knowledge worker's day is full of work that requires judgment but not their specific judgment - coordination, triage, drafting, scheduling, research. Offloading that work to a capable assistant makes the principal demonstrably more effective. The value proposition is not in question.
 
 What is about to change is where that intelligence comes from.
 
@@ -36,7 +36,7 @@ An assistant can only act on what they know. And what they know is limited to wh
 
 They don't have access to your full message history. They can't see your health data or understand that you're running on three hours of sleep. They don't know the backstory of every relationship in your contact list. They can't read between the lines of your calendar and notice the pattern that you systematically overbook yourself on Wednesdays and regret it by Thursday morning.
 
-The intelligence they provide is bounded by the context you're willing to share -- which is always less than the full picture, because sharing the full picture with another person is its own kind of exposure.
+The intelligence they provide is bounded by the context you're willing to share - which is always less than the full picture, because sharing the full picture with another person is its own kind of exposure.
 
 This creates a paradox. The most valuable administrative intelligence would come from a system with complete context. But the more complete the context, the more you're sharing with someone else. Human VAs resolve this by having limited context. Which limits the intelligence.
 
@@ -48,7 +48,7 @@ A Personal AI OS changes the information asymmetry completely.
 
 It has access to your full context: your messages, your calendar, your files, your communication history, your work patterns, your health data, your location patterns. Not as a snapshot you've deliberately shared, but as a live, continuously updated picture of your life.
 
-And crucially -- it has that context without you handing it to another person. The data stays on your device. The processing happens on your hardware. Nothing leaves.
+And crucially - it has that context without you handing it to another person. The data stays on your device. The processing happens on your hardware. Nothing leaves.
 
 This is the dimension the human model structurally cannot match. No human VA can have your full context without you giving it to them. An on-device AI has your full context precisely because it never leaves your hands.
 
@@ -59,7 +59,7 @@ The intelligence that results from full context is categorically different from 
 - It can draft a follow-up in your voice with the specifics of what was actually discussed, not a generic template.
 - It can notice that the email that just arrived is related to the calendar event you've been anxious about and surface them together.
 
-These are not incremental improvements on what a human VA does. They are capabilities that require a different kind of context access -- one that a human assistant can't have by design.
+These are not incremental improvements on what a human VA does. They are capabilities that require a different kind of context access - one that a human assistant can't have by design.
 
 ---
 
@@ -67,7 +67,7 @@ These are not incremental improvements on what a human VA does. They are capabil
 
 The disruption of the VA industry by on-device AI won't look like a sudden cliff. It will look like two things happening simultaneously.
 
-At the bottom of the market -- the use cases that were already best suited to automation -- AI takes over. The clients who used VAs for templated, repeatable administrative work find that an on-device system does it better, faster, and without the relationship overhead.
+At the bottom of the market - the use cases that were already best suited to automation - AI takes over. The clients who used VAs for templated, repeatable administrative work find that an on-device system does it better, faster, and without the relationship overhead.
 
 At the top of the market, human VAs move up the value chain. The work that remains for human assistants is the work that genuinely requires human judgment, interpersonal skill, and real-world presence. The coordinators and schedulers become relationship managers and strategic operators. The function that couldn't be automated becomes more valued because the function that could be automated now is.
 
@@ -77,7 +77,7 @@ This is the pattern technology disruption always follows: the lowest value-add w
 
 ## The people this actually reaches
 
-The VA industry, for all its growth, remained a service primarily available to knowledge workers above a certain income threshold. The cost of a skilled human VA -- even remote, even part-time -- was prohibitive for most people who could have benefited from it.
+The VA industry, for all its growth, remained a service primarily available to knowledge workers above a certain income threshold. The cost of a skilled human VA - even remote, even part-time - was prohibitive for most people who could have benefited from it.
 
 The individuals who needed administrative support most urgently were often the ones least able to afford it: sole traders, early-stage entrepreneurs, freelancers managing multiple clients, mid-level professionals drowning in coordination overhead.
 

--- a/website/writing/va-industry-disruption.md
+++ b/website/writing/va-industry-disruption.md
@@ -3,14 +3,14 @@ layout: default
 title: "Why the Virtual Assistant Industry Is About to Be Disrupted by On-Device AI"
 parent: Perspectives
 nav_order: 28
-description: The VA market is worth billions and growing. On-device AI doesn't compete with it on price - it competes on a dimension the human model can't match: full personal context, always available, private by architecture.
+description: The VA market is worth billions and growing. On-device AI doesn't compete with it on price. It competes on a dimension the human model can't match: full personal context, always available, private by architecture.
 ---
 
 # Why the Virtual Assistant Industry Is About to Be Disrupted by On-Device AI
 
-The market for virtual assistance - human remote workers who handle the administrative work of knowledge workers and small businesses - is a multi-billion dollar industry and growing.
+The market for virtual assistance is a multi-billion dollar industry and growing. Human remote workers handling the administrative work of knowledge workers and small businesses built it.
 
-The growth makes sense. There is a genuine and expanding need for administrative intelligence at the individual level. The knowledge worker's day is full of work that requires judgment but not their specific judgment - coordination, triage, drafting, scheduling, research. Offloading that work to a capable assistant makes the principal demonstrably more effective. The value proposition is not in question.
+The growth makes sense. There is a genuine and expanding need for administrative intelligence at the individual level. The knowledge worker's day is full of work that requires judgment but not their specific judgment: coordination, triage, drafting, scheduling, research. Offloading that work to a capable assistant makes the principal demonstrably more effective. The value proposition is not in question.
 
 What is about to change is where that intelligence comes from.
 
@@ -36,7 +36,7 @@ An assistant can only act on what they know. And what they know is limited to wh
 
 They don't have access to your full message history. They can't see your health data or understand that you're running on three hours of sleep. They don't know the backstory of every relationship in your contact list. They can't read between the lines of your calendar and notice the pattern that you systematically overbook yourself on Wednesdays and regret it by Thursday morning.
 
-The intelligence they provide is bounded by the context you're willing to share - which is always less than the full picture, because sharing the full picture with another person is its own kind of exposure.
+The intelligence they provide is bounded by the context you're willing to share, which is always less than the full picture. Sharing the full picture with another person is its own kind of exposure.
 
 This creates a paradox. The most valuable administrative intelligence would come from a system with complete context. But the more complete the context, the more you're sharing with someone else. Human VAs resolve this by having limited context. Which limits the intelligence.
 
@@ -48,7 +48,7 @@ A Personal AI OS changes the information asymmetry completely.
 
 It has access to your full context: your messages, your calendar, your files, your communication history, your work patterns, your health data, your location patterns. Not as a snapshot you've deliberately shared, but as a live, continuously updated picture of your life.
 
-And crucially - it has that context without you handing it to another person. The data stays on your device. The processing happens on your hardware. Nothing leaves.
+And it has that context without you handing it to another person. The data stays on your device. The processing happens on your hardware. Nothing leaves.
 
 This is the dimension the human model structurally cannot match. No human VA can have your full context without you giving it to them. An on-device AI has your full context precisely because it never leaves your hands.
 
@@ -59,7 +59,7 @@ The intelligence that results from full context is categorically different from 
 - It can draft a follow-up in your voice with the specifics of what was actually discussed, not a generic template.
 - It can notice that the email that just arrived is related to the calendar event you've been anxious about and surface them together.
 
-These are not incremental improvements on what a human VA does. They are capabilities that require a different kind of context access - one that a human assistant can't have by design.
+These are not incremental improvements on what a human VA does. They are capabilities that require a different kind of context access. One that a human assistant can't have by design.
 
 ---
 
@@ -67,7 +67,7 @@ These are not incremental improvements on what a human VA does. They are capabil
 
 The disruption of the VA industry by on-device AI won't look like a sudden cliff. It will look like two things happening simultaneously.
 
-At the bottom of the market - the use cases that were already best suited to automation - AI takes over. The clients who used VAs for templated, repeatable administrative work find that an on-device system does it better, faster, and without the relationship overhead.
+At the bottom of the market, the use cases already best suited to automation, AI takes over. The clients who used VAs for templated, repeatable administrative work find that an on-device system does it better, faster, and without the relationship overhead.
 
 At the top of the market, human VAs move up the value chain. The work that remains for human assistants is the work that genuinely requires human judgment, interpersonal skill, and real-world presence. The coordinators and schedulers become relationship managers and strategic operators. The function that couldn't be automated becomes more valued because the function that could be automated now is.
 
@@ -77,7 +77,7 @@ This is the pattern technology disruption always follows: the lowest value-add w
 
 ## The people this actually reaches
 
-The VA industry, for all its growth, remained a service primarily available to knowledge workers above a certain income threshold. The cost of a skilled human VA - even remote, even part-time - was prohibitive for most people who could have benefited from it.
+The VA industry, for all its growth, remained a service primarily available to knowledge workers above a certain income threshold. The cost of a skilled human VA was prohibitive for most people who could have benefited from it. Even remote, even part-time.
 
 The individuals who needed administrative support most urgently were often the ones least able to afford it: sole traders, early-stage entrepreneurs, freelancers managing multiple clients, mid-level professionals drowning in coordination overhead.
 
@@ -89,4 +89,4 @@ That product is being built now.
 
 ---
 
-*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone - the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*
+*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone, the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*

--- a/website/writing/va-industry-disruption.md
+++ b/website/writing/va-industry-disruption.md
@@ -8,9 +8,9 @@ description: The VA market is worth billions and growing. On-device AI doesn't c
 
 # Why the Virtual Assistant Industry Is About to Be Disrupted by On-Device AI
 
-The market for virtual assistance — human remote workers who handle the administrative work of knowledge workers and small businesses — is a multi-billion dollar industry and growing.
+The market for virtual assistance -- human remote workers who handle the administrative work of knowledge workers and small businesses -- is a multi-billion dollar industry and growing.
 
-The growth makes sense. There is a genuine and expanding need for administrative intelligence at the individual level. The knowledge worker's day is full of work that requires judgment but not their specific judgment — coordination, triage, drafting, scheduling, research. Offloading that work to a capable assistant makes the principal demonstrably more effective. The value proposition is not in question.
+The growth makes sense. There is a genuine and expanding need for administrative intelligence at the individual level. The knowledge worker's day is full of work that requires judgment but not their specific judgment -- coordination, triage, drafting, scheduling, research. Offloading that work to a capable assistant makes the principal demonstrably more effective. The value proposition is not in question.
 
 What is about to change is where that intelligence comes from.
 
@@ -36,7 +36,7 @@ An assistant can only act on what they know. And what they know is limited to wh
 
 They don't have access to your full message history. They can't see your health data or understand that you're running on three hours of sleep. They don't know the backstory of every relationship in your contact list. They can't read between the lines of your calendar and notice the pattern that you systematically overbook yourself on Wednesdays and regret it by Thursday morning.
 
-The intelligence they provide is bounded by the context you're willing to share — which is always less than the full picture, because sharing the full picture with another person is its own kind of exposure.
+The intelligence they provide is bounded by the context you're willing to share -- which is always less than the full picture, because sharing the full picture with another person is its own kind of exposure.
 
 This creates a paradox. The most valuable administrative intelligence would come from a system with complete context. But the more complete the context, the more you're sharing with someone else. Human VAs resolve this by having limited context. Which limits the intelligence.
 
@@ -48,7 +48,7 @@ A Personal AI OS changes the information asymmetry completely.
 
 It has access to your full context: your messages, your calendar, your files, your communication history, your work patterns, your health data, your location patterns. Not as a snapshot you've deliberately shared, but as a live, continuously updated picture of your life.
 
-And crucially — it has that context without you handing it to another person. The data stays on your device. The processing happens on your hardware. Nothing leaves.
+And crucially -- it has that context without you handing it to another person. The data stays on your device. The processing happens on your hardware. Nothing leaves.
 
 This is the dimension the human model structurally cannot match. No human VA can have your full context without you giving it to them. An on-device AI has your full context precisely because it never leaves your hands.
 
@@ -59,7 +59,7 @@ The intelligence that results from full context is categorically different from 
 - It can draft a follow-up in your voice with the specifics of what was actually discussed, not a generic template.
 - It can notice that the email that just arrived is related to the calendar event you've been anxious about and surface them together.
 
-These are not incremental improvements on what a human VA does. They are capabilities that require a different kind of context access — one that a human assistant can't have by design.
+These are not incremental improvements on what a human VA does. They are capabilities that require a different kind of context access -- one that a human assistant can't have by design.
 
 ---
 
@@ -67,7 +67,7 @@ These are not incremental improvements on what a human VA does. They are capabil
 
 The disruption of the VA industry by on-device AI won't look like a sudden cliff. It will look like two things happening simultaneously.
 
-At the bottom of the market — the use cases that were already best suited to automation — AI takes over. The clients who used VAs for templated, repeatable administrative work find that an on-device system does it better, faster, and without the relationship overhead.
+At the bottom of the market -- the use cases that were already best suited to automation -- AI takes over. The clients who used VAs for templated, repeatable administrative work find that an on-device system does it better, faster, and without the relationship overhead.
 
 At the top of the market, human VAs move up the value chain. The work that remains for human assistants is the work that genuinely requires human judgment, interpersonal skill, and real-world presence. The coordinators and schedulers become relationship managers and strategic operators. The function that couldn't be automated becomes more valued because the function that could be automated now is.
 
@@ -77,7 +77,7 @@ This is the pattern technology disruption always follows: the lowest value-add w
 
 ## The people this actually reaches
 
-The VA industry, for all its growth, remained a service primarily available to knowledge workers above a certain income threshold. The cost of a skilled human VA — even remote, even part-time — was prohibitive for most people who could have benefited from it.
+The VA industry, for all its growth, remained a service primarily available to knowledge workers above a certain income threshold. The cost of a skilled human VA -- even remote, even part-time -- was prohibitive for most people who could have benefited from it.
 
 The individuals who needed administrative support most urgently were often the ones least able to afford it: sole traders, early-stage entrepreneurs, freelancers managing multiple clients, mid-level professionals drowning in coordination overhead.
 

--- a/website/writing/va-industry-disruption.md
+++ b/website/writing/va-industry-disruption.md
@@ -1,0 +1,92 @@
+---
+layout: default
+title: "Why the Virtual Assistant Industry Is About to Be Disrupted by On-Device AI"
+parent: Perspectives
+nav_order: 28
+description: The VA market is worth billions and growing. On-device AI doesn't compete with it on price - it competes on a dimension the human model can't match: full personal context, always available, private by architecture.
+---
+
+# Why the Virtual Assistant Industry Is About to Be Disrupted by On-Device AI
+
+The market for virtual assistance — human remote workers who handle the administrative work of knowledge workers and small businesses — is a multi-billion dollar industry and growing.
+
+The growth makes sense. There is a genuine and expanding need for administrative intelligence at the individual level. The knowledge worker's day is full of work that requires judgment but not their specific judgment — coordination, triage, drafting, scheduling, research. Offloading that work to a capable assistant makes the principal demonstrably more effective. The value proposition is not in question.
+
+What is about to change is where that intelligence comes from.
+
+---
+
+## What built the VA industry
+
+The VA industry emerged from a simple structural insight: modern communication tools made it possible to provide administrative support remotely, at lower cost than local hiring.
+
+Before the internet made real-time remote collaboration viable, administrative support required physical proximity. The secretary sat down the hall. The assistant was in the same building.
+
+Remote work tools changed that. You could work with an assistant in a different city, a different time zone, at dramatically lower cost. For a knowledge worker generating value at a professional rate, the arbitrage was obvious: pay less per hour for the coordination work, free up your own hours for the work only you could do.
+
+The economics were compelling. The industry scaled accordingly.
+
+---
+
+## The ceiling in the model
+
+But the VA model has a structural ceiling, and it shows up most clearly in the information asymmetry.
+
+An assistant can only act on what they know. And what they know is limited to what you've shared with them.
+
+They don't have access to your full message history. They can't see your health data or understand that you're running on three hours of sleep. They don't know the backstory of every relationship in your contact list. They can't read between the lines of your calendar and notice the pattern that you systematically overbook yourself on Wednesdays and regret it by Thursday morning.
+
+The intelligence they provide is bounded by the context you're willing to share — which is always less than the full picture, because sharing the full picture with another person is its own kind of exposure.
+
+This creates a paradox. The most valuable administrative intelligence would come from a system with complete context. But the more complete the context, the more you're sharing with someone else. Human VAs resolve this by having limited context. Which limits the intelligence.
+
+---
+
+## Where on-device AI breaks the model
+
+A Personal AI OS changes the information asymmetry completely.
+
+It has access to your full context: your messages, your calendar, your files, your communication history, your work patterns, your health data, your location patterns. Not as a snapshot you've deliberately shared, but as a live, continuously updated picture of your life.
+
+And crucially — it has that context without you handing it to another person. The data stays on your device. The processing happens on your hardware. Nothing leaves.
+
+This is the dimension the human model structurally cannot match. No human VA can have your full context without you giving it to them. An on-device AI has your full context precisely because it never leaves your hands.
+
+The intelligence that results from full context is categorically different from the intelligence that results from partial context:
+
+- It can triage your inbox understanding not just the content of each message but the full history of your relationship with each sender.
+- It can prepare you for a meeting drawing on every previous interaction with those people, every relevant document, every commitment that was made.
+- It can draft a follow-up in your voice with the specifics of what was actually discussed, not a generic template.
+- It can notice that the email that just arrived is related to the calendar event you've been anxious about and surface them together.
+
+These are not incremental improvements on what a human VA does. They are capabilities that require a different kind of context access — one that a human assistant can't have by design.
+
+---
+
+## What happens to the VA industry
+
+The disruption of the VA industry by on-device AI won't look like a sudden cliff. It will look like two things happening simultaneously.
+
+At the bottom of the market — the use cases that were already best suited to automation — AI takes over. The clients who used VAs for templated, repeatable administrative work find that an on-device system does it better, faster, and without the relationship overhead.
+
+At the top of the market, human VAs move up the value chain. The work that remains for human assistants is the work that genuinely requires human judgment, interpersonal skill, and real-world presence. The coordinators and schedulers become relationship managers and strategic operators. The function that couldn't be automated becomes more valued because the function that could be automated now is.
+
+This is the pattern technology disruption always follows: the lowest value-add work gets automated first, and the people who were doing it move to higher value-add work or exit the market.
+
+---
+
+## The people this actually reaches
+
+The VA industry, for all its growth, remained a service primarily available to knowledge workers above a certain income threshold. The cost of a skilled human VA — even remote, even part-time — was prohibitive for most people who could have benefited from it.
+
+The individuals who needed administrative support most urgently were often the ones least able to afford it: sole traders, early-stage entrepreneurs, freelancers managing multiple clients, mid-level professionals drowning in coordination overhead.
+
+On-device AI doesn't just disrupt the existing VA market. It creates a market that previously didn't exist: administrative intelligence for the people the human model never reached.
+
+The device in their pocket already has the compute to run it. The models are open-weight and free to use. The only thing that was missing was the product that made those capabilities into an intelligence layer.
+
+That product is being built now.
+
+---
+
+*Off Grid is building toward this. It starts with on-device AI that works fully offline on your phone - the foundation that makes everything above possible without your data ever leaving your device. [Download for iPhone](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882?utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing) or [Android](https://play.google.com/store/apps/details?id=ai.offgridmobile&utm_source=offgrid-docs&utm_medium=website&utm_campaign=writing).*

--- a/website/writing/what-is-personal-ai-os.md
+++ b/website/writing/what-is-personal-ai-os.md
@@ -7,8 +7,8 @@ description: A Personal AI OS is intelligence that lives on your device, knows y
 faq:
   - q: What is a Personal AI OS?
     a: A Personal AI OS is an intelligence layer that runs entirely on your own hardware - phone, laptop, or both - with access to your full personal context (messages, calendar, files, health data) and the ability to act on your behalf. Unlike cloud AI assistants, it never sends your data to a server. It runs offline, charges no ongoing fees for AI compute, and is auditable by design.
-  - q: How is a Personal AI OS different from an AI assistant like Siri or Alexa?
-    a: Siri and Alexa are cloud-dependent voice interfaces. They send your queries to remote servers, return responses, and retain minimal context between sessions. A Personal AI OS runs locally on your device, maintains persistent context about your life and work, and can act across apps on your behalf - not just answer isolated questions.
+  - q: How is a Personal AI OS different from a platform AI assistant?
+    a: Platform AI assistants are cloud-dependent voice interfaces. They send your queries to remote servers, return responses, and retain minimal context between sessions. A Personal AI OS runs locally on your device, maintains persistent context about your life and work, and can act across apps on your behalf - not just answer isolated questions.
   - q: How is a Personal AI OS different from an AI agent?
     a: AI agents are typically autonomous systems that make decisions and take actions with minimal human oversight, often connected to external services. A Personal AI OS is explicitly non-autonomous - it acts on your behalf with your consent, defers to you on decisions, and operates within the boundary of your own hardware and local network.
   - q: Does a Personal AI OS require an internet connection?
@@ -78,7 +78,7 @@ A Personal AI OS is not an autonomous agent. It does not make decisions on your 
 
 It is also not a walled garden. The category requires openness - open models, open source code, open protocols for cross-device communication. A closed Personal AI OS is a contradiction in terms.
 
-And it is not a product tied to a hardware platform. Apple Intelligence and Google Gemini are AI features inside existing platforms. A Personal AI OS is a layer that runs on your hardware regardless of who made it.
+And it is not a product tied to a hardware platform. The AI features built into operating systems are constrained by the platform's architecture and commercial interests. A Personal AI OS is an independent layer that runs on your hardware regardless of who made it.
 
 ---
 

--- a/website/writing/what-is-personal-ai-os.md
+++ b/website/writing/what-is-personal-ai-os.md
@@ -6,7 +6,7 @@ nav_order: 1
 description: A Personal AI OS is intelligence that lives on your device, knows your full context, and acts on your behalf - without ever sending data to a server. Here's what defines the category and why it matters.
 faq:
   - q: What is a Personal AI OS?
-    a: A Personal AI OS is an intelligence layer that runs entirely on your own hardware - phone, laptop, or both - with access to your full personal context (messages, calendar, files, health data) and the ability to act on your behalf. Unlike cloud AI assistants, it never sends your data to a server. It runs offline, owns no subscription model, and is auditable by design.
+    a: A Personal AI OS is an intelligence layer that runs entirely on your own hardware - phone, laptop, or both - with access to your full personal context (messages, calendar, files, health data) and the ability to act on your behalf. Unlike cloud AI assistants, it never sends your data to a server. It runs offline, charges no ongoing fees for AI compute, and is auditable by design.
   - q: How is a Personal AI OS different from an AI assistant like Siri or Alexa?
     a: Siri and Alexa are cloud-dependent voice interfaces. They send your queries to remote servers, return responses, and retain minimal context between sessions. A Personal AI OS runs locally on your device, maintains persistent context about your life and work, and can act across apps on your behalf - not just answer isolated questions.
   - q: How is a Personal AI OS different from an AI agent?
@@ -68,7 +68,7 @@ These are the properties that define a true Personal AI OS. They are structural 
 
 **6. Open and auditable.** The model weights and application code are inspectable. You can verify what the AI does and does not do with your data. Trust through transparency, not through policy.
 
-**7. No subscription required.** You own the software. You run the model. Intelligence is a tool you own, not a service you rent. The economics of on-device AI allow for this - there is no server cost to recover.
+**7. No cloud compute rent.** You do not pay ongoing fees for someone else's servers to process your queries. The model runs on your hardware. There is no server cost to recover from you. Software may have a price - building it takes work - but the AI itself is not metered.
 
 ---
 

--- a/website/writing/what-is-personal-ai-os.md
+++ b/website/writing/what-is-personal-ai-os.md
@@ -34,7 +34,7 @@ A Personal AI OS is an intelligence layer that:
 - Persists context between sessions, building a working model of your life and work
 - Is open and auditable - no black-box telemetry, no hidden data collection
 
-That's the category. Everything else currently called AI - cloud assistants, chatbots, autonomous agents - is something different.
+That's the category. Everything else currently called AI (cloud assistants, chatbots, autonomous agents) is something different.
 
 ---
 
@@ -42,13 +42,13 @@ That's the category. Everything else currently called AI - cloud assistants, cha
 
 The dominant AI products today are cloud services. You send them a query. They process it on a remote server. They return a response. Your data passes through infrastructure you don't control, gets logged, and contributes to models you can't inspect.
 
-This works for general-purpose tasks where your personal context doesn't matter. Ask about the weather in Tokyo or summarise a Wikipedia article - it doesn't matter that the request went to a server.
+This works for general-purpose tasks where your personal context doesn't matter. Ask about the weather in Tokyo or summarise a Wikipedia article. It doesn't matter that the request went to a server.
 
 But the tasks where AI becomes useful are the ones that require knowing you. Triaging your inbox. Preparing for your next meeting. Noticing that you have three conflicting commitments next Thursday. Drafting a message in your tone, not a generic one.
 
 For those tasks, the AI needs your data. Handing your most personal data to a server you don't control, in exchange for a subscription, is a trade most people haven't consciously agreed to.
 
-A Personal AI OS resolves this by keeping the intelligence local. The model runs on your device. Your context never leaves. The most capable AI for your life is also the most private - not by policy, but by architecture.
+A Personal AI OS resolves this by keeping the intelligence local. The model runs on your device. Your context never leaves. The most capable AI for your life is also the most private: not by policy, but by architecture.
 
 ---
 
@@ -56,19 +56,19 @@ A Personal AI OS resolves this by keeping the intelligence local. The model runs
 
 These are the properties that define a true Personal AI OS. They are structural requirements. An AI product that fails any one of them is something else.
 
-**1. Runs on-device.** Inference happens on your hardware - CPU, GPU, or NPU. No query is sent to a remote model. No response comes back from a server.
+**1. Runs on-device.** Inference happens on your hardware: CPU, GPU, or NPU. No query is sent to a remote model. No response comes back from a server.
 
 **2. Never phones home.** No telemetry. No usage logs. No data collection of any kind. What happens on your device stays on your device.
 
 **3. Persistent context.** The AI maintains a working model of your life across sessions. It knows your calendar, your recent messages, your open tasks, your work patterns. Context is the primitive, not queries.
 
-**4. Acts on your behalf.** The AI can take actions - draft messages, set reminders, summarise documents, search your files - not just answer questions. Agency, with your consent as the operating principle.
+**4. Acts on your behalf.** The AI can take actions (draft messages, set reminders, summarise documents, search your files), not just answer questions. Agency, with your consent as the operating principle.
 
 **5. Works across your devices.** Your phone and laptop are used by one person. The AI should have a unified view across both, synced over your local network without a cloud relay.
 
 **6. Open and auditable.** The model weights and application code are inspectable. You can verify what the AI does and does not do with your data. Trust through transparency, not through policy.
 
-**7. No cloud compute rent.** You do not pay ongoing fees for someone else's servers to process your queries. The model runs on your hardware. There is no server cost to recover from you. Software may have a price - building it takes work - but the AI itself is not metered.
+**7. No cloud compute rent.** You do not pay ongoing fees for someone else's servers to process your queries. The model runs on your hardware. There is no server cost to recover from you. Software may have a price, because building it takes work, but the AI itself is not metered.
 
 ---
 
@@ -76,7 +76,7 @@ These are the properties that define a true Personal AI OS. They are structural 
 
 A Personal AI OS is not an autonomous agent. It does not make decisions on your behalf without your knowledge. It does not connect to external services without your explicit direction. It does not run in the background taking actions you haven't approved.
 
-It is also not a walled garden. The category requires openness - open models, open source code, open protocols for cross-device communication. A closed Personal AI OS is a contradiction in terms.
+It is also not a walled garden. The category requires openness: open models, open source code, open protocols for cross-device communication. A closed Personal AI OS is a contradiction in terms.
 
 And it is not a product tied to a hardware platform. The AI features built into operating systems are constrained by the platform's architecture and commercial interests. A Personal AI OS is an independent layer that runs on your hardware regardless of who made it.
 
@@ -86,7 +86,7 @@ And it is not a product tied to a hardware platform. The AI features built into 
 
 800 million knowledge workers use a phone and a laptop every day. Both devices hold the context that would make AI useful. Neither does anything meaningful with it.
 
-The Personal AI OS is the software category that closes that gap. It is the first architecture that earns the right to your full context - because the data never leaves your hands.
+The Personal AI OS is the software category that closes that gap. It is the first architecture that earns the right to your full context, because the data never leaves your hands.
 
 That's what we're building with [Off Grid]({{ '/' | relative_url }}).
 

--- a/website/writing/what-personal-ai-should-know.md
+++ b/website/writing/what-personal-ai-should-know.md
@@ -10,7 +10,7 @@ description: The right level of context makes a Personal AI OS useful. The wrong
 
 Context is what makes a personal AI useful. The more it knows about your patterns, commitments, and working style, the better it can help you.
 
-But context without limits is surveillance. Surveillance - even self-directed - produces a system that knows too much about you in ways that change how you behave around it.
+But context without limits is surveillance. Even self-directed surveillance produces a system that knows too much about you in ways that change how you behave around it.
 
 The question is not "how much context should a Personal AI OS have?" It's "what kind of context serves you, and what kind creates a system you'd rather not live with?"
 
@@ -18,13 +18,13 @@ The question is not "how much context should a Personal AI OS have?" It's "what 
 
 ## What a Personal AI OS should know
 
-**Your schedule.** The pattern of your week - when you do focused work, when you take calls, when you're typically unavailable, how often plans change. This lets the AI reason about your time in ways that a simple calendar view can't.
+**Your schedule.** The pattern of your week: when you do focused work, when you take calls, when you're typically unavailable, how often plans change. This lets the AI reason about your time in ways that a simple calendar view can't.
 
-**Your communication patterns.** The rhythm of your messages - how quickly you typically respond, which conversations you prioritise, which you defer. Not the content of every message, but the structure of your communication life.
+**Your communication patterns.** The rhythm of your messages: how quickly you typically respond, which conversations you prioritise, which you defer. Not the content of every message, but the structure of your communication life.
 
 **Your active work context.** What you're currently working on, what's blocked, what's coming due. The AI should know enough about your work to help you prepare, prioritise, and not miss things.
 
-**Your preferences and style.** How you write. What you consider important. How you prefer information presented. These don't need to be explicitly programmed - they emerge from observing how you interact with the system over time.
+**Your preferences and style.** How you write. What you consider important. How you prefer information presented. These don't need to be explicitly programmed. They emerge from observing how you interact with the system over time.
 
 **Your recent activity.** What you've been doing in the last few hours and days. Not a permanent record, but enough recent context to understand where you are in your work and what's front of mind.
 
@@ -32,13 +32,13 @@ The question is not "how much context should a Personal AI OS have?" It's "what 
 
 ## What a Personal AI OS should not know
 
-**Historical records you don't need it to have.** The value of persistent context comes from understanding patterns, not from storing everything indefinitely. A Personal AI OS that retains five years of messages and location history is building a liability, not a feature. Context should have a horizon - enough to be useful, not so much that it becomes a permanent record of your life.
+**Historical records you don't need it to have.** The value of persistent context comes from understanding patterns, not from storing everything indefinitely. A Personal AI OS that retains five years of messages and location history is building a liability, not a feature. Context should have a horizon: enough to be useful, not so much that it becomes a permanent record of your life.
 
-**Sensitive personal domains you haven't explicitly opened.** Your financial accounts, your medical records, your private relationships - these require explicit, intentional access grants. The AI should not assume that access to your calendar means access to everything connected to it.
+**Sensitive personal domains you haven't explicitly opened.** Your financial accounts, your medical records, your private relationships: these require explicit, intentional access grants. The AI should not assume that access to your calendar means access to everything connected to it.
 
-**Inferences you haven't verified.** A Personal AI OS can notice patterns - "you seem to do your best work in the mornings" - but it should surface those observations for your confirmation rather than silently acting on them. Inferences about your mental state, your relationships, or your intentions are especially dangerous to act on without verification.
+**Inferences you haven't verified.** A Personal AI OS can notice patterns ("you seem to do your best work in the mornings") but it should surface those observations for your confirmation rather than silently acting on them. Inferences about your mental state, your relationships, or your intentions are especially dangerous to act on without verification.
 
-**Enough to manipulate you.** The line between a helpful personal AI and a manipulative one is whether it's optimising for your outcomes or for its engagement with you. A system that knows your emotional patterns well enough to time notifications for moments of vulnerability is not an assistant - it's an adversary. The Personal AI OS should have this line built in from the start.
+**Enough to manipulate you.** The line between a helpful personal AI and a manipulative one is whether it's optimising for your outcomes or for its engagement with you. A system that knows your emotional patterns well enough to time notifications for moments of vulnerability is not an assistant. It's an adversary. The Personal AI OS should have this line built in from the start.
 
 ---
 
@@ -46,7 +46,7 @@ The question is not "how much context should a Personal AI OS have?" It's "what 
 
 The right framework for a Personal AI OS is explicit consent for each category of access, with the ability to revoke at any time.
 
-Calendar access is not messages access. Messages access is not health data access. Each extension of context should be a deliberate choice - not an opt-out buried in settings, but an opt-in made with a clear understanding of what the AI gains and what you gain from the exchange.
+Calendar access is not messages access. Messages access is not health data access. Each extension of context should be a deliberate choice: not an opt-out buried in settings, but an opt-in made with a clear understanding of what the AI gains and what you gain from the exchange.
 
 This is a design principle as much as a privacy one. A system you don't fully trust is a system you won't give full context. A system you've explicitly consented to is one you can actually use without reservation.
 
@@ -56,7 +56,7 @@ This is a design principle as much as a privacy one. A system you don't fully tr
 
 A Personal AI OS should show its work.
 
-Not in a technical sense - not raw logs of every inference step. But in a legible sense: if the AI says "I prioritised this message because you typically respond to this contact quickly," that reasoning should be accessible and correctable.
+Not in a technical sense, not raw logs of every inference step. But in a legible sense: if the AI says "I prioritised this message because you typically respond to this contact quickly," that reasoning should be accessible and correctable.
 
 Opacity breeds distrust. A system that makes recommendations without explanation creates anxiety about what it might know or infer that it isn't saying. Transparency about what context the AI has used, and the ability to correct its model of you, is part of what makes it a tool rather than something that's just happening to you.
 
@@ -68,7 +68,7 @@ A Personal AI OS should know as much as it needs to help you and no more.
 
 This is good design, not just privacy hygiene. A system with too much context becomes slow, noisy, and prone to surfacing irrelevant information. A system tuned to the right level of context is fast, accurate, and feels like it actually understands you.
 
-The goal is a system that knows the right things - your schedule, your priorities, your working style - well enough to reduce friction and surface what matters, without becoming a burden of its own.
+The goal is a system that knows the right things (your schedule, your priorities, your working style) well enough to reduce friction and surface what matters, without becoming a burden of its own.
 
 ---
 

--- a/website/writing/whatsapp-moment-for-ai.md
+++ b/website/writing/whatsapp-moment-for-ai.md
@@ -1,28 +1,28 @@
 ---
 layout: default
-title: "The WhatsApp Moment for AI: Why Privacy Will Define the Next Platform"
+title: "The Encrypted Messaging Moment for AI: Why Privacy Will Define the Next Platform"
 parent: Perspectives
 nav_order: 4
-description: WhatsApp adopted end-to-end encryption because the market demanded it. AI is the next communication infrastructure. The arc is the same - and the outcome will be the same.
+description: Encrypted messaging went mainstream because the market demanded it. AI is the next communication infrastructure. The arc is the same - and the outcome will be the same.
 ---
 
-# The WhatsApp Moment for AI: Why Privacy Will Define the Next Platform
+# The Encrypted Messaging Moment for AI: Why Privacy Will Define the Next Platform
 
-In 2016, WhatsApp turned on end-to-end encryption for its 1 billion users.
+Around 2016, encrypted messaging crossed into the mainstream.
 
-They didn't do it because the engineers wanted to. They did it because the market demanded it. After the Snowden revelations, after a series of high-profile data breaches, after years of growing awareness that messages on unencrypted platforms were readable by the platforms themselves, users started to care.
+The major messaging platforms — which had resisted encryption for years because it limited their own data access — shipped end-to-end encryption anyway. Not because the engineers pushed for it. Because the market demanded it.
 
-Telegram had been gaining ground on privacy. Signal was becoming the reference implementation. The market signal was clear enough that WhatsApp - owned by Facebook, a company with no obvious incentive to reduce its own data access - shipped end-to-end encryption anyway.
+After years of high-profile data breaches, after growing public awareness that messages on unencrypted platforms were readable by the platforms themselves, users started to care. Encrypted-first apps had been gaining ground on privacy. The market signal was clear enough that even platforms with no obvious incentive to reduce their own data access made the switch.
 
 AI is the next communication infrastructure. The same arc applies.
 
 ## Why AI is communication infrastructure
 
-The canonical communication technologies - telephone, email, SMS, messaging apps - all share a defining property: they carry the most private content in a person's life.
+The canonical communication technologies — telephone, email, SMS, messaging apps — all share a defining property: they carry the most private content in a person's life.
 
 Your phone calls are where you talk to your doctor, your lawyer, your family. Your messages are where you say things you wouldn't say in public. The history of communication technology is a history of fighting for the right to have those conversations without a third party listening.
 
-AI is becoming the next layer of that infrastructure. An AI assistant that knows your messages, your health, your finances, your work - and that can act on your behalf - is the most intimate piece of software ever built. It has more context than any communication app because its entire value proposition is having more context.
+AI is becoming the next layer of that infrastructure. An AI assistant that knows your messages, your health, your finances, your work — and that can act on your behalf — is the most intimate piece of software ever built. It has more context than any communication app because its entire value proposition is having more context.
 
 That makes the privacy question central. The same concerns that drove demand for encrypted messaging are, at higher stakes, the concerns that will drive demand for on-device AI.
 
@@ -30,15 +30,15 @@ That makes the privacy question central. The same concerns that drove demand for
 
 Privacy doesn't win in technology markets because people are principled. It wins because a critical mass of users has a concrete bad experience, understands what caused it, and has an alternative to switch to.
 
-For messaging, that moment came gradually. Snowden, then breaches, then Cambridge Analytica, then enough mainstream coverage that ordinary people understood their messages were readable by the platforms carrying them. Encrypted messaging went from a niche concern to a mainstream expectation.
+For messaging, that moment came gradually. Breaches, then acquisitions with changed terms, then enough mainstream coverage that ordinary people understood their messages were readable by the platforms carrying them. Encrypted messaging went from a niche concern to a mainstream expectation.
 
 For AI, the trigger events will be different in their specifics but identical in their structure. Moments where users experience the consequences of their most personal data sitting on someone else's server. Moments where they understand the alternative exists. Moments where they switch.
 
-Some of those moments will involve breaches. Some will involve policy changes that remove access to user data. Some will involve acquisitions where the terms change after users have already given years of context. The specifics will vary. The outcome - a market that demands on-device AI - will not.
+Some of those moments will involve breaches. Some will involve policy changes that remove access to user data. Some will involve acquisitions where the terms change after users have already given years of context to a product — and then lose access to their own data overnight when the company shuts down or changes hands. The specifics will vary. The outcome — a market that demands on-device AI — will not.
 
 ## The structural difference
 
-WhatsApp's encryption story has one important caveat: encryption protects data in transit, but WhatsApp still knows who you're talking to, when, and how often. Metadata remained. The key privacy property was delivered, but the full picture is more complicated.
+The encrypted messaging story has one important caveat: encryption protects data in transit, but the platform still knows who you're talking to, when, and how often. Metadata remained. The key privacy property was delivered, but the full picture is more complicated.
 
 On-device AI can be structurally cleaner. If inference runs locally and context is stored on-device, there is no transit to encrypt. There is no server that sees metadata. The architecture doesn't produce the data that would need to be protected in the first place.
 
@@ -46,13 +46,13 @@ This is what "private by architecture" means in practice. Not better encryption.
 
 ## What has to be true for this to happen
 
-The WhatsApp moment for AI requires three things to align.
+The encrypted messaging moment for AI requires three things to align.
 
-The technology has to be good enough. In 2016, encrypted messaging was already as fast and reliable as unencrypted messaging. Users didn't have to sacrifice quality for privacy. On-device AI is approaching that inflection point. Models like Qwen 3.5, Gemma 4, and Phi-4 run in real time on current flagship phones. The gap with cloud models is closing.
+The technology has to be good enough. When encrypted messaging went mainstream, it was already as fast and reliable as unencrypted messaging. Users didn't have to sacrifice quality for privacy. On-device AI is approaching that inflection point. Models like Qwen 3.5, Gemma 4, and Phi-4 run in real time on current flagship phones. The gap with cloud models is closing.
 
-The alternatives have to be visible. Users can't demand what they don't know exists. The role of products like Off Grid is partly technical and partly demonstrative - showing that capable AI running entirely on-device is a present reality, not a future possibility.
+The alternatives have to be visible. Users can't demand what they don't know exists. The role of products like Off Grid is partly technical and partly demonstrative — showing that capable AI running entirely on-device is a present reality, not a future possibility.
 
-The consequences have to be understood. The Snowden revelations didn't create the demand for encrypted messaging by themselves. They made visible a risk that had always existed. For AI, the equivalent is users understanding that the context they hand to cloud AI - the full text of their messages, their health records, their financial patterns - is being stored, potentially used for training, and potentially accessible to parties they didn't intend.
+The consequences have to be understood. For AI, the equivalent is users understanding that the context they hand to cloud AI — the full text of their messages, their health records, their financial patterns — is being stored, potentially used for training, and potentially accessible to parties they didn't intend. That understanding is spreading.
 
 All three conditions are converging. The technology is ready. The alternatives exist. The consequences are becoming legible.
 
@@ -60,7 +60,7 @@ All three conditions are converging. The technology is ready. The alternatives e
 
 When the market demands private AI at scale, the question becomes: who built the infrastructure for it?
 
-The platforms - iOS, Android - are late to the architecture. Their on-device AI efforts are features on top of existing cloud platforms, not genuine on-device intelligence layers. The openness required for a true Personal AI OS - open models, inspectable code, no platform lock-in - runs against their economic interests.
+The major platforms are late to the architecture. Their on-device AI efforts are features on top of existing cloud platforms, not genuine on-device intelligence layers. The openness required for a true Personal AI OS — open models, inspectable code, no platform lock-in — runs against their economic interests.
 
 The opportunity is for software that builds the intelligence layer independently of the platforms. Software that runs on the hardware you already own. Software that treats the privacy guarantee as an architectural property, not a marketing claim.
 

--- a/website/writing/whatsapp-moment-for-ai.md
+++ b/website/writing/whatsapp-moment-for-ai.md
@@ -10,7 +10,7 @@ description: Encrypted messaging went mainstream because the market demanded it.
 
 Around 2016, encrypted messaging crossed into the mainstream.
 
-The major messaging platforms — which had resisted encryption for years because it limited their own data access — shipped end-to-end encryption anyway. Not because the engineers pushed for it. Because the market demanded it.
+The major messaging platforms -- which had resisted encryption for years because it limited their own data access -- shipped end-to-end encryption anyway. Not because the engineers pushed for it. Because the market demanded it.
 
 After years of high-profile data breaches, after growing public awareness that messages on unencrypted platforms were readable by the platforms themselves, users started to care. Encrypted-first apps had been gaining ground on privacy. The market signal was clear enough that even platforms with no obvious incentive to reduce their own data access made the switch.
 
@@ -18,11 +18,11 @@ AI is the next communication infrastructure. The same arc applies.
 
 ## Why AI is communication infrastructure
 
-The canonical communication technologies — telephone, email, SMS, messaging apps — all share a defining property: they carry the most private content in a person's life.
+The canonical communication technologies -- telephone, email, SMS, messaging apps -- all share a defining property: they carry the most private content in a person's life.
 
 Your phone calls are where you talk to your doctor, your lawyer, your family. Your messages are where you say things you wouldn't say in public. The history of communication technology is a history of fighting for the right to have those conversations without a third party listening.
 
-AI is becoming the next layer of that infrastructure. An AI assistant that knows your messages, your health, your finances, your work — and that can act on your behalf — is the most intimate piece of software ever built. It has more context than any communication app because its entire value proposition is having more context.
+AI is becoming the next layer of that infrastructure. An AI assistant that knows your messages, your health, your finances, your work -- and that can act on your behalf -- is the most intimate piece of software ever built. It has more context than any communication app because its entire value proposition is having more context.
 
 That makes the privacy question central. The same concerns that drove demand for encrypted messaging are, at higher stakes, the concerns that will drive demand for on-device AI.
 
@@ -34,7 +34,7 @@ For messaging, that moment came gradually. Breaches, then acquisitions with chan
 
 For AI, the trigger events will be different in their specifics but identical in their structure. Moments where users experience the consequences of their most personal data sitting on someone else's server. Moments where they understand the alternative exists. Moments where they switch.
 
-Some of those moments will involve breaches. Some will involve policy changes that remove access to user data. Some will involve acquisitions where the terms change after users have already given years of context to a product — and then lose access to their own data overnight when the company shuts down or changes hands. The specifics will vary. The outcome — a market that demands on-device AI — will not.
+Some of those moments will involve breaches. Some will involve policy changes that remove access to user data. Some will involve acquisitions where the terms change after users have already given years of context to a product -- and then lose access to their own data overnight when the company shuts down or changes hands. The specifics will vary. The outcome -- a market that demands on-device AI -- will not.
 
 ## The structural difference
 
@@ -50,9 +50,9 @@ The encrypted messaging moment for AI requires three things to align.
 
 The technology has to be good enough. When encrypted messaging went mainstream, it was already as fast and reliable as unencrypted messaging. Users didn't have to sacrifice quality for privacy. On-device AI is approaching that inflection point. Models like Qwen 3.5, Gemma 4, and Phi-4 run in real time on current flagship phones. The gap with cloud models is closing.
 
-The alternatives have to be visible. Users can't demand what they don't know exists. The role of products like Off Grid is partly technical and partly demonstrative — showing that capable AI running entirely on-device is a present reality, not a future possibility.
+The alternatives have to be visible. Users can't demand what they don't know exists. The role of products like Off Grid is partly technical and partly demonstrative -- showing that capable AI running entirely on-device is a present reality, not a future possibility.
 
-The consequences have to be understood. For AI, the equivalent is users understanding that the context they hand to cloud AI — the full text of their messages, their health records, their financial patterns — is being stored, potentially used for training, and potentially accessible to parties they didn't intend. That understanding is spreading.
+The consequences have to be understood. For AI, the equivalent is users understanding that the context they hand to cloud AI -- the full text of their messages, their health records, their financial patterns -- is being stored, potentially used for training, and potentially accessible to parties they didn't intend. That understanding is spreading.
 
 All three conditions are converging. The technology is ready. The alternatives exist. The consequences are becoming legible.
 
@@ -60,7 +60,7 @@ All three conditions are converging. The technology is ready. The alternatives e
 
 When the market demands private AI at scale, the question becomes: who built the infrastructure for it?
 
-The major platforms are late to the architecture. Their on-device AI efforts are features on top of existing cloud platforms, not genuine on-device intelligence layers. The openness required for a true Personal AI OS — open models, inspectable code, no platform lock-in — runs against their economic interests.
+The major platforms are late to the architecture. Their on-device AI efforts are features on top of existing cloud platforms, not genuine on-device intelligence layers. The openness required for a true Personal AI OS -- open models, inspectable code, no platform lock-in -- runs against their economic interests.
 
 The opportunity is for software that builds the intelligence layer independently of the platforms. Software that runs on the hardware you already own. Software that treats the privacy guarantee as an architectural property, not a marketing claim.
 

--- a/website/writing/whatsapp-moment-for-ai.md
+++ b/website/writing/whatsapp-moment-for-ai.md
@@ -10,7 +10,7 @@ description: Encrypted messaging went mainstream because the market demanded it.
 
 Around 2016, encrypted messaging crossed into the mainstream.
 
-The major messaging platforms -- which had resisted encryption for years because it limited their own data access -- shipped end-to-end encryption anyway. Not because the engineers pushed for it. Because the market demanded it.
+The major messaging platforms - which had resisted encryption for years because it limited their own data access - shipped end-to-end encryption anyway. Not because the engineers pushed for it. Because the market demanded it.
 
 After years of high-profile data breaches, after growing public awareness that messages on unencrypted platforms were readable by the platforms themselves, users started to care. Encrypted-first apps had been gaining ground on privacy. The market signal was clear enough that even platforms with no obvious incentive to reduce their own data access made the switch.
 
@@ -18,11 +18,11 @@ AI is the next communication infrastructure. The same arc applies.
 
 ## Why AI is communication infrastructure
 
-The canonical communication technologies -- telephone, email, SMS, messaging apps -- all share a defining property: they carry the most private content in a person's life.
+The canonical communication technologies - telephone, email, SMS, messaging apps - all share a defining property: they carry the most private content in a person's life.
 
 Your phone calls are where you talk to your doctor, your lawyer, your family. Your messages are where you say things you wouldn't say in public. The history of communication technology is a history of fighting for the right to have those conversations without a third party listening.
 
-AI is becoming the next layer of that infrastructure. An AI assistant that knows your messages, your health, your finances, your work -- and that can act on your behalf -- is the most intimate piece of software ever built. It has more context than any communication app because its entire value proposition is having more context.
+AI is becoming the next layer of that infrastructure. An AI assistant that knows your messages, your health, your finances, your work - and that can act on your behalf - is the most intimate piece of software ever built. It has more context than any communication app because its entire value proposition is having more context.
 
 That makes the privacy question central. The same concerns that drove demand for encrypted messaging are, at higher stakes, the concerns that will drive demand for on-device AI.
 
@@ -34,7 +34,7 @@ For messaging, that moment came gradually. Breaches, then acquisitions with chan
 
 For AI, the trigger events will be different in their specifics but identical in their structure. Moments where users experience the consequences of their most personal data sitting on someone else's server. Moments where they understand the alternative exists. Moments where they switch.
 
-Some of those moments will involve breaches. Some will involve policy changes that remove access to user data. Some will involve acquisitions where the terms change after users have already given years of context to a product -- and then lose access to their own data overnight when the company shuts down or changes hands. The specifics will vary. The outcome -- a market that demands on-device AI -- will not.
+Some of those moments will involve breaches. Some will involve policy changes that remove access to user data. Some will involve acquisitions where the terms change after users have already given years of context to a product - and then lose access to their own data overnight when the company shuts down or changes hands. The specifics will vary. The outcome - a market that demands on-device AI - will not.
 
 ## The structural difference
 
@@ -50,9 +50,9 @@ The encrypted messaging moment for AI requires three things to align.
 
 The technology has to be good enough. When encrypted messaging went mainstream, it was already as fast and reliable as unencrypted messaging. Users didn't have to sacrifice quality for privacy. On-device AI is approaching that inflection point. Models like Qwen 3.5, Gemma 4, and Phi-4 run in real time on current flagship phones. The gap with cloud models is closing.
 
-The alternatives have to be visible. Users can't demand what they don't know exists. The role of products like Off Grid is partly technical and partly demonstrative -- showing that capable AI running entirely on-device is a present reality, not a future possibility.
+The alternatives have to be visible. Users can't demand what they don't know exists. The role of products like Off Grid is partly technical and partly demonstrative - showing that capable AI running entirely on-device is a present reality, not a future possibility.
 
-The consequences have to be understood. For AI, the equivalent is users understanding that the context they hand to cloud AI -- the full text of their messages, their health records, their financial patterns -- is being stored, potentially used for training, and potentially accessible to parties they didn't intend. That understanding is spreading.
+The consequences have to be understood. For AI, the equivalent is users understanding that the context they hand to cloud AI - the full text of their messages, their health records, their financial patterns - is being stored, potentially used for training, and potentially accessible to parties they didn't intend. That understanding is spreading.
 
 All three conditions are converging. The technology is ready. The alternatives exist. The consequences are becoming legible.
 
@@ -60,7 +60,7 @@ All three conditions are converging. The technology is ready. The alternatives e
 
 When the market demands private AI at scale, the question becomes: who built the infrastructure for it?
 
-The major platforms are late to the architecture. Their on-device AI efforts are features on top of existing cloud platforms, not genuine on-device intelligence layers. The openness required for a true Personal AI OS -- open models, inspectable code, no platform lock-in -- runs against their economic interests.
+The major platforms are late to the architecture. Their on-device AI efforts are features on top of existing cloud platforms, not genuine on-device intelligence layers. The openness required for a true Personal AI OS - open models, inspectable code, no platform lock-in - runs against their economic interests.
 
 The opportunity is for software that builds the intelligence layer independently of the platforms. Software that runs on the hardware you already own. Software that treats the privacy guarantee as an architectural property, not a marketing claim.
 

--- a/website/writing/whatsapp-moment-for-ai.md
+++ b/website/writing/whatsapp-moment-for-ai.md
@@ -10,7 +10,7 @@ description: Encrypted messaging went mainstream because the market demanded it.
 
 Around 2016, encrypted messaging crossed into the mainstream.
 
-The major messaging platforms - which had resisted encryption for years because it limited their own data access - shipped end-to-end encryption anyway. Not because the engineers pushed for it. Because the market demanded it.
+The major messaging platforms, which had resisted encryption for years because it limited their own data access, shipped end-to-end encryption anyway. Not because the engineers pushed for it. Because the market demanded it.
 
 After years of high-profile data breaches, after growing public awareness that messages on unencrypted platforms were readable by the platforms themselves, users started to care. Encrypted-first apps had been gaining ground on privacy. The market signal was clear enough that even platforms with no obvious incentive to reduce their own data access made the switch.
 
@@ -18,11 +18,11 @@ AI is the next communication infrastructure. The same arc applies.
 
 ## Why AI is communication infrastructure
 
-The canonical communication technologies - telephone, email, SMS, messaging apps - all share a defining property: they carry the most private content in a person's life.
+The canonical communication technologies (telephone, email, SMS, messaging apps) all share a defining property: they carry the most private content in a person's life.
 
 Your phone calls are where you talk to your doctor, your lawyer, your family. Your messages are where you say things you wouldn't say in public. The history of communication technology is a history of fighting for the right to have those conversations without a third party listening.
 
-AI is becoming the next layer of that infrastructure. An AI assistant that knows your messages, your health, your finances, your work - and that can act on your behalf - is the most intimate piece of software ever built. It has more context than any communication app because its entire value proposition is having more context.
+AI is becoming the next layer of that infrastructure. An AI assistant that knows your messages, your health, your finances, your work, and that can act on your behalf, is the most intimate piece of software ever built. It has more context than any communication app because its entire value proposition is having more context.
 
 That makes the privacy question central. The same concerns that drove demand for encrypted messaging are, at higher stakes, the concerns that will drive demand for on-device AI.
 
@@ -34,7 +34,7 @@ For messaging, that moment came gradually. Breaches, then acquisitions with chan
 
 For AI, the trigger events will be different in their specifics but identical in their structure. Moments where users experience the consequences of their most personal data sitting on someone else's server. Moments where they understand the alternative exists. Moments where they switch.
 
-Some of those moments will involve breaches. Some will involve policy changes that remove access to user data. Some will involve acquisitions where the terms change after users have already given years of context to a product - and then lose access to their own data overnight when the company shuts down or changes hands. The specifics will vary. The outcome - a market that demands on-device AI - will not.
+Some of those moments will involve breaches. Some will involve policy changes that remove access to user data. Some will involve acquisitions where the terms change after users have already given years of context to a product, and they then lose access to their own data overnight when the company shuts down or changes hands. The specifics will vary. The outcome will not: a market that demands on-device AI.
 
 ## The structural difference
 
@@ -50,9 +50,9 @@ The encrypted messaging moment for AI requires three things to align.
 
 The technology has to be good enough. When encrypted messaging went mainstream, it was already as fast and reliable as unencrypted messaging. Users didn't have to sacrifice quality for privacy. On-device AI is approaching that inflection point. Models like Qwen 3.5, Gemma 4, and Phi-4 run in real time on current flagship phones. The gap with cloud models is closing.
 
-The alternatives have to be visible. Users can't demand what they don't know exists. The role of products like Off Grid is partly technical and partly demonstrative - showing that capable AI running entirely on-device is a present reality, not a future possibility.
+The alternatives have to be visible. Users can't demand what they don't know exists. The role of products like Off Grid is partly technical and partly demonstrative: showing that capable AI running entirely on-device is a present reality, not a future possibility.
 
-The consequences have to be understood. For AI, the equivalent is users understanding that the context they hand to cloud AI - the full text of their messages, their health records, their financial patterns - is being stored, potentially used for training, and potentially accessible to parties they didn't intend. That understanding is spreading.
+The consequences have to be understood. For AI, the equivalent is users understanding that the context they hand to cloud AI (the full text of their messages, their health records, their financial patterns) is being stored, potentially used for training, and potentially accessible to parties they didn't intend. That understanding is spreading.
 
 All three conditions are converging. The technology is ready. The alternatives exist. The consequences are becoming legible.
 
@@ -60,7 +60,7 @@ All three conditions are converging. The technology is ready. The alternatives e
 
 When the market demands private AI at scale, the question becomes: who built the infrastructure for it?
 
-The major platforms are late to the architecture. Their on-device AI efforts are features on top of existing cloud platforms, not genuine on-device intelligence layers. The openness required for a true Personal AI OS - open models, inspectable code, no platform lock-in - runs against their economic interests.
+The major platforms are late to the architecture. Their on-device AI efforts are features on top of existing cloud platforms, not genuine on-device intelligence layers. The openness required for a true Personal AI OS (open models, inspectable code, no platform lock-in) runs against their economic interests.
 
 The opportunity is for software that builds the intelligence layer independently of the platforms. Software that runs on the hardware you already own. Software that treats the privacy guarantee as an architectural property, not a marketing claim.
 

--- a/website/writing/who-owns-your-ai-memory.md
+++ b/website/writing/who-owns-your-ai-memory.md
@@ -20,7 +20,7 @@ But nobody is asking the obvious question: who owns that memory?
 
 Persistent AI memory is not a simple data store. It is a working model of you.
 
-Over time, a system with persistent memory learns: how you communicate, what you care about, what your work involves, what your relationships are like, what decisions you've made and why, what you're worried about, what you find funny, what you avoid. It learns things about you that you haven't told anyone - patterns in your behaviour that emerge from the data rather than from explicit disclosure.
+Over time, a system with persistent memory learns: how you communicate, what you care about, what your work involves, what your relationships are like, what decisions you've made and why, what you're worried about, what you find funny, what you avoid. It learns things about you that you haven't told anyone: patterns in your behaviour that emerge from the data rather than from explicit disclosure.
 
 This is the promise of persistent AI: it becomes more useful the longer you use it, because it knows you better.
 
@@ -32,7 +32,7 @@ It also makes the ownership question significant. A memory this rich and detaile
 
 When that memory lives on a company's server, the ownership is unclear.
 
-The data originated with you. The patterns were derived from your behaviour. But the storage, the infrastructure, and the model of you that was built - all of that sits on infrastructure owned and controlled by the company.
+The data originated with you. The patterns were derived from your behaviour. But the storage, the infrastructure, and the model of you that was built all sit on infrastructure owned and controlled by the company.
 
 You cannot easily export it in a form another system can use. You cannot verify what is stored. You can request deletion, but you cannot verify it was deleted. If the company is acquired, the memory transfers to the acquiring entity under whatever terms were agreed.
 
@@ -44,7 +44,7 @@ The memory that was supposed to be yours, built from your most personal data, is
 
 The most concrete version of this problem appears when a service changes terms, is acquired, or shuts down.
 
-Users who have spent months or years building up context with an AI product - who handed over the context of their professional and personal lives - find that access to that context is controlled by someone else's business decisions.
+Users who have spent months or years building up context with an AI product, who handed over the context of their professional and personal lives, find that access to that context is controlled by someone else's business decisions.
 
 The AI that knew them is gone. Or it is now owned by a different company. Or it continues under terms that include training on their data in ways the original product did not allow.
 
@@ -56,7 +56,7 @@ The memory they thought was theirs turns out to have been held by a company. Com
 
 The alternative is memory that lives on your device.
 
-Your context - your messages, your preferences, your work patterns, the model of you the AI has built - is stored locally. It moves with you to new devices over your local network. It does not require a server to exist. It does not disappear if a company is acquired.
+Your context (your messages, your preferences, your work patterns, the model of you the AI has built) is stored locally. It moves with you to new devices over your local network. It does not require a server to exist. It does not disappear if a company is acquired.
 
 You can inspect it, because it is on your storage and the software that accesses it is open. You can delete specific things from it. You can export it. You can run it with a different AI model if you switch software.
 
@@ -70,9 +70,9 @@ Persistent AI memory is still relatively new. Most users have not been using mem
 
 It will.
 
-As AI memories get richer - as they start to include conversation history, your messages, files, and health data - the value of that memory increases. So does the risk of having it on someone else's server.
+As AI memories get richer, as they start to include conversation history, your messages, files, and health data, the value of that memory increases. So does the risk of having it on someone else's server.
 
-The first wave of high-profile incidents around AI memory ownership - an acquisition where users lose access, a breach that exposes a detailed profile of millions of people, a terms change that makes historical memories available for training - will make this question visible to a mainstream audience.
+The first wave of high-profile incidents around AI memory ownership will make this question visible to a mainstream audience: an acquisition where users lose access, a breach that exposes a detailed profile of millions of people, a terms change that makes historical memories available for training.
 
 When that happens, the products built with on-device memory from the start will have a significant advantage. Not because they were more capable, but because they were built on the right assumption: the memory belongs to the user.
 
@@ -82,7 +82,7 @@ When that happens, the products built with on-device memory from the start will 
 
 Privacy regulation has spent a decade establishing the principle that personal data belongs to the person it is about. The right to access, correct, and delete your data. The right to portability. The right not to have your data sold without your consent.
 
-AI memory is a new form of personal data - one that is arguably the most personal form that has ever existed, because it encodes a model of how you think and behave.
+AI memory is a new form of personal data. It is arguably the most personal form that has ever existed, because it encodes a model of how you think and behave.
 
 The same principles apply. Your AI's memory of you is yours. You should be able to access it, move it, delete it, and ensure it does not end up somewhere you did not intend.
 


### PR DESCRIPTION
## Summary

Full content audit and new content additions for the Off Grid website.

### Content audit — neutrality pass
- **README**: Remove "No subscription" claim (replaced with "no cloud compute rent" framing)
- **Regulatory essay**: Complete rewrite. Removed all country/law names (India, EU, GDPR, CCPA, California, Brazil, LGPD, DPDP) — now argues the case from first principles without geographic specificity
- **WhatsApp essay**: Renamed and rewritten without company names. Now "The Encrypted Messaging Moment for AI" — same argument, no WhatsApp/Telegram/Signal/Facebook
- **VS-assistant essay**: Removed Siri, Alexa, Google Assistant, Cortana, ChatGPT, OpenAI, Claude, Gemini — replaced with generic "platform voice assistants" and "cloud generative AI products"
- **Platform intelligence essay**: Removed Apple Intelligence, Google Gemini, iOS, Android, Google Maps, iMessage, Spotify
- **One-person-two-devices**: Removed Siri, iOS/Android references
- **A day with personal AI OS**: Removed ChatGPT, Copilot
- **What is personal AI OS**: Removed Siri, Alexa, Apple Intelligence, Google Gemini
- **Writing index**: Updated card descriptions to match

### Subscription framing fix
- `7-principles-personal-ai-os.md`: Principle 7 → "No cloud compute rent"
- `what-is-personal-ai-os.md`: FAQ + principle updated
- `case-against-ai-subscriptions.md`: Title/description/intro/closing reframed

### New pages
- **mission.md** (nav_order: 4) — Vision/mission statement. Large-scale framing: ambient intelligence, architecture vs. policy, the 200-year secretary analogy, "democratize intelligence on-person"
- **200-year-secretary.md** — History of the secretary role → why AI finally democratizes a 200-year privilege of wealth
- **next-virtual-assistant.md** — Why your next VA won't be a person, and what on-device AI delivers that human VAs structurally cannot
- **va-industry-disruption.md** — On-device AI disrupts the VA industry through full personal context + always-available access

### Nav reorder
Home(1) → Quick Start(2) → Ethos(3) → Mission(4) → Early Access(5) → Guides(6) → Perspectives(7)