### PR TITLE
Enable PostHog pageview and pageleave tracking

### DIFF
--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -455,6 +455,8 @@
       api_host: 'https://us.i.posthog.com',
       defaults: '2026-01-30',
       person_profiles: 'identified_only',
+      capture_pageview: true,
+      capture_pageleave: true,
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Enables `capture_pageview` and `capture_pageleave` in PostHog init config on the website
- Gives visibility into total site traffic, page-level conversion rates, and time-on-page
- Currently we only track 4 explicit events (early_access_signup, newsletter_signup, docs_download_click, page_reaction) but have no idea how many total visitors we get

## Test plan
- [ ] Deploy website and verify `$pageview` events appear in PostHog dashboard
- [ ] Confirm `$pageleave` events include duration data
- [ ] Verify existing custom events still fire correctly