### PR TITLE
website: add Pro payments page with RevenueCat checkout

### DIFF
--- a/__tests__/unit/website/revenuecatLink.test.ts
+++ b/__tests__/unit/website/revenuecatLink.test.ts
@@ -1,0 +1,78 @@
+/**
+ * RevenueCat Web Purchase Link builder tests.
+ *
+ * Covers the pure URL-building logic used by website/pay.md. The module is a
+ * dependency-free UMD file shared between the browser page and this test.
+ */
+
+const RevenueCatLink = require('../../../website/assets/js/revenuecat-link.js') as {
+  isValidEmail: (email: unknown) => boolean;
+  buildPurchaseUrl: (
+    token: unknown,
+    email: unknown,
+    opts?: { packageId?: string },
+  ) => string | null;
+};
+
+const TOKEN = 'axcqzylghncldjwo';
+
+describe('isValidEmail', () => {
+  it.each([
+    'user@example.com',
+    'a.b+tag@sub.domain.co',
+    '  spaced@example.com  ',
+  ])('accepts %s', email => {
+    expect(RevenueCatLink.isValidEmail(email)).toBe(true);
+  });
+
+  it.each(['', 'no-at-sign', 'missing@tld', '@example.com', 'a@b', null, undefined, 42])(
+    'rejects %s',
+    email => {
+      expect(RevenueCatLink.isValidEmail(email as unknown)).toBe(false);
+    },
+  );
+});
+
+describe('buildPurchaseUrl', () => {
+  it('uses the email as the App User ID path segment and prefills email', () => {
+    expect(RevenueCatLink.buildPurchaseUrl(TOKEN, 'user@example.com')).toBe(
+      'https://pay.rev.cat/axcqzylghncldjwo/user%40example.com?email=user%40example.com',
+    );
+  });
+
+  it('URL-encodes special characters in the email (path and query)', () => {
+    expect(RevenueCatLink.buildPurchaseUrl(TOKEN, 'a.b+tag@sub.domain.co')).toBe(
+      'https://pay.rev.cat/axcqzylghncldjwo/a.b%2Btag%40sub.domain.co?email=a.b%2Btag%40sub.domain.co',
+    );
+  });
+
+  it('trims surrounding whitespace before building the URL', () => {
+    expect(RevenueCatLink.buildPurchaseUrl(TOKEN, '  user@example.com  ')).toBe(
+      'https://pay.rev.cat/axcqzylghncldjwo/user%40example.com?email=user%40example.com',
+    );
+  });
+
+  it('appends package_id when provided', () => {
+    expect(
+      RevenueCatLink.buildPurchaseUrl(TOKEN, 'user@example.com', {
+        packageId: 'round2_30',
+      }),
+    ).toBe(
+      'https://pay.rev.cat/axcqzylghncldjwo/user%40example.com?email=user%40example.com&package_id=round2_30',
+    );
+  });
+
+  it('encodes the token in the path', () => {
+    const url = RevenueCatLink.buildPurchaseUrl('tok/with space', 'user@example.com');
+    expect(url).toContain('https://pay.rev.cat/tok%2Fwith%20space/');
+  });
+
+  it.each([
+    [TOKEN, 'not-an-email'],
+    [TOKEN, ''],
+    ['', 'user@example.com'],
+    [null, 'user@example.com'],
+  ])('returns null for invalid input (token=%s, email=%s)', (token, email) => {
+    expect(RevenueCatLink.buildPurchaseUrl(token as unknown, email as unknown)).toBeNull();
+  });
+});

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.host.url=https://sonarcloud.io
 sonar.sources=src,android/app/src/main,ios
 sonar.tests=__tests__,android/app/src/test,ios/OffgridMobileTests
 
