### PR TITLE
fix(website): allow navigation to accordion parent pages

### DIFF
--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -334,15 +334,14 @@
       var children = item.nextElementSibling;
       if (!children || !children.classList.contains('nav-children')) return;
       item.addEventListener('click', function(e) {
-        e.preventDefault();
         var isOpen = children.classList.contains('open');
         if (isOpen) {
-          children.classList.remove('open');
-          item.classList.remove('section-open');
-        } else {
-          children.classList.add('open');
-          item.classList.add('section-open');
+          // accordion already open — allow navigation to the parent page
+          return;
         }
+        e.preventDefault();
+        children.classList.add('open');
+        item.classList.add('section-open');
       });
     });
 

--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -149,28 +149,27 @@
           {% assign in_section = false %}
           {% if page.parent == p.title %}{% assign in_section = true %}{% endif %}
 
-          <a href="{{ p.url | relative_url }}" class="nav-item{% if is_current %} active{% endif %}{% if in_section %} section-open{% endif %}">
-            {{ p.title }}
-            {% if p.has_children %}
-              <svg class="chevron" width="12" height="12" viewBox="0 0 12 12" fill="none">
-                <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            {% endif %}
-          </a>
-
           {% if p.has_children %}
+            <div class="nav-item-wrap">
+              <a href="{{ p.url | relative_url }}" class="nav-item{% if is_current %} active{% endif %}{% if in_section %} section-open{% endif %}">{{ p.title }}</a>
+              <button class="nav-toggle{% if in_section or is_current %} open{% endif %}" aria-label="Toggle section">
+                <svg class="chevron" width="12" height="12" viewBox="0 0 12 12" fill="none">
+                  <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </button>
+            </div>
             {% assign children = site.pages | where: "parent", p.title | sort: "nav_order" %}
             {% if children.size > 0 %}
               <div class="nav-children{% if in_section or is_current %} open{% endif %}">
                 {% for child in children %}
                   {% assign child_active = false %}
                   {% if page.url == child.url %}{% assign child_active = true %}{% endif %}
-                  <a href="{{ child.url | relative_url }}" class="nav-child{% if child_active %} active{% endif %}">
-                    {{ child.title }}
-                  </a>
+                  <a href="{{ child.url | relative_url }}" class="nav-child{% if child_active %} active{% endif %}">{{ child.title }}</a>
                 {% endfor %}
               </div>
             {% endif %}
+          {% else %}
+            <a href="{{ p.url | relative_url }}" class="nav-item{% if is_current %} active{% endif %}">{{ p.title }}</a>
           {% endif %}
         {% endfor %}
       </nav>
@@ -330,18 +329,21 @@
       h.appendChild(a);
     });
     // Accordion toggle for sidebar nav sections
-    document.querySelectorAll('.sidebar-nav .nav-item').forEach(function(item) {
-      var children = item.nextElementSibling;
+    document.querySelectorAll('.sidebar-nav .nav-toggle').forEach(function(toggle) {
+      var wrap = toggle.closest('.nav-item-wrap');
+      var children = wrap ? wrap.nextElementSibling : null;
       if (!children || !children.classList.contains('nav-children')) return;
-      item.addEventListener('click', function(e) {
+      toggle.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
         var isOpen = children.classList.contains('open');
         if (isOpen) {
-          // accordion already open — allow navigation to the parent page
-          return;
+          children.classList.remove('open');
+          toggle.classList.remove('open');
+        } else {
+          children.classList.add('open');
+          toggle.classList.add('open');
         }
-        e.preventDefault();
-        children.classList.add('open');
-        item.classList.add('section-open');
       });
     });
 

--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -151,8 +151,11 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
 }
 .nav-item:hover { color: var(--text-primary); background: var(--bg-hover); }
 .nav-item.active { color: var(--accent); font-weight: 600; }
-.nav-item .chevron { margin-left: auto; color: var(--text-muted); transition: transform 0.2s; }
-.nav-item.section-open .chevron { transform: rotate(180deg); }
+.nav-item-wrap { display: flex; align-items: center; }
+.nav-item-wrap .nav-item { flex: 1; }
+.nav-toggle { background: none; border: none; padding: 4px 6px; cursor: pointer; color: var(--text-muted); display: flex; align-items: center; flex-shrink: 0; }
+.nav-toggle .chevron { transition: transform 0.2s; }
+.nav-toggle.open .chevron { transform: rotate(180deg); }
 
 .nav-children { display: none; padding-left: 12px; }
 .nav-children.open { display: block; }


### PR DESCRIPTION
## Summary

- Moved the chevron SVG out of the `<a>` nav link and into a separate `<button class="nav-toggle">` element wrapped in `.nav-item-wrap`
- Updated JS: accordion toggle now binds to `.nav-toggle` click only — the nav link click navigates freely without any `preventDefault`
- Updated CSS: added `.nav-item-wrap` (flex container), `.nav-toggle` (borderless button), and `.nav-toggle.open .chevron` rotation — removed old `.nav-item.section-open .chevron` rule

**Before:** clicking Ethos only toggled the accordion; navigating to the Ethos page required a second click when the accordion was already open.

**After:** clicking the Ethos text navigates to the Ethos page and the accordion opens automatically (via `in_section`/`is_current` Liquid classes). Clicking the chevron button toggles open/closed without navigating.

## Test plan

- [ ] Click "Ethos" text in sidebar from any page — should navigate to Ethos page with accordion open
- [ ] Click chevron button — should toggle accordion open/closed without navigating
- [ ] On Ethos page, accordion should already be open on load
- [ ] Child pages (Vision, Mission) should still appear under Ethos accordion