### PR TITLE
fix(settings): disable thinking by default and fix phi model detection

### DIFF
--- a/src/screens/ModelsScreen/utils.ts
+++ b/src/screens/ModelsScreen/utils.ts
@@ -71,7 +71,8 @@ export function getModelType(model: ModelInfo): ModelTypeFilter {
 export function isPhiModel(modelName: string, modelId: string): boolean {
   const name = modelName.toLowerCase();
   const id = modelId.toLowerCase();
-  return name.includes('phi') || id.includes('phi');
+  const phiPattern = /\bphi[-_]?\d/i;
+  return phiPattern.test(name) || phiPattern.test(id);
 }
 
 export function getTextModelCompatibility(

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -135,7 +135,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   cacheType: 'q8_0' as CacheType,
   showGenerationDetails: false,
   enabledTools: ['web_search', 'calculator', 'get_current_datetime', 'get_device_info', 'read_url', 'search_knowledge_base'],
-  thinkingEnabled: true,
+  thinkingEnabled: false,
 };
 
 function migrateEnabledTools(merged: any): void {


### PR DESCRIPTION
## Summary

- Thinking mode was on by default for all models that support it, increasing TTFT for new users before they've opted in. New users now start with thinking off and can enable it in settings when needed — better UX especially for vision models where thinking adds latency without clear benefit on first use
- Dolphin models (`dolphin-mistral`, `dolphin-llama` etc.) were incorrectly blocked because `'dolphin'.includes('phi')` is `true`. Replaced with `/\bphi[-_]?\d/i` so only actual Phi variants (phi-3, phi3, phi-4) are matched

## Impact

- New installs: thinking off by default, toggle still works
- Existing users: no change, persisted store value takes precedence
- Dolphin models: now loadable

