### PR TITLE
Fix gradle wrapper + add Fastlane metadata for F-Droid/IzzyOnDroid

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,26 @@
+# Fastlane metadata
+
+This folder follows the [Fastlane Supply](https://docs.fastlane.tools/actions/supply/) structure used by F-Droid and IzzyOnDroid for app metadata. Edit these files to update store listings without going through manual review.
+
+```
+fastlane/metadata/android/en-US/
+├── title.txt                    Short app name (max 50 chars)
+├── short_description.txt        One-liner (max 80 chars)
+├── full_description.txt         Long description (~4000 chars)
+├── changelogs/
+│   └── <versionCode>.txt        Release notes per version (max 500 chars)
+└── images/
+    ├── icon.png                 512×512 app icon (TODO: add)
+    ├── featureGraphic.png       1024×500 (TODO: add)
+    └── phoneScreenshots/
+        ├── 1.png                (TODO: add)
+        ├── 2.png
+        └── ...                  Up to 8 screenshots, 320–3840 px
+```
+
+## TODO
+
+- [ ] Add `images/icon.png` (512×512)
+- [ ] Add `images/featureGraphic.png` (1024×500)
+- [ ] Add 4-8 phone screenshots in `images/phoneScreenshots/`
+- [ ] Add localized variants (e.g. `metadata/android/de-DE/`) if/when translations land

--- a/fastlane/metadata/android/en-US/changelogs/1776434971.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1776434971.txt
@@ -1,0 +1,1 @@
+v0.0.89 — bug fixes and stability improvements.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,19 @@
+Off Grid is a fully on-device AI assistant. Large language models run directly on your phone via llama.cpp and GGUF — no cloud, no account, no telemetry. Airplane-mode tested.
+
+Capabilities:
+
+* Chat with Llama 3.2, Qwen 3, Gemma 3, Phi-4, DeepSeek R1, and Mistral. Streaming responses, markdown rendering, "thinking mode" for reasoning models.
+
+* Voice input via on-device whisper.cpp. Hold to record, auto-transcribe. Audio never leaves your phone.
+
+* Vision — point your camera and ask. Supports SmolVLM, Qwen-VL, Gemma 3n.
+
+* Document analysis. Attach PDFs, code, CSVs. Native PDF text extraction. No cloud parsing.
+
+* Tool calling. Models that support function calling can use built-in tools — web search, calculator, date/time, knowledge-base search.
+
+* Project knowledge bases. Upload PDFs and notes. Documents are chunked and embedded on-device with a bundled MiniLM model, retrieved via cosine similarity, all stored in local SQLite.
+
+* Bring-your-own model. Sideload any GGUF file.
+
+Built on llama.cpp, whisper.cpp, llama.rn, and whisper.rn — all standard FOSS components. MIT-licensed.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Run open-source LLMs on your device. Voice, vision, image gen — all offline.

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Off Grid


### PR DESCRIPTION
## Summary

Resolves three of the warnings from the F-Droid bot's automated scan on the IzzyOnDroid inclusion request ([Codeberg #171](https://codeberg.org/IzzyOnDroid/repodata/issues/171)).

## What changed

### 1. Gradle wrapper version aligned

Before: properties file declared gradle 8.13, but \`gradle-wrapper.jar\` in the repo is gradle 9.1.0. This is the partial-upgrade footgun the bot flagged.

After: properties URL bumped to 9.1.0 to match the jar.

### 2. \`distributionSha256Sum\` added

Adds the official SHA-256 (\`a17ddd85…686c806\`) for \`gradle-9.1.0-bin.zip\`, sourced from \`https://services.gradle.org/distributions/gradle-9.1.0-bin.zip.sha256\`. Protects against MitM and supply-chain attacks on the Gradle download path. See [project-integrity](https://blog.gradle.org/project-integrity).

### 3. Fastlane metadata folder added

Standard F-Droid / IzzyOnDroid layout:

\`\`\`
fastlane/metadata/android/en-US/
├── title.txt                              Off Grid
├── short_description.txt                  one-line tagline (80 chars)
├── full_description.txt                   long description (~1.5KB)
└── changelogs/
    └── 1776434971.txt                     v0.0.89 placeholder
\`\`\`

Tracking screenshot/icon TODOs in \`fastlane/README.md\` — text metadata alone is enough for the next F-Droid bot scan to clear, and screenshots can be added incrementally.

## Why this matters beyond F-Droid

Issues 1 and 2 are real build-correctness improvements that affect every contributor, not just F-Droid packaging. Without them:

- a fresh clone may resolve to a different Gradle version on first \`./gradlew\` invocation, depending on whether the wrapper jar is honoured before the URL
- the Gradle download is unverified — a compromised distribution could ship a backdoored Gradle without anyone noticing

## Out of scope (filed separately)

The F-Droid bot also flags the proprietary Qualcomm QNN/Hexagon blobs in \`android/app/src/main/assets/qnnlibs/\`. That's the libre-flavor work — separate Gradle product flavor that excludes those assets. Not in this PR.

## Test plan

- [ ] \`cd android && ./gradlew --version\` reports 9.1.0
- [ ] Existing CI passes (build, lint, tests)
- [ ] Subsequent F-Droid bot rerun shows wrapper + Fastlane warnings cleared