### PR TITLE
website: point home Pro CTA at /pay

### DIFF
--- a/website/index.md
+++ b/website/index.md
@@ -92,7 +92,7 @@ A version with voice, custom personas, and tool integrations - Slack, calendar, 
 A small group gets it before the public release. Round 2 alpha is **$30 one-time** (Round 1 sold out at the same price). Goes to **$50 one-time** at public launch. No subscription, no surprise pricing.
 
 <div class="hero-buttons">
-  <a href="{{ '/early-access' | relative_url }}" class="btn btn-green">Join the waitlist</a>
+  <a href="{{ '/pay' | relative_url }}" class="btn btn-green">Get Pro</a>
   <a href="https://off-grid-mobile.slack.com/archives/C0B4KMHNP61" target="_blank" rel="noopener" class="btn btn-outline">
     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/></svg>
     Join #pro-waitlist


### PR DESCRIPTION
## Summary
- The "Pro - alpha access" CTA on the home page linked to `/early-access`; switch it to `/pay`
- Relabel the button from "Join the waitlist" to "Get Pro" to match the checkout page

## Test plan
- [ ] Build the site and confirm the green button under "Pro - alpha access" on the home page links to `/pay`
- [ ] Confirm the rest of the home page renders unchanged