### PR TITLE
chore(readme): add UTM tracking to Wednesday CTAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@
 
 <sub><b>BUILT BY</b></sub>
 
-<a href="https://mobile.wednesday.is/hire-ai-native-mobile-squad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://mobile.wednesday.is/logos/wednesday-logo.svg" /><img src="src/assets/wednesday-logo.svg" alt="Wednesday Solutions" height="104" /></picture></a>
+<a href="https://mobile.wednesday.is/hire-ai-native-mobile-squad?utm_source=github&utm_medium=offgrid-readme&utm_campaign=ai-native-mobile-squad&utm_content=logo"><picture><source media="(prefers-color-scheme: dark)" srcset="https://mobile.wednesday.is/logos/wednesday-logo.svg" /><img src="src/assets/wednesday-logo.svg" alt="Wednesday Solutions" height="104" /></picture></a>
 
 </div>
 
-Off Grid is built by [**Wednesday Solutions**](https://mobile.wednesday.is/hire-ai-native-mobile-squad). We run **AI-Native Mobile Squads**: pre-vetted iOS and Android engineers paired with AI tooling for code review, testing, screenshot regression, and release notes. Squads plug into your org in a week and ship to production from day one.
+Off Grid is built by [**Wednesday Solutions**](https://mobile.wednesday.is/hire-ai-native-mobile-squad?utm_source=github&utm_medium=offgrid-readme&utm_campaign=ai-native-mobile-squad&utm_content=body-link). We run **AI-Native Mobile Squads**: pre-vetted iOS and Android engineers paired with AI tooling for code review, testing, screenshot regression, and release notes. Squads plug into your org in a week and ship to production from day one.
 
 <table align="center">
   <tr>
@@ -42,7 +42,7 @@ Off Grid is built by [**Wednesday Solutions**](https://mobile.wednesday.is/hire-
 <p align="center"><b>Want the same team that shipped offline AI to a phone working on your product?</b></p>
 
 <p align="center">
-<a href="https://mobile.wednesday.is/hire-ai-native-mobile-squad"><img src="https://img.shields.io/badge/Hire%20an%20AI--Native%20Squad%20%E2%86%92-181717?style=for-the-badge&labelColor=000000" alt="Hire an AI-Native Squad" /></a>
+<a href="https://mobile.wednesday.is/hire-ai-native-mobile-squad?utm_source=github&utm_medium=offgrid-readme&utm_campaign=ai-native-mobile-squad&utm_content=hire-cta"><img src="https://img.shields.io/badge/Hire%20an%20AI--Native%20Squad%20%E2%86%92-181717?style=for-the-badge&labelColor=000000" alt="Hire an AI-Native Squad" /></a>
 </p>
 
 ---


### PR DESCRIPTION
## Context

Originally added in PR #336 (`9e2b6f37`), but that PR was merged before this commit landed — only the light-mode fix (`37f87768`) made it into main. This PR cleanly re-applies just the UTM addition on top of current main.

## What this does

Adds UTM query params to all three Wednesday-pointing links in the README so traffic from this README to mobile.wednesday.is is attributable in analytics.

### Scheme

| Param | Value |
|---|---|
| `utm_source` | `github` |
| `utm_medium` | `offgrid-readme` |
| `utm_campaign` | `ai-native-mobile-squad` |
| `utm_content` | `logo` / `body-link` / `hire-cta` (per-link) |

### Links updated

| Link | utm_content |
|---|---|
| Logo (clickable) | `logo` |
| Body text "Wednesday Solutions" | `body-link` |
| "Hire an AI-Native Squad →" CTA button | `hire-cta` |

## What it lets us measure

- **Total README → website sessions**: filter by `utm_medium=offgrid-readme`
- **Which CTA converts best**: group by `utm_content` (logo vs body-link vs hire-cta)
- **README → booked-call conversion rate**: assuming the destination tracks booking events
- **Trend over time**: sessions/week from this source

## Prerequisite

Wednesday's site needs analytics that respect UTMs (GA4, Plausible, Mixpanel — all support out of the box).

## Test plan

- [ ] Click the Wednesday logo → URL has `utm_content=logo`
- [ ] Click "Wednesday Solutions" body link → URL has `utm_content=body-link`
- [ ] Click "Hire an AI-Native Squad →" CTA → URL has `utm_content=hire-cta`
- [ ] All three URLs land on `/hire-ai-native-mobile-squad`
- [ ] Verify analytics dashboard captures the UTMs (~5 min after a sample visit)

## Why no other changes

This PR only edits `href` attributes on three anchor tags. No content changes, no logic changes, no other files touched.