### PR TITLE
feat: RevenueCat pro license service + cross-platform offering

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import logger, { setLogListener } from './src/utils/logger';
 import { useAppStore, useAuthStore, useRemoteServerStore } from './src/stores';
 import { useDebugLogsStore } from './src/stores/debugLogsStore';
 import { loadProFeatures } from './src/bootstrap/loadProFeatures';
+import { configureRevenueCat, checkProStatus } from './src/services/proLicenseService';
 import { hydrateDownloadStore } from './src/services/downloadHydration';
 import { useDownloadListeners } from './src/hooks/useDownloads';
 import { LockScreen } from './src/screens';
@@ -171,8 +172,14 @@ function App() {
       // Initialize RAG database tables
       ragService.ensureReady().catch((err) => logger.error('Failed to initialize RAG service on startup', err));
 
-      // Load pro features synchronously (screens registered before AppNavigator renders)
-      loadProFeatures().catch((err) => logger.error('[App] loadProFeatures failed:', err));
+      // Configure RevenueCat and read the cached entitlement before Pro features load.
+      // configureRevenueCat is sync; checkProStatus reads the keychain cache immediately
+      // and fires a background RC network sync so the next launch stays fresh.
+      configureRevenueCat();
+      await checkProStatus();
+
+      // Load pro features — only activates if the keychain entitlement is set.
+      await loadProFeatures();
 
       // Show the UI immediately
       setIsInitializing(false);

--- a/App.tsx
+++ b/App.tsx
@@ -175,11 +175,19 @@ function App() {
       // Configure RevenueCat and read the cached entitlement before Pro features load.
       // configureRevenueCat is sync; checkProStatus reads the keychain cache immediately
       // and fires a background RC network sync so the next launch stays fresh.
-      configureRevenueCat();
-      await checkProStatus();
+      //
+      // Pro is optional: a failure here (missing native module, keychain locked,
+      // bad RC config) must never abort app init or hang the splash screen, so the
+      // whole block is isolated and only logs on error.
+      try {
+        configureRevenueCat();
+        await checkProStatus();
 
-      // Load pro features — only activates if the keychain entitlement is set.
-      await loadProFeatures();
+        // Load pro features — only activates if the keychain entitlement is set.
+        await loadProFeatures();
+      } catch (proError) {
+        logger.error('[App] Pro initialization failed, continuing without Pro:', proError);
+      }
 
       // Show the UI immediately
       setIsInitializing(false);

--- a/App.tsx
+++ b/App.tsx
@@ -181,10 +181,11 @@ function App() {
       // whole block is isolated and only logs on error.
       try {
         configureRevenueCat();
-        await checkProStatus();
+        const isPro = await checkProStatus();
 
         // Load pro features — only activates if the keychain entitlement is set.
-        await loadProFeatures();
+        // Reuse the entitlement read above to avoid a second keychain round-trip.
+        await loadProFeatures(isPro);
       } catch (proError) {
         logger.error('[App] Pro initialization failed, continuing without Pro:', proError);
       }

--- a/__tests__/integration/onboarding/proBootFlow.test.ts
+++ b/__tests__/integration/onboarding/proBootFlow.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Integration: Pro boot flow
+ *
+ * Verifies that configureRevenueCat + checkProStatus run before loadProFeatures,
+ * and that Pro features only activate when the keychain entitlement is set.
+ */
+
+jest.mock('react-native-purchases', () => ({
+  __esModule: true,
+  default: {
+    setLogLevel: jest.fn(),
+    configure: jest.fn(),
+    getCustomerInfo: jest.fn().mockResolvedValue({ entitlements: { active: {} }, originalAppUserId: 'anon', allPurchaseDates: {} }),
+    invalidateCustomerInfoCache: jest.fn().mockResolvedValue(undefined),
+    getOfferings: jest.fn(),
+    purchasePackage: jest.fn(),
+    restorePurchases: jest.fn(),
+    logOut: jest.fn(),
+  },
+  LOG_LEVEL: { DEBUG: 'debug', ERROR: 'error' },
+}));
+
+jest.mock('react-native-keychain', () => ({
+  getGenericPassword: jest.fn(),
+  setGenericPassword: jest.fn(),
+  resetGenericPassword: jest.fn(),
+  ACCESSIBLE: { AFTER_FIRST_UNLOCK: 'AfterFirstUnlock' },
+}));
+
+jest.mock('../../../src/stores/appStore', () => {
+  const setHasRegisteredPro = jest.fn();
+  return { useAppStore: { getState: () => ({ setHasRegisteredPro }) } };
+});
+
+jest.mock('../../../src/services/tools/extensions', () => ({ registerToolExtension: jest.fn() }));
+jest.mock('../../../src/navigation/screenRegistry', () => ({ registerScreen: jest.fn() }));
+jest.mock('../../../src/components/settings/sectionRegistry', () => ({ registerSettingsSection: jest.fn() }));
+jest.mock('@offgrid/pro', () => ({ activate: jest.fn() }), { virtual: true });
+
+import { configureRevenueCat, checkProStatus } from '../../../src/services/proLicenseService';
+import { loadProFeatures } from '../../../src/bootstrap/loadProFeatures';
+
+const Purchases = require('react-native-purchases').default;
+const Keychain = require('react-native-keychain');
+const mockConfigure = Purchases.configure;
+const mockGetCustomerInfo = Purchases.getCustomerInfo;
+const mockGetGenericPassword = Keychain.getGenericPassword;
+const mockSetGenericPassword = Keychain.setGenericPassword;
+const mockActivate = require('@offgrid/pro').activate;
+const mockSetHasRegisteredPro = require('../../../src/stores/appStore').useAppStore.getState().setHasRegisteredPro;
+
+describe('Pro boot flow integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('configures RevenueCat, reads entitlement, and skips Pro activation when not subscribed', async () => {
+    mockGetGenericPassword.mockResolvedValue(false);
+    mockGetCustomerInfo.mockResolvedValue({ entitlements: { active: {} } });
+
+    configureRevenueCat();
+    await checkProStatus();
+    await loadProFeatures();
+
+    expect(mockConfigure).toHaveBeenCalledTimes(1);
+    expect(mockActivate).not.toHaveBeenCalled();
+  });
+
+  it('configures RevenueCat, reads entitlement, and activates Pro when subscribed', async () => {
+    const license = JSON.stringify({ isPro: true, verifiedAt: 0 });
+    mockGetGenericPassword.mockResolvedValue({ password: license });
+    mockGetCustomerInfo.mockResolvedValue({
+      entitlements: { active: { pro: { productIdentifier: 'offgrid_pro' } } },
+    });
+
+    configureRevenueCat();
+    await checkProStatus();
+    await loadProFeatures();
+
+    expect(mockConfigure).toHaveBeenCalledTimes(1);
+    expect(mockActivate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        registerToolExtension: expect.any(Function),
+        registerScreen: expect.any(Function),
+        registerSettingsSection: expect.any(Function),
+      }),
+    );
+  });
+
+  it('background RC sync writes updated entitlement to store after boot', async () => {
+    // Keychain is empty but RC says the user is subscribed (e.g. new device install)
+    mockGetGenericPassword
+      .mockResolvedValueOnce(false)  // first read in checkProStatus (returns cached false)
+      .mockResolvedValue({ password: JSON.stringify({ isPro: true, verifiedAt: 1 }) });
+    mockGetCustomerInfo.mockResolvedValue({
+      entitlements: { active: { pro: { productIdentifier: 'offgrid_pro' } } },
+    });
+    mockSetGenericPassword.mockResolvedValue(true);
+
+    configureRevenueCat();
+    const isPro = await checkProStatus();
+
+    // Cached value from empty keychain is false; background sync fires async
+    expect(isPro).toBe(false);
+
+    // Allow the background syncWithRevenueCat to complete
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(mockSetGenericPassword).toHaveBeenCalledTimes(1);
+    expect(mockSetHasRegisteredPro).toHaveBeenCalledWith(true);
+  });
+});

