### PR TITLE
docs: fix broken Wednesday logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 <sub><b>BUILT BY</b></sub>
 
-<a href="https://wednesday.is/?utm_source=github&utm_medium=offgrid-readme&utm_content=logo"><picture><source media="(prefers-color-scheme: dark)" srcset="https://wednesday.is/logos/wednesday-logo.svg" /><img src="src/assets/wednesday-logo.svg" alt="Wednesday Solutions" height="104" /></picture></a>
+<a href="https://wednesday.is/?utm_source=github&utm_medium=offgrid-readme&utm_content=logo"><img src="src/assets/wednesday-logo.svg" alt="Wednesday Solutions" height="104" /></a>
 
 </div>
 


### PR DESCRIPTION
## Summary
- The dark-mode `srcset` in the BUILT BY block pointed at `https://wednesday.is/logos/wednesday-logo.svg`, which 404s (only `mobile.wednesday.is` served that path), so the logo wasn't rendering on github.com
- Drop the `<picture>` wrapper and use the local `src/assets/wednesday-logo.svg` for both themes

Follow-up to #395 — the fix was on the branch but not in the squash-merged set.

## Test plan
- [ ] Render README on GitHub in dark mode and confirm the Wednesday Solutions logo shows