-sonar.exclusions=**/node_modules/**,**/Pods/**,**/build/**,**/coverage/**,ios/build/**,android/build/**
+sonar.exclusions=**/node_modules/**,**/Pods/**,**/build/**,**/coverage/**,ios/build/**,android/build/**,website/**
 sonar.test.inclusions=__tests__/**,android/app/src/test/**,ios/OffgridMobileTests/**
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,6 @@
+# Jekyll build output and local bundler state - never commit these.
+_site/
+.jekyll-cache/
+.jekyll-metadata
+.bundle/
+vendor/

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,0 +1,243 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.6)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86-linux-gnu)
+    ffi (1.17.4-x86-linux-musl)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.35.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    http_parser.rb (0.8.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.9.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.19.9)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (7.0.5)
+    rake (13.4.2)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.7.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.101.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.101.0-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.2)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3)
+  jekyll-seo-tag
+  jekyll-sitemap
+  tzinfo (>= 1, < 3)
+  tzinfo-data
+  wdm (~> 0.1.1)
+
+CHECKSUMS
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  colorator (1.1.0) sha256=e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  em-websocket (0.5.3) sha256=f56a92bde4e6cb879256d58ee31f124181f68f8887bd14d53d5d9a292758c6a8
+  eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
+  ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
+  ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
+  ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
+  ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564
+  ffi (1.17.4-arm-linux-musl) sha256=9d4838ded0465bef6e2426935f6bcc93134b6616785a84ffd2a3d82bc3cf6f95
+  ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
+  ffi (1.17.4-x86-linux-gnu) sha256=38e150df5f4ca555e25beca4090823ae09657bceded154e3c52f8631c1ed72cf
+  ffi (1.17.4-x86-linux-musl) sha256=fbeec0fc7c795bcf86f623bb18d31ea1820f7bd580e1703a3d3740d527437809
+  ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
+  ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
+  ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
+  forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
+  google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
+  google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
+  google-protobuf (4.35.1-aarch64-linux-musl) sha256=d5c65cef6bd6498a9e5ed5f88cf6cf7e341c10b0a005e32137d5d1a2b6e8c18a
+  google-protobuf (4.35.1-arm64-darwin) sha256=d9c957df04fa89c749fa9a72a7b383eb4296efc9b2303dc6fd6fbe39c698ad6b
+  google-protobuf (4.35.1-x86-linux-gnu) sha256=cc7492566b27ad8b5dfa3a7b6f9b11e905050cc53c2fa8ff22de375a9e7a70fb
+  google-protobuf (4.35.1-x86-linux-musl) sha256=ab403790b59e4dc588ffbed1eaacf05d4ca2f0d12ac9c13d6c64e69380d8c99e
+  google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
+  google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
+  google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
+  jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
+  jekyll-seo-tag (2.9.0) sha256=0260015a8e1df9bf195cdfb0c675b7b2883fd8cbf12556e1c1cbe36a831c6852
+  jekyll-sitemap (1.4.0) sha256=0de08c5debc185ea5a8f980e1025c7cd3f8e0c35c8b6ef592f15c46235cf4218
+  jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
+  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
+  kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
+  kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
+  liquid (4.0.4) sha256=4fcfebb1a045e47918388dbb7a0925e7c3893e58d2bd6c3b3c73ec17a2d8fdb3
+  listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mercenary (0.4.0) sha256=b25a1e4a59adca88665e08e24acf0af30da5b5d859f7d8f38fba52c28f405138
+  pathutil (0.16.2) sha256=e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
+  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
+  safe_yaml (1.0.5) sha256=a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848
+  sass-embedded (1.101.0) sha256=57dbc3409e2c0a2c581a4c9945c2bd72ec88e71ec98017bd02dd1da8a76b22f4
+  sass-embedded (1.101.0-aarch64-linux-android) sha256=ad0a35c6ff5cdc4e31c5d8261a768ef460c6c7d1458081183e42170e1474c4b5
+  sass-embedded (1.101.0-aarch64-linux-gnu) sha256=8f6926349e880dbb4fda75fb182086fb60aa821b756bcbfc8e5b2b23b1f269d6
+  sass-embedded (1.101.0-aarch64-linux-musl) sha256=0a02b4b75db305160db1b0512f040762242128a9b5c01b0fa7a504f2b24557f2
+  sass-embedded (1.101.0-arm-linux-androideabi) sha256=88e762531f90d4a2eef55ffafeba337585e1bb24b22307ebd7fe5505de9a4476
+  sass-embedded (1.101.0-arm-linux-gnueabihf) sha256=358df7f98d13ff53739ebc45f5c5acd4dd96833bf87f39c74d11f798081d4158
+  sass-embedded (1.101.0-arm-linux-musleabihf) sha256=d993a3ad017250d46d1312bc10cfded5ab4585906d37a60a56494bd662182d3a
+  sass-embedded (1.101.0-arm64-darwin) sha256=9fed684380b49499dfc856aba0d026a0748f924bd78044ffff2bae1537aea73e
+  sass-embedded (1.101.0-riscv64-linux-android) sha256=1bd35527e1ca24af6aa2ba9db797bc9b72331ebbec9ff6e99ea02b24f83b3da1
+  sass-embedded (1.101.0-riscv64-linux-gnu) sha256=7805a249ed4c31b58b2f7d054d14f0ed24c61a836f579cd76ed2367088142bcf
+  sass-embedded (1.101.0-riscv64-linux-musl) sha256=8bd60eb9ebe6f9f2740a4e9ddb792a3db1fbba282e3375103844b4979eb7c731
+  sass-embedded (1.101.0-x86_64-darwin) sha256=20ff4afd7c052b3f8d7b4abe511e8114985a07dff7616750a43ee1fc2759fb28
+  sass-embedded (1.101.0-x86_64-linux-android) sha256=472b72114ededa00a22e13553dd31f98d1a92d52bdbe2e738a4dbac2dd50c779
+  sass-embedded (1.101.0-x86_64-linux-gnu) sha256=ff48452b2351eaaf4e6e02f59de0e9e35f6f163e8456d520db49b4d87cf73c27
+  sass-embedded (1.101.0-x86_64-linux-musl) sha256=2286feef3c7a8d9bbb075aa1651e1a81942aca1213f7c2d30cc1d6f4eb5b4104
+  terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+
+BUNDLED WITH
+  4.0.11

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -18,10 +18,11 @@ plugins:
 
 posthog_token: "phc_u7cnV9P3cTovsfPTE2nhB7g5G4qdtZJ5dgMzv7ryfKWs"
 
-# RevenueCat Web Purchase Link token. This is public by design - it appears in
-# every customer's checkout URL, so it is safe to commit. The pay page builds:
-# https://pay.rev.cat/<revenuecat_token>/<app_user_id>?email=<email>
-revenuecat_token: "avvnmcnfsgbmjaee"
+# RevenueCat Web Purchase Link id (the path segment in pay.rev.cat/<id>/...).
+# This is public by design - it appears in every customer's checkout URL, so it
+# is safe to commit. It is a link path id, not a secret/auth token. The pay page
+# builds: https://pay.rev.cat/<revenuecat_link_id>/<app_user_id>?email=<email>
+revenuecat_link_id: "avvnmcnfsgbmjaee"
 
 logo: /assets/logo.png
 cover: /assets/cover.png

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -18,6 +18,11 @@ plugins:
 
 posthog_token: "phc_u7cnV9P3cTovsfPTE2nhB7g5G4qdtZJ5dgMzv7ryfKWs"
 
+# RevenueCat Web Purchase Link token. This is public by design - it appears in
+# every customer's checkout URL, so it is safe to commit. The pay page builds:
+# https://pay.rev.cat/<revenuecat_token>/<app_user_id>?email=<email>
+revenuecat_token: "avvnmcnfsgbmjaee"
+
 logo: /assets/logo.png
 cover: /assets/cover.png
 
@@ -27,3 +32,5 @@ exclude:
   - Gemfile.lock
   - node_modules
   - vendor
+  - .bundle
+  - _site

--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -669,6 +669,7 @@ body { font-family: var(--font); color: var(--text-primary); background: var(--b
 }
 .ea-input::placeholder { color: var(--text-muted); }
 .ea-input:focus { border-color: var(--accent); }
+.ea-input-error, .ea-input-error:focus { border-color: #ef4444; }
 
 .ea-form-footer { margin-top: 10px; display: flex; flex-direction: column; gap: 6px; }
 .ea-pricing-note { font-size: 0.75rem; color: var(--text-muted); margin: 0; }

--- a/website/assets/js/revenuecat-link.js
+++ b/website/assets/js/revenuecat-link.js
@@ -1,0 +1,46 @@
+// Builds a RevenueCat Web Purchase Link from a customer email.
+//
+// RevenueCat identifies the customer by the App User ID, which is a *path*
+// segment (not a query parameter). We use the email itself as the App User ID
+// so the purchase is tied to a stable id we can later match to the app account.
+// The `email` query parameter only prefills the email field on the checkout
+// page (subscribers cannot override it).
+//
+//   https://pay.rev.cat/<token>/<urlEncodedEmail>?email=<urlEncodedEmail>
+//
+// This file is loaded as a browser global by /pay/ and imported directly by the
+// unit test, so it has no dependencies and works in both environments.
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.RevenueCatLink = factory();
+  }
+})(typeof self !== 'undefined' ? self : this, function () {
+  var EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  function isValidEmail(email) {
+    return typeof email === 'string' && EMAIL_RE.test(email.trim());
+  }
+
+  // Returns the purchase URL, or null if the inputs are invalid.
+  // opts may include { packageId } to pre-select a package.
+  function buildPurchaseUrl(token, email, opts) {
+    if (!token || typeof token !== 'string') return null;
+    if (!isValidEmail(email)) return null;
+
+    var trimmed = email.trim();
+    var encoded = encodeURIComponent(trimmed);
+    var url = `https://pay.rev.cat/${encodeURIComponent(token)}/${encoded}?email=${encoded}`;
+
+    if (opts && opts.packageId) {
+      url += `&package_id=${encodeURIComponent(opts.packageId)}`;
+    }
+    return url;
+  }
+
+  return {
+    isValidEmail: isValidEmail,
+    buildPurchaseUrl: buildPurchaseUrl,
+  };
+});

--- a/website/assets/js/revenuecat-link.js
+++ b/website/assets/js/revenuecat-link.js
@@ -17,7 +17,10 @@
     root.RevenueCatLink = factory();
   }
 })(typeof self !== 'undefined' ? self : this, function () {
-  var EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  // Linear-time email check (no overlapping quantifiers, so no catastrophic
+  // backtracking / ReDoS): local part, '@', then dot-separated domain labels
+  // that themselves contain no dots.
+  var EMAIL_RE = /^[^\s@]+@[^\s.@]+(\.[^\s.@]+)+$/;
 
   function isValidEmail(email) {
     return typeof email === 'string' && EMAIL_RE.test(email.trim());

--- a/website/assets/js/revenuecat-link.js
+++ b/website/assets/js/revenuecat-link.js
@@ -34,11 +34,15 @@
 
     var trimmed = email.trim();
     var encoded = encodeURIComponent(trimmed);
-    var url = `https://pay.rev.cat/${encodeURIComponent(token)}/${encoded}?email=${encoded}`;
+    // String concatenation (not template literals) keeps this file ES5-only.
+    /* eslint-disable prefer-template */
+    var url =
+      'https://pay.rev.cat/' + encodeURIComponent(token) + '/' + encoded + '?email=' + encoded;
 
     if (opts && opts.packageId) {
-      url += `&package_id=${encodeURIComponent(opts.packageId)}`;
+      url += '&package_id=' + encodeURIComponent(opts.packageId);
     }
