### PR TITLE
website: swap Early Access for Get Pro in sidebar

### DIFF
--- a/website/early-access.md
+++ b/website/early-access.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Early Access
-nav_order: 4
 description: Join the waitlist for early access to Off Grid. Be among the first to run the personal AI OS, shape what gets built, and lock in the Round 2 price.
 ---
 

--- a/website/pay.md
+++ b/website/pay.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Get Pro
-nav_order: 5
+nav_order: 4
 description: Buy Off Grid Pro. Enter your email and check out. $50 one-time, no subscription. Have a promo code? Apply it at checkout.
 ---
 


### PR DESCRIPTION
## Summary
- Remove `nav_order` from `website/early-access.md` so it no longer appears in the left sidebar (page itself stays reachable at `/early-access`)
- Move `website/pay.md` from `nav_order: 5` to `4` so Get Pro fills the slot Early Access used to occupy

## Test plan
- [ ] Build the Jekyll site and confirm the sidebar shows Get Pro in position 4 with no Early Access entry
- [ ] Visit `/pay` and confirm the existing content renders unchanged
- [ ] Visit `/early-access` directly and confirm the page still loads