--- a/__tests__/rntl/screens/ProDetailScreen.test.tsx
+++ b/__tests__/rntl/screens/ProDetailScreen.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * ProDetailScreen Tests
+ *
+ * Renders the real Pro screen and exercises the purchase / restore handlers
+ * and the entitlement-driven UI states (Get Pro vs Pro Active).
+ */
+
+import React from 'react';
+import { Alert } from 'react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { useAppStore } from '../../../src/stores/appStore';
+
+const mockPresentProPaywall = jest.fn();
+const mockRestorePro = jest.fn();
+const mockResetProIdentityForTesting = jest.fn();
+jest.mock('../../../src/services/proLicenseService', () => ({
+  presentProPaywall: (...args: unknown[]) => mockPresentProPaywall(...args),
+  restorePro: (...args: unknown[]) => mockRestorePro(...args),
+  resetProIdentityForTesting: (...args: unknown[]) => mockResetProIdentityForTesting(...args),
+}));
+
+import { ProDetailScreen } from '../../../src/screens/ProDetailScreen';
+
+describe('ProDetailScreen', () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAppStore.setState({ hasRegisteredPro: false });
+    alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  it('renders the Get Pro call-to-action when the user is not Pro', () => {
+    const { queryAllByText } = render(<ProDetailScreen />);
+    expect(queryAllByText('Get Pro').length).toBeGreaterThan(0);
+  });
+
+  it('shows the restart prompt after a successful purchase', async () => {
+    mockPresentProPaywall.mockResolvedValueOnce(true);
+    const { getAllByText } = render(<ProDetailScreen />);
+
+    fireEvent.press(getAllByText('Get Pro')[0]);
+
+    await waitFor(() => expect(mockPresentProPaywall).toHaveBeenCalledTimes(1));
+    expect(alertSpy).toHaveBeenCalledWith('Pro activated', expect.any(String), expect.anything());
+  });
+
+  it('does not show the restart prompt when the purchase is not completed', async () => {
+    mockPresentProPaywall.mockResolvedValueOnce(false);
+    const { getAllByText } = render(<ProDetailScreen />);
+
+    fireEvent.press(getAllByText('Get Pro')[0]);
+
+    await waitFor(() => expect(mockPresentProPaywall).toHaveBeenCalledTimes(1));
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows a failure alert when the purchase throws', async () => {
+    mockPresentProPaywall.mockRejectedValueOnce(new Error('boom'));
+    const { getAllByText } = render(<ProDetailScreen />);
+
+    fireEvent.press(getAllByText('Get Pro')[0]);
+
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledWith('Purchase failed', expect.any(String)));
+  });
+
+  it('shows the restart prompt when a restore finds an active subscription', async () => {
+    mockRestorePro.mockResolvedValueOnce(true);
+    const { getByText } = render(<ProDetailScreen />);
+
+    fireEvent.press(getByText('Restore purchases'));
+
+    await waitFor(() => expect(mockRestorePro).toHaveBeenCalledTimes(1));
+    expect(alertSpy).toHaveBeenCalledWith('Pro activated', expect.any(String), expect.anything());
+  });
+
+  it('tells the user when a restore finds no purchases', async () => {
+    mockRestorePro.mockResolvedValueOnce(false);
+    const { getByText } = render(<ProDetailScreen />);
+
+    fireEvent.press(getByText('Restore purchases'));
+
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledWith('No purchases found', expect.any(String)));
+  });
+
+  it('shows a failure alert when the restore throws', async () => {
+    mockRestorePro.mockRejectedValueOnce(new Error('boom'));
+    const { getByText } = render(<ProDetailScreen />);
+
+    fireEvent.press(getByText('Restore purchases'));
+
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledWith('Restore failed', expect.any(String)));
+  });
+
+  it('renders the Pro Active state when the user already owns Pro', () => {
+    useAppStore.setState({ hasRegisteredPro: true });
+    const { getByText, queryByText } = render(<ProDetailScreen />);
+
+    expect(getByText('Pro Active')).toBeTruthy();
+    expect(getByText('Pro is active on this account.')).toBeTruthy();
+    expect(queryByText('Restore purchases')).toBeNull();
+  });
+
+  it('runs the dev reset and confirms when the Pro user taps [DEV] reset', async () => {
+    useAppStore.setState({ hasRegisteredPro: true });
+    mockResetProIdentityForTesting.mockResolvedValueOnce(undefined);
+    const { getByText } = render(<ProDetailScreen />);
+
+    fireEvent.press(getByText('[DEV] Reset Pro identity'));
+
+    await waitFor(() => expect(mockResetProIdentityForTesting).toHaveBeenCalledTimes(1));
+    expect(alertSpy).toHaveBeenCalledWith('Dev reset', expect.any(String));
+  });
+});

--- a/__tests__/unit/services/loadProFeatures.test.ts
+++ b/__tests__/unit/services/loadProFeatures.test.ts
@@ -52,4 +52,20 @@ describe('loadProFeatures()', () => {
       }),
     );
   });
