### PR TITLE
 fix(patch): prevent NullPointerException crash in react-native-zip-a…

### DIFF
--- a/patches/react-native-zip-archive+7.1.0.patch
+++ b/patches/react-native-zip-archive+7.1.0.patch
@@ -1,8 +1,49 @@
 diff --git a/node_modules/react-native-zip-archive/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java b/node_modules/react-native-zip-archive/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
-index 14bd68f..cccbd99 100644
+index 14bd68f..e381579 100644
 --- a/node_modules/react-native-zip-archive/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
 +++ b/node_modules/react-native-zip-archive/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
-@@ -470,7 +470,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+@@ -174,7 +174,12 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+           }
+         } catch (Exception ex) {
+           updateProgress(0, 1, zipFilePath); // force 0%
+-          promise.reject("RNZipArchiveError", "Failed to extract file " + ex.getLocalizedMessage());
++          safeReject(
++            promise,
++            "RNZipArchiveError",
++            "Failed to extract file " + (ex.getLocalizedMessage() != null ? ex.getLocalizedMessage() : "unknown error"),
++            ex
++          );
+         }
+       }
+     }).start();
+@@ -342,7 +347,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+       processZip(filesOrDirectory, destFile, parameters, promise, password.toCharArray());
+ 
+     } catch (Exception ex) {
+-      promise.reject("RNZipArchiveError", ex.getMessage());
++      promise.reject("RNZipArchiveError", ex.getMessage() != null ? ex.getMessage() : "unknown error");
+       return;
+     }
+   }
+@@ -356,7 +361,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+       processZip(filesOrDirectory, destFile, parameters, promise, null);
+ 
+     } catch (Exception ex) {
+-      promise.reject("RNZipArchiveError", ex.getMessage());
++      promise.reject("RNZipArchiveError", ex.getMessage() != null ? ex.getMessage() : "unknown error");
+       return;
+     }
+   }
+@@ -413,7 +418,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+           }
+           promise.resolve(destFile);
+         } catch (Exception ex) {
+-          promise.reject("RNZipArchiveError", ex.getMessage());
++          promise.reject("RNZipArchiveError", ex.getMessage() != null ? ex.getMessage() : "unknown error");
+           return;
+         }
+       }
+@@ -470,7 +475,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
    }
  
    private static CompressionLevel getCompressionLevel(double compressionLevel) {
@@ -11,3 +52,20 @@ index 14bd68f..cccbd99 100644
        case -1:
          return CompressionLevel.NORMAL;
        case 0:
+@@ -499,6 +504,16 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+     }
+   }
+ 
++  private void safeReject(Promise promise, String code, String message, Throwable throwable) {
++    String safeCode = code != null ? code : "RNZipArchiveError";
++    String safeMessage = message != null ? message : "Zip operation failed";
++    try {
++      promise.reject(safeCode, safeMessage, throwable);
++    } catch (NullPointerException npe) {
++      Log.w(TAG, "Failed to reject promise", npe);
++    }
++  }
++
+   /**
+    * Returns the exception stack trace as a string
+    */

--- a/patches/react-native-zip-archive+7.1.0.patch
+++ b/patches/react-native-zip-archive+7.1.0.patch
@@ -1,8 +1,16 @@
 diff --git a/node_modules/react-native-zip-archive/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java b/node_modules/react-native-zip-archive/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
-index 14bd68f..e381579 100644
+index 14bd68f..bfae10e 100644
 --- a/node_modules/react-native-zip-archive/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
 +++ b/node_modules/react-native-zip-archive/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
-@@ -174,7 +174,12 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+@@ -44,6 +44,7 @@ import java.nio.charset.Charset;
+ 
+ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+   private static final String TAG = RNZipArchiveModule.class.getSimpleName();
++  private static final String ERROR_CODE = "RNZipArchiveError";
+ 
+   private static final String PROGRESS_EVENT_NAME = "zipArchiveProgressEvent";
+   private static final String EVENT_KEY_FILENAME = "filePath";
+@@ -174,7 +175,12 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
            }
          } catch (Exception ex) {
            updateProgress(0, 1, zipFilePath); // force 0%
@@ -16,34 +24,34 @@ index 14bd68f..e381579 100644
          }
        }
      }).start();
-@@ -342,7 +347,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+@@ -342,7 +348,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
        processZip(filesOrDirectory, destFile, parameters, promise, password.toCharArray());
  
      } catch (Exception ex) {
 -      promise.reject("RNZipArchiveError", ex.getMessage());
-+      promise.reject("RNZipArchiveError", ex.getMessage() != null ? ex.getMessage() : "unknown error");
++      safeReject(promise, ERROR_CODE, ex.getMessage() != null ? ex.getMessage() : "unknown error", ex);
        return;
      }
    }
-@@ -356,7 +361,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+@@ -356,7 +362,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
        processZip(filesOrDirectory, destFile, parameters, promise, null);
  
      } catch (Exception ex) {
 -      promise.reject("RNZipArchiveError", ex.getMessage());
-+      promise.reject("RNZipArchiveError", ex.getMessage() != null ? ex.getMessage() : "unknown error");
++      safeReject(promise, ERROR_CODE, ex.getMessage() != null ? ex.getMessage() : "unknown error", ex);
        return;
      }
    }
-@@ -413,7 +418,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+@@ -413,7 +419,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
            }
            promise.resolve(destFile);
          } catch (Exception ex) {
 -          promise.reject("RNZipArchiveError", ex.getMessage());
-+          promise.reject("RNZipArchiveError", ex.getMessage() != null ? ex.getMessage() : "unknown error");
++          safeReject(promise, ERROR_CODE, ex.getMessage() != null ? ex.getMessage() : "unknown error", ex);
            return;
          }
        }
-@@ -470,7 +475,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+@@ -470,7 +476,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
    }
  
    private static CompressionLevel getCompressionLevel(double compressionLevel) {
@@ -52,7 +60,7 @@ index 14bd68f..e381579 100644
        case -1:
          return CompressionLevel.NORMAL;
        case 0:
-@@ -499,6 +504,16 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
+@@ -499,6 +505,16 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
      }
    }
  


### PR DESCRIPTION
## Summary
- `ex.getMessage()` and `ex.getLocalizedMessage()` can return `null` in Java for certain exception types, causing `PromiseImpl.reject` to crash with a `NullPointerException` on the React Native bridge
- Added a `safeReject()` helper that null-checks both `code` and `message` before calling `promise.reject`, with a try/catch as a last-resort guard
- Applied `safeReject` consistently across all 4 reject sites in `RNZipArchiveModule.java`
- Added `ERROR_CODE` constant to avoid hardcoded strings
- Fixed `switch (compressionLevel)` to `switch ((int) compressionLevel)` to correct an uncast double

## Test plan
- [ ] Build release APK and install on Android device
- [ ] Trigger a zip operation with an invalid path to verify it rejects cleanly instead of crashing
- [ ] Monitor Play Console crash count after rollout - previously 60 events across 17 users in 4 hours on version 0.0.90
