### PR TITLE
docs: drop redundant built-by line under Wednesday logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@
 
 </div>
 
-Off Grid is built by [**Wednesday Solutions**](https://wednesday.is/?utm_source=github&utm_medium=offgrid-readme&utm_content=body-link).
-
 ---
 
 <br />


### PR DESCRIPTION
## Summary
- Remove the "Off Grid is built by Wednesday Solutions." sentence underneath the BUILT BY logo block
- The logo above is already linked to wednesday.is, so the duplicate line was visual noise

## Test plan
- [ ] Render README on GitHub and confirm only the logo (linking to wednesday.is) sits in the BUILT BY block