### PR TITLE
fix(remote): stop sending max_tokens/num_predict to remote servers

### DIFF
--- a/src/services/providers/openAICompatibleProvider.ts
+++ b/src/services/providers/openAICompatibleProvider.ts
@@ -99,7 +99,9 @@ export class OpenAICompatibleProvider implements LLMProvider {
       messages: openaiMessages,
       stream: true,
       ...(options.temperature !== undefined && { temperature: options.temperature }),
-      ...(options.maxTokens !== undefined && { max_tokens: options.maxTokens }),
+      // max_tokens intentionally omitted — the remote server owns output limits.
+      // A client-side cap (default 1024) silently truncates reasoning models that
+      // need a larger budget for <think> blocks (Qwen3, DeepSeek-R1, etc).
       ...(options.topP !== undefined && { top_p: options.topP }),
       ...(options.tools && options.tools.length > 0 && { tools: options.tools, tool_choice: 'auto' }),
       // LM Studio only: control Qwen3 thinking per-request via chat_template_kwargs.

--- a/src/services/providers/openAICompatibleStream.ts
+++ b/src/services/providers/openAICompatibleStream.ts
@@ -289,7 +289,8 @@ export async function generateOllamaChatImpl(
     ...(options.tools && options.tools.length > 0 && { tools: options.tools }),
     options: {
       ...(options.temperature !== undefined && { temperature: options.temperature }),
-      ...(options.maxTokens !== undefined && { num_predict: options.maxTokens }),
+      // num_predict intentionally omitted — Ollama defaults to -1 (until natural stop).
+      // A client-side cap truncates reasoning models mid-<think>.
       ...(options.topP !== undefined && { top_p: options.topP }),
     },
   };


### PR DESCRIPTION
## Summary

The app was sending `max_tokens: 1024` (LM Studio / OpenAI-compatible) and `num_predict: 1024` (Ollama) on every remote request, sourced from the local `maxTokens` setting. Reasoning models like Qwen3 and DeepSeek-R1 routinely spend 2k-5k tokens inside a `<think>` block before producing visible output, so the 1024 cap stopped the stream mid-think. The closing `</think>` never arrived, `ThinkTagParser` routed every token to `onReasoning`, and the chat bubble stayed empty - users saw a loading spinner forever.

This PR drops the client-side cap on both remote code paths. Output limits belong on the server, where the user already configured the model. LM Studio defaults to the model's full remaining context window; Ollama defaults to `-1` (until natural stop). Local generation is unchanged - the `maxTokens` slider still bounds the on-device llama.cpp inference loop.

## Changes

- `src/services/providers/openAICompatibleProvider.ts` - drop `max_tokens` from the `/v1/chat/completions` body
- `src/services/providers/openAICompatibleStream.ts` - drop `num_predict` from the Ollama `/api/chat` body

## Why the client cap was wrong

- The user picks the model and configures its context on the server; the client second-guessing that just produces silent truncation.
- Other LM Studio / Ollama clients (Open WebUI, Continue.dev) don't send a cap by default for the same reason.
- Reasoning-token budget is unpredictable per-prompt - any fixed client default will be wrong for some class of model.
- The local default of 1024 leaked into the remote path because one `maxTokens` setting backs both. Local needs the cap (KV cache / battery); remote does not.

## Reported case

User on Play Store review and follow-up email: Qwen3.6-35B-A3B on LM Studio produced only a loading animation. Server log showed a clean 1024-token generation with `finish_reason: length`, but no content reached the UI because the entire stream was inside an unclosed `<think>` block.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] `npm test -- openAICompatibleProvider remoteProviderRouting` - 61/61 pass
- [ ] Manual: point app at LM Studio with Qwen3 model, send a prompt, confirm response renders
- [ ] Manual: point app at Ollama with a non-reasoning model (e.g. llama3.1), confirm output completes naturally instead of being cut at 1024 tokens
- [ ] Manual: load a local model, confirm `maxTokens` slider still bounds on-device output

## Follow-ups (not in this PR)

- The `maxTokens` and `contextLength` sliders are still editable when a remote model is active. The settings modal shows a banner that says they don't apply, but the sliders aren't disabled. Worth hiding both for remote sessions in a separate change.
- `documentService.ts` truncates attachment / pasted-text content using `settings.contextLength` regardless of provider type - low slider + remote model silently cuts attached docs. Separate bug.
