### PR TITLE
fix(ios): prevent main-thread hang in download progress polling

### DIFF
--- a/__tests__/rntl/screens/OnboardingScreen.test.tsx
+++ b/__tests__/rntl/screens/OnboardingScreen.test.tsx
@@ -237,6 +237,17 @@ describe('OnboardingScreen', () => {
     expect(mockDiscoverLANServers).toHaveBeenCalled();
   });
 
+  it('opens correct Wednesday URL when tapping Made with love', () => {
+    const { Linking } = require('react-native');
+    const spy = jest.spyOn(Linking, 'openURL').mockImplementation(() => Promise.resolve());
+    const { getByText } = render(<OnboardingScreen navigation={navigation} />);
+    fireEvent.press(getByText('Wednesday'));
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('mobile.wednesday.is/hire-ai-native-mobile-squad'),
+    );
+    spy.mockRestore();
+  });
+
   it('completes onboarding when Get Started pressed on last slide', async () => {
     const { act: reactAct } = require('@testing-library/react-native');
     const { Dimensions } = require('react-native');

--- a/ios/DownloadManagerModule.swift
+++ b/ios/DownloadManagerModule.swift
@@ -937,9 +937,11 @@ extension DownloadManagerModule {
 
   func pollProgress() {
     guard hasListeners else { return }
-    queue.sync(flags: .barrier) {
-      let activeDownloads = downloads.filter { $0.value.status == "running" || $0.value.status == "pending" || $0.value.status == "paused" }
-      for (downloadId, var info) in activeDownloads {
+    queue.async(flags: .barrier) { [weak self] in
+      guard let self = self else { return }
+      let activeDownloads = self.downloads.filter { $0.value.status == "running" || $0.value.status == "pending" || $0.value.status == "paused" }
+      var events: [[String: Any]] = []
+      for (_, var info) in activeDownloads {
         if info.isMultiFile {
           var aggregateBytes: Int64 = 0
           var aggregateTotal: Int64 = 0
@@ -961,17 +963,24 @@ extension DownloadManagerModule {
           if task.countOfBytesExpectedToReceive > 0 {
             info.totalBytes = task.countOfBytesExpectedToReceive
           }
-          info.status = statusString(from: task.state)
+          info.status = self.statusString(from: task.state)
         }
-        downloads[downloadId] = info
-        sendEvent(withName: "DownloadProgress", body: [
-            "downloadId": info.downloadId,
-            "fileName": info.fileName,
-            "modelId": info.modelId,
-            "bytesDownloaded": NSNumber(value: info.bytesDownloaded),
-            "totalBytes": NSNumber(value: info.totalBytes),
-            "status": info.status
-          ] as [String: Any])
+        self.downloads[info.downloadId] = info
+        events.append([
+          "downloadId": info.downloadId,
+          "fileName": info.fileName,
+          "modelId": info.modelId,
+          "bytesDownloaded": NSNumber(value: info.bytesDownloaded),
+          "totalBytes": NSNumber(value: info.totalBytes),
+          "status": info.status
+        ] as [String: Any])
+      }
+      if !events.isEmpty {
+        DispatchQueue.main.async { [weak self] in
+          for event in events {
+            self?.sendEvent(withName: "DownloadProgress", body: event)
+          }
+        }
       }
     }
   }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -40,6 +40,11 @@ target 'OffgridMobile' do
       target.build_configurations.each do |config|
         config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++20'
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '17.0'
+        # Suppress fmt consteval errors on newer Xcode/clang
+        if target.name == 'fmt'
+          config.build_settings['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'NO'
+          config.build_settings['OTHER_CPLUSPLUSFLAGS'] = '$(inherited) -Wno-error'
+        end
       end
     end
   end

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -264,7 +264,7 @@ export const OnboardingScreen: React.FC<OnboardingScreenProps> = ({
             testID="onboarding-next"
           />
           <TouchableOpacity
-            onPress={() => Linking.openURL('https://www.wednesday.is/?utm_source=off-grid-mobile-app')}
+            onPress={() => Linking.openURL('https://mobile.wednesday.is/hire-ai-native-mobile-squad?utm_source=off-grid-mobile-app&utm_medium=onboarding&utm_campaign=in-app')}
             style={styles.madeWithLove}
           >
             <View style={styles.madeWithLoveRow}>

--- a/src/screens/ProDetailScreen/index.tsx
+++ b/src/screens/ProDetailScreen/index.tsx
@@ -39,7 +39,7 @@ export const ProDetailScreen: React.FC = () => {
 
       <ScrollView style={styles.flex} contentContainerStyle={styles.content}>
         <Text style={styles.title}>Off Grid PRO</Text>
-        <Text style={styles.subtitle}>Lifetime access - Coming soon</Text>
+        <Text style={styles.subtitle}>Coming soon</Text>
 
         <View style={styles.featureList}>
           {FEATURES.map(f => (


### PR DESCRIPTION
## Summary

- **fix(ios): prevent main-thread hang in download progress polling** — `pollProgress()` was using `queue.sync(flags: .barrier)` on the main thread, which blocked the UI whenever the download queue was contended (e.g., during zip extraction). Changed to `queue.async` — progress data is now gathered on the background queue and events are dispatched back to the main thread. This prevents iOS watchdog kills (ANR-equivalent) during model downloads.

- **fix(onboarding): update Wednesday URL** — Onboarding screen now links to `https://mobile.wednesday.is/hire-ai-native-mobile-squad` with UTM params, consistent with About screen and MadeWithLove component.

- **fix(pro): remove "Lifetime access" from "Coming soon" subtitle** — PRO detail screen now just says "Coming soon" instead of the contradictory "Lifetime access - Coming soon".

- **fix(ios): suppress fmt consteval errors on Xcode 26.x** — Added Podfile workaround for fmt 11.0.2 consteval compilation errors on newer Apple clang.

## Test plan

- [ ] Build and run on iOS device
- [ ] Start a model download, tap around the app while downloading — app should stay responsive
- [ ] Verify Wednesday link on onboarding screen opens correct URL
- [ ] Verify PRO screen shows "Coming soon" (not "Lifetime access - Coming soon")