+    /* eslint-enable prefer-template */
     return url;
   }
 

--- a/website/early-access.md
+++ b/website/early-access.md
@@ -38,6 +38,9 @@ description: Join the waitlist for early access to Off Grid. Be among the first 
   <p class="ea-slack-direct">
     Already in Slack? <a href="https://off-grid-mobile.slack.com/archives/C0B4KMHNP61" target="_blank" rel="noopener">Jump straight to #pro-waitlist</a> - that's where the alpha builds drop.
   </p>
+  <p class="ea-slack-direct">
+    Already on the list, or got a promo code? <a href="{{ '/pay' | relative_url }}">Skip the wait and pay here</a> - your code applies at checkout.
+  </p>
 </div>
 
 ---

--- a/website/pay.md
+++ b/website/pay.md
@@ -83,7 +83,7 @@ If we do not ship Pro within 12 weeks, email us and you get a full refund.
 <script src="{{ '/assets/js/revenuecat-link.js' | relative_url }}"></script>
 <script>
   (function() {
-    var TOKEN = {{ site.revenuecat_token | jsonify }};
+    var LINK_ID = {{ site.revenuecat_link_id | jsonify }};
     var form = document.getElementById('payForm');
     var emailInput = document.getElementById('payEmail');
     var submit = document.getElementById('paySubmit');
@@ -119,7 +119,7 @@ If we do not ship Pro within 12 weeks, email us and you get a full refund.
     form.addEventListener('submit', function(e) {
       e.preventDefault();
       var email = emailInput.value.trim();
-      var url = RevenueCatLink.buildPurchaseUrl(TOKEN, email);
+      var url = RevenueCatLink.buildPurchaseUrl(LINK_ID, email);
       if (!url) {
         showError('Enter a valid email address.');
         emailInput.focus();

--- a/website/pay.md
+++ b/website/pay.md
@@ -1,0 +1,136 @@
+---
+layout: default
+title: Get Pro
+nav_order: 5
+description: Buy Off Grid Pro. Enter your email and check out. $50 one-time, no subscription. Have a promo code? Apply it at checkout.
+---
+
+<div class="early-access-hero">
+  <div class="early-access-badge">Off Grid Pro</div>
+  <h1>Pay once.<br>Run it forever.</h1>
+  <p class="early-access-sub">Off Grid Pro adds voice, custom personas, and tool integrations. All of it runs on your phone, the same as the rest. Enter your email below to check out. Your email is the account the purchase attaches to, so use the one you sign into the app with.</p>
+</div>
+
+<div class="early-access-form-section ea-form-top">
+  <form id="payForm" class="early-access-form" novalidate>
+    <div class="ea-inline-group">
+      <input type="email" id="payEmail" class="ea-input" placeholder="your@email.com" autocomplete="email" aria-invalid="false" required>
+      <button type="submit" class="ea-submit" id="paySubmit" disabled>Continue to checkout</button>
+    </div>
+    <div class="ea-form-footer">
+      <p class="ea-pricing-note">$50 one-time · no subscription · promo codes apply at checkout</p>
+    </div>
+    <p class="ea-status" id="payStatus" aria-live="polite"></p>
+  </form>
+  <p class="ea-slack-direct">
+    Have a promo code? Enter it on the checkout page after this step. Checkout is handled by RevenueCat. Nothing on this page touches your phone's models or data.
+  </p>
+</div>
+
+---
+
+<div class="early-access-perks">
+  <div class="perk-card">
+    <div class="perk-icon">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+    </div>
+    <div>
+      <div class="perk-title">Voice in, voice out</div>
+      <div class="perk-desc">Whisper transcribes what you say, Kokoro speaks the reply. Hold to talk, listen back. No audio leaves the device.</div>
+    </div>
+  </div>
+  <div class="perk-card">
+    <div class="perk-icon">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+    </div>
+    <div>
+      <div class="perk-title">Custom personas</div>
+      <div class="perk-desc">Build assistants with your own prompts, voices, and memory. Switch contexts in a tap.</div>
+    </div>
+  </div>
+  <div class="perk-card">
+    <div class="perk-icon">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.59 13.41a1.998 1.998 0 0 1 0-2.83l4.24-4.24a4 4 0 0 1 5.66 5.66l-1.41 1.41"/><path d="M13.41 10.59a1.998 1.998 0 0 1 0 2.83l-4.24 4.24a4 4 0 0 1-5.66-5.66l1.41-1.41"/></svg>
+    </div>
+    <div>
+      <div class="perk-title">Tool integrations</div>
+      <div class="perk-desc">Read your inbox, draft a reply, schedule a meeting, file a ticket. Slack, calendar, email, any MCP server. You approve every action that leaves the phone.</div>
+    </div>
+  </div>
+  <div class="perk-card">
+    <div class="perk-icon">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+    </div>
+    <div>
+      <div class="perk-title">Pay once, keep it</div>
+      <div class="perk-desc"><strong>$50 one-time</strong>. No subscription, no surprise pricing. Have a promo code? Enter it at checkout to adjust the price.</div>
+    </div>
+  </div>
+</div>
+
+---
+
+## How checkout works
+
+You enter your email and we send you to RevenueCat's hosted checkout with that email attached. The purchase is tied to your email, so sign into the app with the same address to unlock Pro.
+
+Have a promo code? Apply it on the checkout page, before you pay. The price updates once the code is accepted.
+
+Pro is a one-time $50 purchase, not a subscription. The open-source core has 100K downloads already. Pro is an extension of it, not a rewrite.
+
+If we do not ship Pro within 12 weeks, email us and you get a full refund.
+
+<script src="{{ '/assets/js/revenuecat-link.js' | relative_url }}"></script>
+<script>
+  (function() {
+    var TOKEN = {{ site.revenuecat_token | jsonify }};
+    var form = document.getElementById('payForm');
+    var emailInput = document.getElementById('payEmail');
+    var submit = document.getElementById('paySubmit');
+    var status = document.getElementById('payStatus');
+    if (!form || !window.RevenueCatLink) return;
+
+    function clearError() {
+      emailInput.classList.remove('ea-input-error');
+      emailInput.setAttribute('aria-invalid', 'false');
+      if (status.classList.contains('ea-status-error')) {
+        status.textContent = '';
+        status.className = 'ea-status';
+      }
+    }
+
+    function showError(message) {
+      emailInput.classList.add('ea-input-error');
+      emailInput.setAttribute('aria-invalid', 'true');
+      status.textContent = message;
+      status.className = 'ea-status ea-status-error';
+    }
+
+    // Enable the button only once something is typed; clear errors as they type.
+    emailInput.addEventListener('input', function() {
+      submit.disabled = emailInput.value.trim() === '';
+      clearError();
+    });
+
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      var email = emailInput.value.trim();
+      var url = RevenueCatLink.buildPurchaseUrl(TOKEN, email);
+      if (!url) {
+        showError('Enter a valid email address.');
+        emailInput.focus();
+        return;
+      }
+      if (typeof posthog !== 'undefined') {
+        posthog.identify(email, { email: email });
+        posthog.capture('pro_checkout_started', {
+          email: email,
+          source: window.location.pathname
+        });
+      }
+      status.innerHTML = 'Checkout opened in a new tab. <a href="' + url + '" target="_blank" rel="noopener">Reopen it</a> if your browser blocked the popup.';
+      status.className = 'ea-status ea-status-success';
+      window.open(url, '_blank', 'noopener');
+    });
+  })();
+</script>

--- a/website/pay.md
+++ b/website/pay.md
@@ -90,6 +90,10 @@ If we do not ship Pro within 12 weeks, email us and you get a full refund.
     var status = document.getElementById('payStatus');
     if (!form || !window.RevenueCatLink) return;
 
+    // Sync the button state on load too - the browser may have autofilled the
+    // field (or restored it on back-navigation) without firing an input event.
+    submit.disabled = emailInput.value.trim() === '';
+
     function clearError() {
       emailInput.classList.remove('ea-input-error');
       emailInput.setAttribute('aria-invalid', 'false');
@@ -122,11 +126,16 @@ If we do not ship Pro within 12 weeks, email us and you get a full refund.
         return;
       }
       if (typeof posthog !== 'undefined') {
-        posthog.identify(email, { email: email });
-        posthog.capture('pro_checkout_started', {
-          email: email,
-          source: window.location.pathname
-        });
+        // Never let an analytics failure (blocked, errored) stop the purchase.
+        try {
+          posthog.identify(email, { email: email });
+          posthog.capture('pro_checkout_started', {
+            email: email,
+            source: window.location.pathname
+          });
+        } catch (err) {
+          console.warn('PostHog tracking failed:', err);
+        }
       }
       status.innerHTML = 'Checkout opened in a new tab. <a href="' + url + '" target="_blank" rel="noopener">Reopen it</a> if your browser blocked the popup.';
       status.className = 'ea-status ea-status-success';

--- a/website/pay.md
+++ b/website/pay.md
@@ -14,7 +14,7 @@ description: Buy Off Grid Pro. Enter your email and check out. $50 one-time, no 
 <div class="early-access-form-section ea-form-top">
   <form id="payForm" class="early-access-form" novalidate>
     <div class="ea-inline-group">
-      <input type="email" id="payEmail" class="ea-input" placeholder="your@email.com" autocomplete="email" aria-invalid="false" required>
+      <input type="email" id="payEmail" class="ea-input" placeholder="your@email.com" autocomplete="email" aria-invalid="false" aria-describedby="payStatus" required>
       <button type="submit" class="ea-submit" id="paySubmit" disabled>Continue to checkout</button>
     </div>
     <div class="ea-form-footer">
@@ -119,10 +119,15 @@ If we do not ship Pro within 12 weeks, email us and you get a full refund.
     form.addEventListener('submit', function(e) {
       e.preventDefault();
       var email = emailInput.value.trim();
-      var url = RevenueCatLink.buildPurchaseUrl(LINK_ID, email);
-      if (!url) {
+      if (!RevenueCatLink.isValidEmail(email)) {
         showError('Enter a valid email address.');
         emailInput.focus();
+        return;
+      }
+      var url = RevenueCatLink.buildPurchaseUrl(LINK_ID, email);
+      if (!url) {
+        // Email is valid, so a null URL means the link id is not configured.
+        showError('Checkout is not available right now. Please try again later.');
         return;
       }
       if (typeof posthog !== 'undefined') {
@@ -139,7 +144,9 @@ If we do not ship Pro within 12 weeks, email us and you get a full refund.
       }
       status.innerHTML = 'Checkout opened in a new tab. <a href="' + url + '" target="_blank" rel="noopener">Reopen it</a> if your browser blocked the popup.';
       status.className = 'ea-status ea-status-success';
-      window.open(url, '_blank', 'noopener');
+      // No features string: a non-empty one forces a popup window; '_blank'
+      // alone opens a real new tab and already defaults to noopener.
+      window.open(url, '_blank');
     });
   })();
 </script>


### PR DESCRIPTION
## What

Adds a `/pay/` page where a customer enters their email and is sent to RevenueCat's hosted checkout to buy Off Grid Pro ($50 one-time). Also links to it from the early-access page.

## How it works

- The email is used as the RevenueCat **App User ID** (a URL path segment) and is also prefilled on the checkout page. Generated link:
  ```
  https://pay.rev.cat/<token>/<urlEncodedEmail>?email=<urlEncodedEmail>
  ```
- Clicking **Continue to checkout** validates the email, fires a PostHog `pro_checkout_started` event, then opens the checkout in a **new tab** (`window.open`), with a fallback "Reopen it" link if the popup is blocked.
- **Promo codes** are applied on the RevenueCat checkout page, before paying. The copy points users there.
- The button is **disabled until the field has input**; an invalid email **highlights the field** (red border, `aria-invalid`) and shows an error that clears as the user types.

## Token / config

- The RevenueCat web link token is **public by design** (it appears in every customer's checkout URL), so it lives in `website/_config.yml` as `revenuecat_token` and is baked into the static HTML at build time. Production token is set. This mirrors how `posthog_token` is already handled.

## Changes

- `website/pay.md` — the page + inline submit handler
- `website/assets/js/revenuecat-link.js` — dependency-free, unit-tested URL builder (UMD: browser global + CommonJS)
- `website/assets/css/main.css` — `.ea-input-error` highlight style
- `website/early-access.md` — link to `/pay/` for people already on the list or with a promo code
- `website/_config.yml` — `revenuecat_token`; exclude `.bundle`/`_site`
- `website/.gitignore` — ignore Jekyll build artifacts (`_site`, `vendor`, `.bundle`, caches)
- `website/Gemfile.lock` — committed for reproducible builds
- `__tests__/unit/website/revenuecatLink.test.ts` — 20 tests (encoding, validation, package_id, null cases)

## Testing

- `npm test` (website unit test): 20/20 pass
- `npm run lint` and `npx tsc --noEmit`: clean
- Built locally with Jekyll; `/pay/` and `/early-access/` render, link resolves, generated URL verified against RevenueCat's documented format

## Notes

Copy follows `docs/brand_tone_voice.md` (no em dashes, no exclamation marks, no curly quotes, no forbidden words, proof-first pricing, privacy stated as mechanism).