+
+  it('reuses a passed isPro=true without re-reading the keychain', async () => {
+    const mockActivate = jest.fn();
+    jest.mock('@offgrid/pro', () => ({ activate: mockActivate }), { virtual: true });
+    await loadProFeatures(true);
+    expect(mockActivate).toHaveBeenCalledTimes(1);
+    expect(mockReadProFromKeychain).not.toHaveBeenCalled();
+  });
+
+  it('reuses a passed isPro=false without re-reading the keychain', async () => {
+    const mockActivate = jest.fn();
+    jest.mock('@offgrid/pro', () => ({ activate: mockActivate }), { virtual: true });
+    await loadProFeatures(false);
+    expect(mockActivate).not.toHaveBeenCalled();
+    expect(mockReadProFromKeychain).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/unit/services/loadProFeatures.test.ts
+++ b/__tests__/unit/services/loadProFeatures.test.ts
@@ -10,9 +10,15 @@ jest.mock('../../../src/components/settings/sectionRegistry', () => ({
   registerSettingsSection: jest.fn(),
 }));
 
+const mockReadProFromKeychain = jest.fn();
+jest.mock('../../../src/services/proLicenseService', () => ({
+  readProFromKeychain: (...args: any[]) => mockReadProFromKeychain(...args),
+}));
+
 describe('loadProFeatures()', () => {
   beforeEach(() => {
     jest.resetModules();
+    mockReadProFromKeychain.mockResolvedValue(false);
   });
 
   it('returns without error when @offgrid/pro package is not installed', async () => {
@@ -25,9 +31,18 @@ describe('loadProFeatures()', () => {
     await expect(loadProFeatures()).resolves.toBeUndefined();
   });
 
-  it('calls pro.activate with the three registries when package is present', async () => {
+  it('does not call pro.activate when there is no entitlement', async () => {
     const mockActivate = jest.fn();
     jest.mock('@offgrid/pro', () => ({ activate: mockActivate }), { virtual: true });
+    mockReadProFromKeychain.mockResolvedValueOnce(false);
+    await loadProFeatures();
+    expect(mockActivate).not.toHaveBeenCalled();
+  });
+
+  it('calls pro.activate with the three registries when entitlement is active', async () => {
+    const mockActivate = jest.fn();
+    jest.mock('@offgrid/pro', () => ({ activate: mockActivate }), { virtual: true });
+    mockReadProFromKeychain.mockResolvedValueOnce(true);
     await loadProFeatures();
     expect(mockActivate).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/__tests__/unit/services/proLicenseService.test.ts
+++ b/__tests__/unit/services/proLicenseService.test.ts
@@ -9,15 +9,18 @@ import {
 
 jest.mock('react-native-purchases', () => ({
   __esModule: true,
-  default: { setLogLevel: jest.fn(), configure: jest.fn(), getCustomerInfo: jest.fn(), restorePurchases: jest.fn() },
+  default: {
+    setLogLevel: jest.fn(),
+    configure: jest.fn(),
+    getCustomerInfo: jest.fn().mockResolvedValue({ entitlements: { active: {} }, originalAppUserId: 'anon', allPurchaseDates: {} }),
+    restorePurchases: jest.fn(),
+    getOfferings: jest.fn(),
+    purchasePackage: jest.fn(),
+    invalidateCustomerInfoCache: jest.fn().mockResolvedValue(undefined),
+    logOut: jest.fn(),
+  },
   LOG_LEVEL: { DEBUG: 'debug', ERROR: 'error' },
-}), { virtual: true });
-
-jest.mock('react-native-purchases-ui', () => ({
-  __esModule: true,
-  default: { presentPaywall: jest.fn() },
-  PAYWALL_RESULT: { PURCHASED: 'PURCHASED', RESTORED: 'RESTORED', NOT_PRESENTED: 'NOT_PRESENTED', ERROR: 'ERROR', CANCELLED: 'CANCELLED' },
-}), { virtual: true });
+}));
 
 jest.mock('react-native-keychain', () => ({
   getGenericPassword: jest.fn(),
@@ -34,10 +37,18 @@ jest.mock('../../../src/stores/appStore', () => ({
 const { getGenericPassword: mockGetGenericPassword, setGenericPassword: mockSetGenericPassword, resetGenericPassword: mockResetGenericPassword } =
   require('react-native-keychain');
 const Purchases = require('react-native-purchases').default;
-const RevenueCatUI = require('react-native-purchases-ui').default;
-const { PAYWALL_RESULT } = require('react-native-purchases-ui');
 
-const ENTITLEMENT_ACTIVE = { 'offgrid Pro': { productIdentifier: 'pro_monthly' } };
+const makeOffering = () => ({
+  all: {},
+  current: {
+    identifier: 'default',
+    availablePackages: [
+      { identifier: '$rc_lifetime', product: { identifier: 'off_grid_pro_lifetime', priceString: '$9.99' } },
+    ],
+  },
+});
+
+const ENTITLEMENT_ACTIVE = { pro: { productIdentifier: 'pro_monthly' } };
 const ENTITLEMENT_EMPTY = {};
 
 describe('proLicenseService', () => {
@@ -82,22 +93,28 @@ describe('proLicenseService', () => {
   });
 
   describe('presentProPaywall()', () => {
-    it('returns true and writes license when PURCHASED', async () => {
-      RevenueCatUI.presentPaywall.mockResolvedValueOnce(PAYWALL_RESULT.PURCHASED);
+    it('returns true and writes license when the purchase grants the entitlement', async () => {
+      Purchases.getOfferings.mockResolvedValueOnce(makeOffering());
+      Purchases.purchasePackage.mockResolvedValueOnce({
+        customerInfo: { entitlements: { active: ENTITLEMENT_ACTIVE }, originalAppUserId: 'anon' },
+      });
       mockSetGenericPassword.mockResolvedValueOnce(true);
       expect(await presentProPaywall()).toBe(true);
       expect(mockSetHasRegisteredPro).toHaveBeenCalledWith(true);
     });
 
-    it('returns true and writes license when RESTORED', async () => {
-      RevenueCatUI.presentPaywall.mockResolvedValueOnce(PAYWALL_RESULT.RESTORED);
-      mockSetGenericPassword.mockResolvedValueOnce(true);
-      expect(await presentProPaywall()).toBe(true);
-      expect(mockSetHasRegisteredPro).toHaveBeenCalledWith(true);
+    it('returns false when the purchase does not grant the entitlement', async () => {
+      Purchases.getOfferings.mockResolvedValueOnce(makeOffering());
+      Purchases.purchasePackage.mockResolvedValueOnce({
+        customerInfo: { entitlements: { active: ENTITLEMENT_EMPTY }, originalAppUserId: 'anon' },
+      });
+      expect(await presentProPaywall()).toBe(false);
+      expect(mockSetHasRegisteredPro).not.toHaveBeenCalled();
     });
 
-    it('returns false when CANCELLED', async () => {
-      RevenueCatUI.presentPaywall.mockResolvedValueOnce(PAYWALL_RESULT.CANCELLED);
+    it('returns false when the user cancels', async () => {
+      Purchases.getOfferings.mockResolvedValueOnce(makeOffering());
+      Purchases.purchasePackage.mockRejectedValueOnce({ userCancelled: true });
       expect(await presentProPaywall()).toBe(false);
       expect(mockSetHasRegisteredPro).not.toHaveBeenCalled();
     });

--- a/__tests__/unit/services/proLicenseService.test.ts
+++ b/__tests__/unit/services/proLicenseService.test.ts
@@ -5,6 +5,7 @@ import {
   restorePro,
   clearProForTesting,
   configureRevenueCat,
+  resetProIdentityForTesting,
 } from '../../../src/services/proLicenseService';
 
 jest.mock('react-native-purchases', () => ({
@@ -118,6 +119,31 @@ describe('proLicenseService', () => {
       expect(await presentProPaywall()).toBe(false);
       expect(mockSetHasRegisteredPro).not.toHaveBeenCalled();
     });
+
+    it('still reports success when the keychain write fails after a granted purchase', async () => {
+      Purchases.getOfferings.mockResolvedValueOnce(makeOffering());
+      Purchases.purchasePackage.mockResolvedValueOnce({
+        customerInfo: { entitlements: { active: ENTITLEMENT_ACTIVE }, originalAppUserId: 'anon' },
+      });
+      // A keychain failure must not turn a charged purchase into a "Purchase failed".
+      mockSetGenericPassword.mockRejectedValueOnce(new Error('keychain locked'));
+      expect(await presentProPaywall()).toBe(true);
+      expect(mockSetHasRegisteredPro).toHaveBeenCalledWith(true);
+    });
+
+    it('falls back to the first package when no $rc_lifetime package exists', async () => {
+      const offering = makeOffering();
+      offering.current.availablePackages = [
+        { identifier: '$rc_monthly', product: { identifier: 'off_grid_pro_monthly', priceString: '$1.99' } },
+      ];
+      Purchases.getOfferings.mockResolvedValueOnce(offering);
+      Purchases.purchasePackage.mockResolvedValueOnce({
+        customerInfo: { entitlements: { active: ENTITLEMENT_ACTIVE }, originalAppUserId: 'anon' },
+      });
+      mockSetGenericPassword.mockResolvedValueOnce(true);
+      expect(await presentProPaywall()).toBe(true);
+      expect(Purchases.purchasePackage).toHaveBeenCalledWith(offering.current.availablePackages[0]);
+    });
   });
 
   describe('restorePro()', () => {
@@ -145,6 +171,21 @@ describe('proLicenseService', () => {
     });
   });
 
+  describe('presentProPaywall() error paths', () => {
+    it('throws when there is no current offering', async () => {
+      Purchases.getOfferings.mockResolvedValueOnce({ all: {}, current: null });
+      await expect(presentProPaywall()).rejects.toThrow('No offering available');
+    });
+
+    it('throws when the current offering has no packages', async () => {
+      Purchases.getOfferings.mockResolvedValueOnce({
+        all: {},
+        current: { identifier: 'default', availablePackages: [] },
+      });
+      await expect(presentProPaywall()).rejects.toThrow('No package available');
+    });
+  });
+
   describe('configureRevenueCat()', () => {
     it('configures RC SDK on iOS', () => {
       const Platform = require('react-native').Platform;
@@ -158,6 +199,48 @@ describe('proLicenseService', () => {
       Platform.OS = 'android';
       configureRevenueCat();
       expect(Purchases.configure).toHaveBeenCalledTimes(1);
+    });
+
+    it('rethrows when the RC SDK fails to configure', () => {
+      Purchases.configure.mockImplementationOnce(() => {
+        throw new Error('native module missing');
+      });
+      expect(() => configureRevenueCat()).toThrow('native module missing');
+    });
+  });
+
+  describe('resetProIdentityForTesting()', () => {
+    it('skips logOut for an anonymous user and clears the keychain', async () => {
+      Purchases.getCustomerInfo.mockResolvedValueOnce({
+        originalAppUserId: '$RCAnonymousID:abc',
+        entitlements: { active: {} },
+        allPurchaseDates: {},
+      });
+      await resetProIdentityForTesting();
+      expect(Purchases.logOut).not.toHaveBeenCalled();
+      expect(mockResetGenericPassword).toHaveBeenCalledTimes(1);
+      expect(mockSetHasRegisteredPro).toHaveBeenCalledWith(false);
+    });
+
+    it('logs out an identified user before clearing the keychain', async () => {
+      Purchases.getCustomerInfo
+        .mockResolvedValueOnce({
+          originalAppUserId: 'real-user-123',
+          entitlements: { active: {} },
+          allPurchaseDates: {},
+        })
+        .mockResolvedValueOnce({ originalAppUserId: '$RCAnonymousID:new', entitlements: { active: {} } });
+      Purchases.logOut.mockResolvedValueOnce(undefined);
+      await resetProIdentityForTesting();
+      expect(Purchases.logOut).toHaveBeenCalledTimes(1);
+      expect(mockResetGenericPassword).toHaveBeenCalledTimes(1);
+    });
+
+    it('continues clearing the keychain when the RC lookup throws', async () => {
+      Purchases.getCustomerInfo.mockRejectedValueOnce(new Error('network down'));
+      await resetProIdentityForTesting();
+      expect(mockResetGenericPassword).toHaveBeenCalledTimes(1);
+      expect(mockSetHasRegisteredPro).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/__tests__/unit/services/proLicenseService.test.ts
+++ b/__tests__/unit/services/proLicenseService.test.ts
@@ -53,6 +53,15 @@ const ENTITLEMENT_ACTIVE = { pro: { productIdentifier: 'pro_monthly' } };
 const ENTITLEMENT_EMPTY = {};
 
 describe('proLicenseService', () => {
+  beforeAll(() => {
+    // configureRevenueCat sets the module-level isConfigured flag that the
+    // purchase/restore/reset entry points require. Pin Platform.OS first since
+    // its default varies in the RN test environment.
+    const Platform = require('react-native').Platform;
+    Platform.OS = 'ios';
+    configureRevenueCat();
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -202,10 +211,56 @@ describe('proLicenseService', () => {
     });
 
     it('rethrows when the RC SDK fails to configure', () => {
+      const Platform = require('react-native').Platform;
+      Platform.OS = 'ios';
       Purchases.configure.mockImplementationOnce(() => {
         throw new Error('native module missing');
       });
       expect(() => configureRevenueCat()).toThrow('native module missing');
+    });
+
+    it('skips configuration on unsupported platforms (e.g. web)', () => {
+      const Platform = require('react-native').Platform;
+      Platform.OS = 'web';
+      configureRevenueCat();
+      expect(Purchases.configure).not.toHaveBeenCalled();
+      Platform.OS = 'ios';
+    });
+  });
+
+  describe('guards when the SDK is not configured', () => {
+    // A fresh module instance where configureRevenueCat() never ran, so the
+    // module-level isConfigured flag is false.
+    let svc: typeof import('../../../src/services/proLicenseService');
+    let isolatedKeychain: { getGenericPassword: jest.Mock; resetGenericPassword: jest.Mock };
+    let isolatedPurchases: { getCustomerInfo: jest.Mock };
+
+    beforeEach(() => {
+      jest.isolateModules(() => {
+        svc = require('../../../src/services/proLicenseService');
+        isolatedKeychain = require('react-native-keychain');
+        isolatedPurchases = require('react-native-purchases').default;
+      });
+    });
+
+    it('presentProPaywall throws', async () => {
+      await expect(svc.presentProPaywall()).rejects.toThrow('RevenueCat is not configured');
+    });
+
+    it('restorePro throws', async () => {
+      await expect(svc.restorePro()).rejects.toThrow('RevenueCat is not configured');
+    });
+
+    it('resetProIdentityForTesting no-ops without touching the keychain', async () => {
+      await svc.resetProIdentityForTesting();
+      expect(isolatedKeychain.resetGenericPassword).not.toHaveBeenCalled();
+    });
+
+    it('checkProStatus does not fire a background sync', async () => {
+      isolatedKeychain.getGenericPassword.mockResolvedValue(false);
+      expect(await svc.checkProStatus()).toBe(false);
+      await new Promise(resolve => setImmediate(resolve));
+      expect(isolatedPurchases.getCustomerInfo).not.toHaveBeenCalled();
     });
   });
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -98,6 +98,11 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - PurchasesHybridCommon (18.14.1):
+    - RevenueCat (= 5.78.0)
+  - PurchasesHybridCommonUI (18.14.1):
+    - PurchasesHybridCommon (= 18.14.1)
+    - RevenueCatUI (= 5.78.0)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -1982,8 +1987,6 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-add-calendar-event (5.0.0):
-    - React-Core
   - react-native-blur (4.4.1):
     - boost
     - DoubleConversion
@@ -2799,6 +2802,9 @@ PODS:
     - React-perflogger (= 0.83.1)
     - React-utils (= 0.83.1)
     - SocketRocket
+  - RevenueCat (5.78.0)
+  - RevenueCatUI (5.78.0):
+    - RevenueCat (= 5.78.0)
   - RNCalendarEvents (2.2.0):
     - React
   - RNCAsyncStorage (2.2.0):
@@ -2889,6 +2895,12 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - RNPaywalls (10.3.0):
+    - PurchasesHybridCommonUI (= 18.14.1)
+    - React-Core
+  - RNPurchases (10.3.0):
+    - PurchasesHybridCommon (= 18.14.1)
+    - React-Core
   - RNReactNativeHapticFeedback (2.3.3):
     - boost
     - DoubleConversion
@@ -3332,7 +3344,6 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
-  - react-native-add-calendar-event (from `../node_modules/react-native-add-calendar-event`)
   - "react-native-blur (from `../node_modules/@react-native-community/blur`)"
   - "react-native-document-picker (from `../node_modules/@react-native-documents/picker`)"
   - "react-native-document-viewer (from `../node_modules/@react-native-documents/viewer`)"
@@ -3379,6 +3390,8 @@ DEPENDENCIES:
   - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
+  - RNPaywalls (from `../node_modules/react-native-purchases-ui`)
+  - RNPurchases (from `../node_modules/react-native-purchases`)
   - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -3393,6 +3406,10 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - lottie-ios
+    - PurchasesHybridCommon
+    - PurchasesHybridCommonUI
+    - RevenueCat
+    - RevenueCatUI
     - SocketRocket
     - SSZipArchive
 
@@ -3492,8 +3509,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
-  react-native-add-calendar-event:
-    :path: "../node_modules/react-native-add-calendar-event"
   react-native-blur:
     :path: "../node_modules/@react-native-community/blur"
   react-native-document-picker:
@@ -3586,6 +3601,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-gesture-handler"
   RNKeychain:
     :path: "../node_modules/react-native-keychain"
+  RNPaywalls:
+    :path: "../node_modules/react-native-purchases-ui"
+  RNPurchases:
+    :path: "../node_modules/react-native-purchases"
   RNReactNativeHapticFeedback:
     :path: "../node_modules/react-native-haptic-feedback"
   RNReanimated:
@@ -3618,6 +3637,8 @@ SPEC CHECKSUMS:
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
   lottie-react-native: 691b8363e8c591fb78a78254ff2517258891456b
   op-sqlite: bafff369cecaee4fe65c89eec47deaba26f2db95
+  PurchasesHybridCommon: 825e4e748b62c919bc4cb4032b0d1e452409bd74
+  PurchasesHybridCommonUI: 536abdfc64b82adcbb9ba352630722a4a1270571
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: a41bbdd9af30bf2e5715796b313e44ec43eefff1
   RCTRequired: 7be34aabb0b77c3cefe644528df0fa0afad4e4d0
@@ -3654,7 +3675,6 @@ SPEC CHECKSUMS:
   React-logger: b8483fa08e0d62e430c76d864309d90576ca2f68
   React-Mapbuffer: 7b72a669e94662359dad4f42b5af005eb24b4e83
   React-microtasksnativemodule: cdc02da075f2857803ed63f24f5f72fc40e094c0
-  react-native-add-calendar-event: 4eb42bdf84beb58de81f6d2ce1778a7632223dfe
   react-native-blur: 6af83e7e3c4c1446a188d9b2c493600fc4beb173
   react-native-document-picker: dc2d83366e47e89e7c51e8a41eab99c1d54e941c
   react-native-document-viewer: 8c6ed07e7e27352743fa98e8dd6d288ad925b884
@@ -3695,12 +3715,16 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 0eb286cc274abb059ee601b862ebddac2e681d01
   ReactCodegen: 3d48510bcef445f6403c0004047d4d9cbb915435
   ReactCommon: ac934cb340aee91282ecd6f273a26d24d4c55cae
+  RevenueCat: f3641992451c1426da8d8d1466cec3bbdb765962
+  RevenueCatUI: 32998f100fe73f1d0172df7eef4f0dd1bc781a05
   RNCalendarEvents: f90f73666b6bcbb3cc8a491ffbb5e48c0db3de37
   RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
   RNDeviceInfo: 36d7f232bfe7c9b5c494cb7793230424ed32c388
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
   RNGestureHandler: cd4be101cfa17ea6bbd438710caa02e286a84381
   RNKeychain: a2c134ab796272c3d605e035ab727591000b30f3
+  RNPaywalls: f125e0b623a8ccadbe45e2815ac024bbf9053bb9
+  RNPurchases: ebcfb4effc608048bf2481a413b0bcaa2b6677f7
   RNReactNativeHapticFeedback: be4f1b4bf0398c30b59b76ed92ecb0a2ff3a69c6
   RNReanimated: 292cd58688552a22b3fc1cefcfbc49b336dfed68
   RNScreens: 714e10b6b554f7dc7ad9f78dcf36dc8e3fc73415
@@ -3713,6 +3737,6 @@ SPEC CHECKSUMS:
   whisper-rn: 7566faf9b7d78e39ab9fc634cb90fdee81177793
   Yoga: 5456bb010373068fc92221140921b09d126b116e
 
-PODFILE CHECKSUM: 30f084aba7ca9595d2440626582f30bcd67c6464
+PODFILE CHECKSUM: 88f0d247acf3f66fc1ac0eb9612471f79e7f0cce
 
 COCOAPODS: 1.16.2

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -216,6 +216,24 @@ jest.mock('react-native-keychain', () => ({
   resetGenericPassword: jest.fn(() => Promise.resolve(true)),
 }));
 
+// react-native-purchases mock — the real package loads a native module that
+// is unavailable in the node test env, so any (even transitive / coverage-only)
+// require would throw. Suites that need behaviour override this with a local mock.
+jest.mock('react-native-purchases', () => ({
+  __esModule: true,
+  default: {
+    setLogLevel: jest.fn(),
+    configure: jest.fn(),
+    getCustomerInfo: jest.fn(() => Promise.resolve({ entitlements: { active: {} }, originalAppUserId: 'anon', allPurchaseDates: {} })),
+    restorePurchases: jest.fn(() => Promise.resolve({ entitlements: { active: {} } })),
+    getOfferings: jest.fn(() => Promise.resolve({ all: {}, current: null })),
+    purchasePackage: jest.fn(() => Promise.resolve({ customerInfo: { entitlements: { active: {} } } })),
+    invalidateCustomerInfoCache: jest.fn(() => Promise.resolve()),
+    logOut: jest.fn(() => Promise.resolve()),
+  },
+  LOG_LEVEL: { DEBUG: 'debug', ERROR: 'error' },
+}));
+
 // @react-native-voice/voice mock
 jest.mock('@react-native-voice/voice', () => ({
   start: jest.fn(() => Promise.resolve()),

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,8 @@
         "react-native-image-picker": "^8.2.1",
         "react-native-keychain": "^10.0.0",
         "react-native-linear-gradient": "^2.8.3",
+        "react-native-purchases": "^10.3.0",
+        "react-native-purchases-ui": "^10.3.0",
         "react-native-reanimated": "^4.2.1",
         "react-native-safe-area-context": "^5.6.2",
         "react-native-screens": "^4.20.0",
@@ -4054,6 +4056,27 @@
       "dependencies": {
         "nanoid": "^3.3.11"
       }
+    },
+    "node_modules/@revenuecat/purchases-js": {
+      "version": "1.42.3",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-js/-/purchases-js-1.42.3.tgz",
+      "integrity": "sha512-CkR+Jj0QtsO+SO1AN7stXwJsWGNO33NJEPXkvk//v1ppB0Qff1B3y+022rCo27tJiQHFllR0K78czcUKBrizvg==",
+      "license": "MIT"
+    },
+    "node_modules/@revenuecat/purchases-js-hybrid-mappings": {
+      "version": "18.14.1",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-js-hybrid-mappings/-/purchases-js-hybrid-mappings-18.14.1.tgz",
+      "integrity": "sha512-O5U3h7qsvGFCUG1C4Kmb/CgGwK/zSF5NDXVu2v1AMTlKxXdDU3hpDyC/lesfmSpW8x4qIPeQU+p9wLMY8V68Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@revenuecat/purchases-js": "1.42.3"
+      }
+    },
+    "node_modules/@revenuecat/purchases-typescript-internal": {
+      "version": "18.14.1",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-typescript-internal/-/purchases-typescript-internal-18.14.1.tgz",
+      "integrity": "sha512-A4dn2jxmSVWO7LbjGxHT/tNFH3INKCoM0utu9fPzTtqdi8hd61mPrjBAzBLMCHal4KzCzp8MKRguNCedzLP7qA==",
+      "license": "MIT"
     },
     "node_modules/@ronradtke/react-native-markdown-display": {
       "version": "8.1.0",
@@ -12450,6 +12473,52 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-purchases": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-purchases/-/react-native-purchases-10.3.0.tgz",
+      "integrity": "sha512-PTxp+MbGIIeZomcTcUGiZLw6IzoSd4Vmfpw0Htdxk5axPBS4O+sRXtgScI6rsEe1EwKSqBHSdi4LPQhZgZeAgQ==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/purchaseTesterTypescript",
+        "react-native-purchases-store-galaxy",
+        "react-native-purchases-ui",
+        "e2e-tests/MaestroTestApp"
+      ],
+      "dependencies": {
+        "@revenuecat/purchases-js-hybrid-mappings": "18.14.1",
+        "@revenuecat/purchases-typescript-internal": "18.14.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.6.3",
+        "react-native": ">= 0.73.0",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native-purchases-ui": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-purchases-ui/-/react-native-purchases-ui-10.3.0.tgz",
+      "integrity": "sha512-tMumwPy/tJsdoYdPIDgMiGiGxUSzEevJfW+DGtFX/207PeB5tLF/CQG8/tw+34A+lCZ51JLrMoourEDCDgJvMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@revenuecat/purchases-typescript-internal": "18.14.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">= 0.73.0",
+        "react-native-purchases": "10.3.0",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "react-native-image-picker": "^8.2.1",
     "react-native-keychain": "^10.0.0",
     "react-native-linear-gradient": "^2.8.3",
+    "react-native-purchases": "^10.3.0",
+    "react-native-purchases-ui": "^10.3.0",
     "react-native-reanimated": "^4.2.1",
     "react-native-safe-area-context": "^5.6.2",
     "react-native-screens": "^4.20.0",

--- a/src/bootstrap/loadProFeatures.ts
+++ b/src/bootstrap/loadProFeatures.ts
@@ -3,7 +3,7 @@ import { registerScreen } from '../navigation/screenRegistry';
 import { registerSettingsSection } from '../components/settings/sectionRegistry';
 import { readProFromKeychain } from '../services/proLicenseService';
 
-export async function loadProFeatures(): Promise<void> {
+export async function loadProFeatures(isPro?: boolean): Promise<void> {
   let pro: any;
   try {
     pro = require('@offgrid/pro');
@@ -14,8 +14,10 @@ export async function loadProFeatures(): Promise<void> {
     return; // proStub.js returns null — free build via metro extraNodeModules
   }
 
-  const isPro = await readProFromKeychain();
-  if (!isPro) {
+  // The boot path already read the entitlement in checkProStatus(); reuse it to
+  // avoid a second keychain round-trip. Fall back to a read for standalone callers.
+  const active = isPro ?? (await readProFromKeychain());
+  if (!active) {
     return; // paid features stay dormant until the user purchases
   }
 

--- a/src/bootstrap/loadProFeatures.ts
+++ b/src/bootstrap/loadProFeatures.ts
@@ -1,6 +1,7 @@
 import { registerToolExtension } from '../services/tools/extensions';
 import { registerScreen } from '../navigation/screenRegistry';
 import { registerSettingsSection } from '../components/settings/sectionRegistry';
+import { readProFromKeychain } from '../services/proLicenseService';
 
 export async function loadProFeatures(): Promise<void> {
   let pro: any;
@@ -13,7 +14,10 @@ export async function loadProFeatures(): Promise<void> {
     return; // proStub.js returns null — free build via metro extraNodeModules
   }
 
-  // Run synchronously before any await so screens are registered before the
-  // navigator renders (App.tsx doesn't await loadProFeatures).
+  const isPro = await readProFromKeychain();
+  if (!isPro) {
+    return; // paid features stay dormant until the user purchases
+  }
+
   pro.activate({ registerToolExtension, registerScreen, registerSettingsSection });
 }

--- a/src/config/revenueCatKeys.ts
+++ b/src/config/revenueCatKeys.ts
@@ -1,0 +1,25 @@
+/**
+ * RevenueCat public SDK keys.
+ *
+ * The production iOS/Android keys are intentionally NOT committed. Put the real keys in
+ * your local working copy, then keep them out of git with:
+ *
+ *   git update-index --skip-worktree src/config/revenueCatKeys.ts
+ *
+ * (RevenueCat public SDK keys are not secret — they're extractable from any app binary —
+ * but we keep the production keys out of the open-source repo as a hygiene measure.)
+ *
+ * Get the keys from the RevenueCat dashboard:
+ *   - iOS key starts with 'appl_'
+ *   - Android key starts with 'goog_'
+ */
+export const RC_API_KEY_IOS = 'appl_REPLACE_WITH_IOS_KEY';
+export const RC_API_KEY_ANDROID = 'goog_REPLACE_WITH_ANDROID_KEY';
+
+/**
+ * RevenueCat Test Store key — public, safe to commit. Routes purchases through RC's
+ * simulated store (no App Store / Play Store needed) for local flow testing. Only used
+ * when USE_RC_TEST_STORE is true AND the build is __DEV__, so it can never reach production.
+ */
+export const RC_API_KEY_TEST_STORE = 'test_UDUmOVwoEWFUtYONRUfQOOjVisB';
+export const USE_RC_TEST_STORE = false;

--- a/src/screens/ProDetailScreen/index.tsx
+++ b/src/screens/ProDetailScreen/index.tsx
@@ -25,8 +25,7 @@ function showRestartPrompt(): void {
 }
 
 export const ProDetailScreen: React.FC = () => {
-  const { isDark } = useTheme();
-  const { colors } = useTheme();
+  const { colors, isDark } = useTheme();
   const styles = useThemedStyles(createStyles);
   const hasRegisteredPro = useAppStore((s) => s.hasRegisteredPro);
   const [loading, setLoading] = useState(false);

--- a/src/screens/ProDetailScreen/index.tsx
+++ b/src/screens/ProDetailScreen/index.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { View, Text, TouchableOpacity, ScrollView, Linking, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, ScrollView, Alert, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Icon from 'react-native-vector-icons/Feather';
 import LinearGradient from 'react-native-linear-gradient';
 import { useTheme, useThemedStyles } from '../../theme';
 import type { ThemeColors, ThemeShadows } from '../../theme';
 import { SPACING, TYPOGRAPHY } from '../../constants';
-import { PRO_URL } from '../../utils/proPrompt';
 import { useAppStore } from '../../stores';
+import { presentProPaywall, restorePro, resetProIdentityForTesting } from '../../services/proLicenseService';
 
 const INTEGRATIONS = [
   { icon: 'mic', title: 'Voice', desc: 'Local speech-to-text\nprocessing.' },
@@ -16,15 +16,49 @@ const INTEGRATIONS = [
   { icon: 'message-square', title: 'Messaging', desc: 'Slack,\nTelegram & more.' },
 ];
 
+function showRestartPrompt(): void {
+  Alert.alert(
+    'Pro activated',
+    'Force-close and reopen the app to unlock Pro features.',
+    [{ text: 'OK' }],
+  );
+}
 
 export const ProDetailScreen: React.FC = () => {
-  const { colors, isDark } = useTheme();
+  const { isDark } = useTheme();
+  const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
-  const setHasRegisteredPro = useAppStore((s) => s.setHasRegisteredPro);
+  const hasRegisteredPro = useAppStore((s) => s.hasRegisteredPro);
+  const [loading, setLoading] = useState(false);
 
-  const handleCTA = () => {
-    setHasRegisteredPro(true);
-    Linking.openURL(PRO_URL);
+  const handleGetPro = async () => {
+    setLoading(true);
+    try {
+      const purchased = await presentProPaywall();
+      if (purchased) {
+        showRestartPrompt();
+      }
+    } catch {
+      Alert.alert('Purchase failed', 'Something went wrong. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    setLoading(true);
+    try {
+      const restored = await restorePro();
+      if (restored) {
+        showRestartPrompt();
+      } else {
+        Alert.alert('No purchases found', 'No active Pro subscription was found for this account.');
+      }
+    } catch {
+      Alert.alert('Restore failed', 'Something went wrong. Please try again.');
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -49,9 +83,20 @@ export const ProDetailScreen: React.FC = () => {
             </View>
             <Text style={styles.logoText}>Off Grid Pro</Text>
           </View>
-          <TouchableOpacity style={styles.getProButton} onPress={handleCTA}>
-            <Text style={styles.getProButtonText}>Get Pro</Text>
-          </TouchableOpacity>
+          {hasRegisteredPro ? (
+            <View style={styles.proActiveBadge}>
+              <Icon name="check" size={12} color="#FFFFFF" />
+              <Text style={styles.proActiveBadgeText}>Pro Active</Text>
+            </View>
+          ) : (
+            <TouchableOpacity
+              style={[styles.getProButton, loading && styles.buttonDisabled]}
+              onPress={handleGetPro}
+              disabled={loading}
+            >
+              <Text style={styles.getProButtonText}>{loading ? 'Loading...' : 'Get Pro'}</Text>
+            </TouchableOpacity>
+          )}
         </View>
 
         {/* Hero */}
@@ -134,10 +179,44 @@ export const ProDetailScreen: React.FC = () => {
           </View>
         </View>
 
-        {/* CTA */}
-        <TouchableOpacity style={styles.ctaButton} onPress={handleCTA}>
-          <Text style={styles.ctaText}>I am in 🔥</Text>
-         </TouchableOpacity>
+        {/* CTA / Pro active */}
+        {hasRegisteredPro ? (
+          <>
+            <View style={styles.proActiveCard}>
+              <Icon name="check-circle" size={20} color={colors.primary} />
+              <Text style={styles.proActiveText}>Pro is active on this account.</Text>
+            </View>
+            {__DEV__ && (
+              <TouchableOpacity
+                style={styles.restoreButton}
+                onPress={async () => {
+                  await resetProIdentityForTesting();
+                  Alert.alert('Dev reset', 'RC identity reset. Restart the app to test purchase from scratch.');
+                }}
+              >
+                <Text style={styles.restoreText}>[DEV] Reset Pro identity</Text>
+              </TouchableOpacity>
+            )}
+          </>
+        ) : (
+          <>
+            <TouchableOpacity
+              style={[styles.ctaButton, loading && styles.buttonDisabled]}
+              onPress={handleGetPro}
+              disabled={loading}
+            >
+              <Text style={styles.ctaText}>{loading ? 'Loading...' : 'Get Pro'}</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.restoreButton}
+              onPress={handleRestore}
+              disabled={loading}
+            >
+              <Text style={styles.restoreText}>Restore purchases</Text>
+            </TouchableOpacity>
+          </>
+        )}
 
       </ScrollView>
     </SafeAreaView>
@@ -183,6 +262,16 @@ const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     borderRadius: 20,
   },
   getProButtonText: { ...TYPOGRAPHY.bodySmall, color: '#FFFFFF' },
+  proActiveBadge: {
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    gap: SPACING.xs,
+    backgroundColor: colors.primary,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    borderRadius: 20,
+  },
+  proActiveBadgeText: { ...TYPOGRAPHY.bodySmall, color: '#FFFFFF' },
 
   // Hero
   hero: {
@@ -348,19 +437,48 @@ const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   // CTA
   ctaButton: {
     marginHorizontal: SPACING.xl,
-    marginBottom: SPACING.xl,
+    marginBottom: SPACING.md,
     backgroundColor: colors.primary,
     borderRadius: 12,
     paddingVertical: SPACING.lg,
     flexDirection: 'row' as const,
     alignItems: 'center' as const,
     justifyContent: 'center' as const,
-    gap: SPACING.sm,
   },
   ctaText: {
     ...TYPOGRAPHY.body,
     color: '#FFFFFF',
     letterSpacing: 0.5,
   },
+  restoreButton: {
+    marginHorizontal: SPACING.xl,
+    marginBottom: SPACING.xl,
+    paddingVertical: SPACING.md,
+    alignItems: 'center' as const,
+  },
+  restoreText: {
+    ...TYPOGRAPHY.bodySmall,
+    color: colors.textSecondary,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
 
+  // Pro active state
+  proActiveCard: {
+    marginHorizontal: SPACING.xl,
+    marginBottom: SPACING.xl,
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+    gap: SPACING.sm,
+    paddingVertical: SPACING.lg,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.primary,
+  },
+  proActiveText: {
+    ...TYPOGRAPHY.body,
+    color: colors.primary,
+  },
 });

--- a/src/services/proLicenseService.ts
+++ b/src/services/proLicenseService.ts
@@ -1,14 +1,16 @@
 import { Platform } from 'react-native';
-// @ts-ignore — remove after: npm install react-native-purchases react-native-purchases-ui
 import Purchases, { LOG_LEVEL } from 'react-native-purchases';
-// @ts-ignore
-import RevenueCatUI, { PAYWALL_RESULT } from 'react-native-purchases-ui';
 import * as Keychain from 'react-native-keychain';
+import logger from '../utils/logger';
+import {
+  RC_API_KEY_IOS,
+  RC_API_KEY_ANDROID,
+  RC_API_KEY_TEST_STORE,
+  USE_RC_TEST_STORE,
+} from '../config/revenueCatKeys';
 
 const KEYCHAIN_SERVICE = 'off-grid-pro-license';
-const ENTITLEMENT_ID = 'offgrid Pro';
-const RC_API_KEY_IOS = 'test_UDUmOVwoEWFUtYONRUfQOOjVisB';
-const RC_API_KEY_ANDROID = 'test_UDUmOVwoEWFUtYONRUfQOOjVisB';
+const ENTITLEMENT_ID = 'pro';
 
 type ProLicense = { isPro: boolean; verifiedAt: number };
 
@@ -18,14 +20,24 @@ function setProInStore(isPro: boolean): void {
 }
 
 export function configureRevenueCat(): void {
-  Purchases.setLogLevel(__DEV__ ? LOG_LEVEL.DEBUG : LOG_LEVEL.ERROR);
-  Purchases.configure({
-    apiKey: Platform.OS === 'ios' ? RC_API_KEY_IOS : RC_API_KEY_ANDROID,
-  });
+  try {
+    Purchases.setLogLevel(__DEV__ ? LOG_LEVEL.DEBUG : LOG_LEVEL.ERROR);
+    const useTestStore = __DEV__ && USE_RC_TEST_STORE;
+    const apiKey = useTestStore
+      ? RC_API_KEY_TEST_STORE
+      : Platform.OS === 'ios' ? RC_API_KEY_IOS : RC_API_KEY_ANDROID;
+    logger.log(`[RC] configure platform=${Platform.OS} store=${useTestStore ? 'TEST' : Platform.OS} key=${apiKey.slice(0, 12)}...`);
+    Purchases.configure({ apiKey });
+    logger.log('[RC] configure: SDK configured OK');
+  } catch (e: any) {
+    logger.error(`[RC] configure FAILED: ${e?.message ?? e}`);
+    throw e;
+  }
 }
 
 async function writeLicense(isPro: boolean): Promise<void> {
   const license: ProLicense = { isPro, verifiedAt: Date.now() };
+  logger.log(`[RC] writeLicense isPro=${isPro}`);
   await Keychain.setGenericPassword('license', JSON.stringify(license), {
     service: KEYCHAIN_SERVICE,
     accessible: Keychain.ACCESSIBLE.AFTER_FIRST_UNLOCK,
@@ -35,48 +47,108 @@ async function writeLicense(isPro: boolean): Promise<void> {
 export async function readProFromKeychain(): Promise<boolean> {
   try {
     const result = await Keychain.getGenericPassword({ service: KEYCHAIN_SERVICE });
-    if (!result) return false;
+    if (!result) {
+      logger.log('[RC] readProFromKeychain: no entry found → false');
+      return false;
+    }
     const license: ProLicense = JSON.parse(result.password);
+    const age = Math.round((Date.now() - license.verifiedAt) / 1000);
+    logger.log(`[RC] readProFromKeychain: isPro=${license.isPro} verifiedAt=${license.verifiedAt} age=${age}s`);
     return license.isPro ?? false;
-  } catch {
+  } catch (e: any) {
+    logger.error(`[RC] readProFromKeychain error: ${e?.message ?? e}`);
     return false;
   }
 }
 
 export async function checkProStatus(): Promise<boolean> {
+  logger.log('[RC] checkProStatus: reading keychain...');
   const cached = await readProFromKeychain();
+  logger.log(`[RC] checkProStatus: cached=${cached}, firing background sync`);
   syncWithRevenueCat().catch(() => {});
   return cached;
 }
 
 async function syncWithRevenueCat(): Promise<void> {
   try {
+    logger.log('[RC] syncWithRevenueCat: invalidating cache + fetching...');
+    await Purchases.invalidateCustomerInfoCache();
     const info = await Purchases.getCustomerInfo();
+    const activeKeys = Object.keys(info.entitlements.active);
+    logger.log(`[RC] syncWithRevenueCat: customerID=${info.originalAppUserId}`);
+    logger.log(`[RC] syncWithRevenueCat: activeEntitlements=[${activeKeys.join(', ') || 'none'}]`);
+    logger.log(`[RC] syncWithRevenueCat: allPurchaseDates=${JSON.stringify(info.allPurchaseDates)}`);
     const isPro = info.entitlements.active[ENTITLEMENT_ID] !== undefined;
+    if (isPro) {
+      const ent = info.entitlements.active[ENTITLEMENT_ID];
+      logger.log(`[RC] syncWithRevenueCat: entitlement productID=${ent?.productIdentifier} isSandbox=${ent?.isSandbox} unsubscribeDetected=${ent?.unsubscribeDetectedAt ?? 'null'}`);
+    }
+    logger.log(`[RC] syncWithRevenueCat: isPro=${isPro} → writing to keychain`);
     await writeLicense(isPro);
     setProInStore(isPro);
-  } catch {
-    // No network — cached value stands
+    logger.log('[RC] syncWithRevenueCat: done');
+  } catch (e: any) {
+    logger.error(`[RC] syncWithRevenueCat error: ${e?.message ?? e}`);
   }
 }
 
 export async function presentProPaywall(): Promise<boolean> {
-  const result: PAYWALL_RESULT = await RevenueCatUI.presentPaywall();
-  switch (result) {
-    case PAYWALL_RESULT.PURCHASED:
-    case PAYWALL_RESULT.RESTORED: {
+  try {
+    logger.log('[RC] presentProPaywall: fetching offerings...');
+    const offerings = await Purchases.getOfferings();
+    logger.log(`[RC] presentProPaywall: availableOfferings=[${Object.keys(offerings.all).join(', ')}] current=${offerings.current?.identifier ?? 'none'}`);
+    const offering = offerings.current;
+    if (!offering) {
+      logger.error('[RC] presentProPaywall ABORT: no current offering (set one as current in RC)');
+      throw new Error('No offering available');
+    }
+    logger.log(`[RC] presentProPaywall: using offering=${offering.identifier} packages=${offering.availablePackages.length}`);
+    offering.availablePackages.forEach(p =>
+      logger.log(`[RC]   package=${p.identifier} product=${p.product?.identifier ?? 'NONE'} price=${p.product?.priceString ?? 'NONE'}`),
+    );
+    const pkg = offering.availablePackages[0];
+    if (!pkg) {
+      logger.error('[RC] presentProPaywall ABORT: no package in offering (no store product for this platform — check the package has an Android/iOS product)');
+      throw new Error('No package available');
+    }
+    logger.log(`[RC] presentProPaywall: purchasing package=${pkg.identifier} product=${pkg.product.identifier} price=${pkg.product.priceString}`);
+
+    const { customerInfo } = await Purchases.purchasePackage(pkg);
+    const activeKeys = Object.keys(customerInfo.entitlements.active);
+    logger.log(`[RC] post-purchase activeEntitlements=[${activeKeys.join(', ') || 'none'}]`);
+    const isPro = customerInfo.entitlements.active[ENTITLEMENT_ID] !== undefined;
+    logger.log(`[RC] post-purchase isPro=${isPro} customerID=${customerInfo.originalAppUserId}`);
+    if (isPro) {
+      const ent = customerInfo.entitlements.active[ENTITLEMENT_ID];
+      logger.log(`[RC] post-purchase entitlement isSandbox=${ent?.isSandbox} productID=${ent?.productIdentifier}`);
+    }
+
+    if (isPro) {
       await writeLicense(true);
       setProInStore(true);
       return true;
     }
-    default:
+    return false;
+  } catch (e: any) {
+    if (e?.userCancelled) {
+      logger.log('[RC] presentProPaywall: user cancelled');
       return false;
+    }
+    logger.error(
+      `[RC] presentProPaywall FAILED code=${e?.code} readable=${e?.readableErrorCode ?? 'n/a'} ` +
+      `msg=${e?.message ?? e} underlying=${e?.underlyingErrorMessage ?? 'n/a'}`,
+    );
+    throw e;
   }
 }
 
 export async function restorePro(): Promise<boolean> {
+  logger.log('[RC] restorePro: start');
   const info = await Purchases.restorePurchases();
+  const activeKeys = Object.keys(info.entitlements.active);
+  logger.log(`[RC] restorePro: activeEntitlements=[${activeKeys.join(', ') || 'none'}]`);
   const isPro = info.entitlements.active[ENTITLEMENT_ID] !== undefined;
+  logger.log(`[RC] restorePro: isPro=${isPro}`);
   await writeLicense(isPro);
   setProInStore(isPro);
   return isPro;
@@ -85,4 +157,33 @@ export async function restorePro(): Promise<boolean> {
 export async function clearProForTesting(): Promise<void> {
   await Keychain.resetGenericPassword({ service: KEYCHAIN_SERVICE });
   setProInStore(false);
+}
+
+export async function resetProIdentityForTesting(): Promise<void> {
+  logger.log('[RC] resetProIdentityForTesting: start');
+  logger.log('[RC] resetProIdentityForTesting: invalidating RC cache...');
+  await Purchases.invalidateCustomerInfoCache();
+  try {
+    const before = await Purchases.getCustomerInfo();
+    const isAnonymous = before.originalAppUserId.startsWith('$RCAnonymousID:');
+    logger.log(`[RC] resetProIdentityForTesting: customerID before=${before.originalAppUserId} anonymous=${isAnonymous}`);
+    logger.log(`[RC] resetProIdentityForTesting: entitlements before=[${Object.keys(before.entitlements.active).join(', ') || 'none'}]`);
+    logger.log(`[RC] resetProIdentityForTesting: allPurchases before=${JSON.stringify(before.allPurchaseDates)}`);
+    // logOut only works for identified users. Anonymous users can only be reset
+    // by deleting the app (which clears the anonymous ID from UserDefaults).
+    if (!isAnonymous) {
+      await Purchases.logOut();
+      await Purchases.invalidateCustomerInfoCache();
+      const after = await Purchases.getCustomerInfo();
+      logger.log(`[RC] resetProIdentityForTesting: logOut done, customerID after=${after.originalAppUserId}`);
+    } else {
+      logger.log('[RC] resetProIdentityForTesting: anonymous user — skipping logOut (delete the app to get a fresh ID)');
+    }
+  } catch (e: any) {
+    logger.error(`[RC] resetProIdentityForTesting: ${e?.message ?? e} — continuing`);
+  }
+  logger.log('[RC] resetProIdentityForTesting: clearing keychain...');
+  await Keychain.resetGenericPassword({ service: KEYCHAIN_SERVICE });
+  setProInStore(false);
+  logger.log('[RC] resetProIdentityForTesting: done');
 }

--- a/src/services/proLicenseService.ts
+++ b/src/services/proLicenseService.ts
@@ -12,6 +12,12 @@ import {
 const KEYCHAIN_SERVICE = 'off-grid-pro-license';
 const ENTITLEMENT_ID = 'pro';
 
+// react-native-purchases only ships native modules for iOS and Android. On any
+// other platform (e.g. React Native Web) configure is skipped and this stays
+// false, so the RC-backed entry points below no-op or fail loudly instead of
+// throwing native "module not found" errors.
+let isConfigured = false;
+
 type ProLicense = { isPro: boolean; verifiedAt: number };
 
 function setProInStore(isPro: boolean): void {
@@ -20,6 +26,10 @@ function setProInStore(isPro: boolean): void {
 }
 
 export function configureRevenueCat(): void {
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
+    logger.log(`[RC] configure skipped: unsupported platform ${Platform.OS}`);
+    return;
+  }
   try {
     Purchases.setLogLevel(__DEV__ ? LOG_LEVEL.DEBUG : LOG_LEVEL.ERROR);
     const useTestStore = __DEV__ && USE_RC_TEST_STORE;
@@ -28,6 +38,7 @@ export function configureRevenueCat(): void {
       : Platform.OS === 'ios' ? RC_API_KEY_IOS : RC_API_KEY_ANDROID;
     logger.log(`[RC] configure platform=${Platform.OS} store=${useTestStore ? 'TEST' : Platform.OS} key=${apiKey.slice(0, 12)}...`);
     Purchases.configure({ apiKey });
+    isConfigured = true;
     logger.log('[RC] configure: SDK configured OK');
   } catch (e: any) {
     logger.error(`[RC] configure FAILED: ${e?.message ?? e}`);
@@ -79,6 +90,10 @@ export async function checkProStatus(): Promise<boolean> {
 }
 
 async function syncWithRevenueCat(): Promise<void> {
+  if (!isConfigured) {
+    logger.log('[RC] syncWithRevenueCat skipped: SDK not configured');
+    return;
+  }
   try {
     logger.log('[RC] syncWithRevenueCat: invalidating cache + fetching...');
     await Purchases.invalidateCustomerInfoCache();
@@ -102,6 +117,10 @@ async function syncWithRevenueCat(): Promise<void> {
 }
 
 export async function presentProPaywall(): Promise<boolean> {
+  if (!isConfigured) {
+    logger.error('[RC] presentProPaywall ABORT: SDK not configured');
+    throw new Error('RevenueCat is not configured');
+  }
   try {
     logger.log('[RC] presentProPaywall: fetching offerings...');
     const offerings = await Purchases.getOfferings();
@@ -156,6 +175,10 @@ export async function presentProPaywall(): Promise<boolean> {
 }
 
 export async function restorePro(): Promise<boolean> {
+  if (!isConfigured) {
+    logger.error('[RC] restorePro ABORT: SDK not configured');
+    throw new Error('RevenueCat is not configured');
+  }
   logger.log('[RC] restorePro: start');
   const info = await Purchases.restorePurchases();
   const activeKeys = Object.keys(info.entitlements.active);
@@ -173,6 +196,10 @@ export async function clearProForTesting(): Promise<void> {
 }
 
 export async function resetProIdentityForTesting(): Promise<void> {
+  if (!isConfigured) {
+    logger.log('[RC] resetProIdentityForTesting skipped: SDK not configured');
+    return;
+  }
   logger.log('[RC] resetProIdentityForTesting: start');
   logger.log('[RC] resetProIdentityForTesting: invalidating RC cache...');
   await Purchases.invalidateCustomerInfoCache();

--- a/src/services/proLicenseService.ts
+++ b/src/services/proLicenseService.ts
@@ -38,10 +38,19 @@ export function configureRevenueCat(): void {
 async function writeLicense(isPro: boolean): Promise<void> {
   const license: ProLicense = { isPro, verifiedAt: Date.now() };
   logger.log(`[RC] writeLicense isPro=${isPro}`);
-  await Keychain.setGenericPassword('license', JSON.stringify(license), {
-    service: KEYCHAIN_SERVICE,
-    accessible: Keychain.ACCESSIBLE.AFTER_FIRST_UNLOCK,
-  });
+  try {
+    await Keychain.setGenericPassword('license', JSON.stringify(license), {
+      service: KEYCHAIN_SERVICE,
+      accessible: Keychain.ACCESSIBLE.AFTER_FIRST_UNLOCK,
+    });
+  } catch (e) {
+    // A keychain write failure (locked keychain, unsupported platform) must not
+    // surface as a "Purchase failed"/"Restore failed" after the user was charged.
+    // The entitlement is still live on RevenueCat and the next background sync
+    // re-writes the cache, so log and continue rather than throwing.
+    const message = e instanceof Error ? e.message : String(e);
+    logger.error(`[RC] writeLicense failed to persist to keychain: ${message}`);
+  }
 }
 
 export async function readProFromKeychain(): Promise<boolean> {
@@ -106,7 +115,11 @@ export async function presentProPaywall(): Promise<boolean> {
     offering.availablePackages.forEach(p =>
       logger.log(`[RC]   package=${p.identifier} product=${p.product?.identifier ?? 'NONE'} price=${p.product?.priceString ?? 'NONE'}`),
     );
-    const pkg = offering.availablePackages[0];
+    // Prefer the lifetime package explicitly. Relying on availablePackages[0] is
+    // fragile: RC can reorder packages or add new ones (monthly/yearly) later.
+    const pkg =
+      offering.availablePackages.find(p => p.identifier === '$rc_lifetime') ??
+      offering.availablePackages[0];
     if (!pkg) {
       logger.error('[RC] presentProPaywall ABORT: no package in offering (no store product for this platform — check the package has an Android/iOS product)');
       throw new Error('No package available');


### PR DESCRIPTION
## What
Wires the RevenueCat-backed Pro license flow and a single cross-platform offering, and hardens the boot/purchase path per code review.

## Changes
- Configure RevenueCat at app boot and gate the `pro` entitlement before loading Pro features; the entitlement is cached in the keychain and refreshed via a background sync.
- Purchase directly through `offerings.current`, selecting the `$rc_lifetime` package explicitly (with a first-package fallback) so one **Lifetime** package serves the App Store, Play Store, and Web products.
- Public SDK keys moved to `src/config/revenueCatKeys.ts` with placeholders committed; real keys are kept local-only (gitignored), matching the existing test-store-key convention.
- Added a global `react-native-purchases` Jest mock plus unit and integration tests covering configure → check → purchase → entitlement → unlock.

## Robustness (review hardening)
- Pro initialization in `App.tsx` is isolated in its own `try/catch`, so an RC failure (missing native module, locked keychain, bad config) can never abort app init or hang the splash screen.
- `react-native-purchases` only ships native modules for iOS/Android. `configureRevenueCat` now skips unsupported platforms (e.g. web) and tracks an `isConfigured` flag; `presentProPaywall`/`restorePro` fail loudly and `syncWithRevenueCat`/`resetProIdentityForTesting` no-op when the SDK was never configured.
- Keychain writes no longer throw out of `writeLicense`: a persist failure after a successful charge is logged and swallowed (the entitlement is still live on RC and the next sync re-writes the cache) instead of surfacing a bogus "Purchase failed"/"Restore failed".
- `loadProFeatures` accepts the pre-read entitlement from `checkProStatus()` to avoid a redundant keychain read on boot.

## RevenueCat dashboard (already configured)
- Entitlement `pro` linked to App Store, Play Store, and Web products.
- `default` offering (current) with one `$rc_lifetime` package containing all three store products.

## Testing
- `tsc --noEmit` clean; `eslint` clean; full Jest suite green (188 suites, 5555 tests).
- Pro source coverage: `proLicenseService.ts` ~99%, `ProDetailScreen` 100%, `loadProFeatures` 100% — including the new guard, keychain-failure, package-fallback, and platform-skip branches.
- iOS: verified a real local StoreKit purchase (lifetime) granting the `pro` entitlement in RevenueCat.
- Android: verified the RC Test Store flow end to end; real Play sandbox is pending internal-track upload + license-tester setup.

## Notes
- No secret keys committed — only public SDK keys (placeholders) plus the public test-store key.
- The `[DEV] Reset Pro identity` control and the Test Store key are gated behind `__DEV__`, so they never ship in release builds.
- React Native Web is not a build target in this PR (the service no-ops there); a dedicated web SDK key/branch will land with the web workstream.
