### PR TITLE
website: drop alpha/round framing from home Pro section

### DIFF
--- a/website/index.md
+++ b/website/index.md
@@ -80,7 +80,7 @@ With Off Grid the model lives in your phone's memory. Inference happens on your 
 
 ---
 
-## Pro - alpha access
+## Pro
 
 A version with voice, custom personas, and tool integrations - Slack, calendar, email, any MCP server. All on-device, same as the rest.
 
@@ -89,14 +89,10 @@ A version with voice, custom personas, and tool integrations - Slack, calendar, 
 - **Integrations** - Read your inbox, draft a reply, schedule a meeting, file a Linear ticket. You approve every action that leaves the phone.
 - **Direct line to the team** - Private channel with the people building it. File a bug, watch it get fixed.
 
-A small group gets it before the public release. Round 2 alpha is **$30 one-time** (Round 1 sold out at the same price). Goes to **$50 one-time** at public launch. No subscription, no surprise pricing.
+**$50 one-time.** No subscription, no surprise pricing.
 
 <div class="hero-buttons">
   <a href="{{ '/pay' | relative_url }}" class="btn btn-green">Get Pro</a>
-  <a href="https://off-grid-mobile.slack.com/archives/C0B4KMHNP61" target="_blank" rel="noopener" class="btn btn-outline">
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/></svg>
-    Join #pro-waitlist
-  </a>
 </div>
 
 ---


### PR DESCRIPTION
## Summary
- Rename the home page heading from "Pro - alpha access" to "Pro"
- Replace the Round 1 / Round 2 / public-launch pricing paragraph with a single "$50 one-time. No subscription, no surprise pricing." line
- Drop the "Join #pro-waitlist" Slack button so the section stops referencing a waitlist
- The Get Pro CTA continues to point at `/pay`

## Test plan
- [ ] Build the site and confirm the home page Pro section shows the new heading, flat $50 copy, and only the Get Pro button