### PR TITLE
fix: disable persistent file logging to stop UI stalls/ANRs

### DIFF
--- a/src/stores/remoteModelCapabilities.ts
+++ b/src/stores/remoteModelCapabilities.ts
@@ -43,10 +43,25 @@ function extractOllamaCapabilities(data: Record<string, unknown>): RemoteModelIn
   let contextLength = 4096;
   let supportsVision = false;
 
+  // Newer Ollama versions expose a top-level `capabilities` array (e.g. ["vision", "tools"]).
+  // Gemma 4 and similar models use this field instead of model_info keys.
+  let supportsToolCalling: boolean | undefined;
+  if (Array.isArray(data.capabilities)) {
+    const caps = data.capabilities as unknown[];
+    supportsVision = caps.includes('vision');
+    supportsToolCalling = caps.includes('tools');
+  }
+
   if (data.model_info && typeof data.model_info === 'object') {
     const parsed = parseModelInfoKeys(data.model_info as Record<string, unknown>);
     if (parsed.contextLength > 0) contextLength = parsed.contextLength;
-    supportsVision = parsed.supportsVision;
+    if (!supportsVision) supportsVision = parsed.supportsVision;
+  }
+
+  // projector_info is present for multimodal models when capabilities array is missing.
+  if (!supportsVision && data.projector_info && typeof data.projector_info === 'object') {
+    const projectorKeys = Object.keys(data.projector_info as Record<string, unknown>);
+    supportsVision = projectorKeys.some(k => k.includes('vision') || k.includes('clip'));
   }
 
   if (contextLength === 4096 && typeof data.parameters === 'string') {
@@ -63,7 +78,7 @@ function extractOllamaCapabilities(data: Record<string, unknown>): RemoteModelIn
     /\.Think|\.Thinking|\.IsThinkSet/.test(template) ||
     /^RENDERER\s/m.test(modelfile);
 
-  return { contextLength, supportsVision, supportsThinking };
+  return { contextLength, supportsVision, supportsToolCalling, supportsThinking };
 }
 
 /**

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,72 +1,13 @@
-import RNFS from 'react-native-fs';
-
-const LOG_FILE_NAME = 'download-debug.log';
-const MAX_LOG_FILE_BYTES = 2 * 1024 * 1024;
-const RETAINED_LOG_LINES = 4000;
-
-let writeQueue = Promise.resolve();
-
-function getLogFilePath(): string {
-  return `${RNFS.DocumentDirectoryPath}/${LOG_FILE_NAME}`;
-}
-
-function formatArg(arg: unknown): string {
-  if (arg instanceof Error) {
-    return `${arg.name}: ${arg.message}${arg.stack ? `\n${arg.stack}` : ''}`;
-  }
-  if (typeof arg === 'string') return arg;
-  if (typeof arg === 'number' || typeof arg === 'boolean' || arg == null) return String(arg);
-  try {
-    return JSON.stringify(arg);
-  } catch {
-    return String(arg);
-  }
-}
-
-function appendPersistentLog(level: 'log' | 'warn' | 'error', args: unknown[]): void {
-  const timestamp = new Date().toISOString();
-  const line = `[${timestamp}] ${level.toUpperCase()}: ${args.map(formatArg).join(' ')}\n`;
-
-  writeQueue = writeQueue.then(async () => {
-    try {
-      const path = getLogFilePath();
-      if (await RNFS.exists(path)) {
-        await RNFS.appendFile(path, line, 'utf8');
-      } else {
-        await RNFS.writeFile(path, line, 'utf8');
-      }
-
-      const stat = await RNFS.stat(path);
-      const size = typeof stat.size === 'string' ? Number.parseInt(stat.size, 10) : stat.size;
-      if (size > MAX_LOG_FILE_BYTES) {
-        const content = await RNFS.readFile(path, 'utf8');
-        const trimmed = content.split('\n').filter(Boolean).slice(-RETAINED_LOG_LINES).join('\n');
-        await RNFS.writeFile(path, trimmed ? `${trimmed}\n` : '', 'utf8');
-      }
-    } catch {
-      // Logging must never break app execution.
-    }
-  });
-}
-
-function capture(level: 'log' | 'warn' | 'error', args: unknown[]): void {
-  appendPersistentLog(level, args);
-}
-
 const logger = {
   log: (...args: unknown[]): void => {
-    capture('log', args);
     if (__DEV__) console.log(...args); // NOSONAR
   },
   warn: (...args: unknown[]): void => {
-    capture('warn', args);
     if (__DEV__) console.warn(...args); // NOSONAR
   },
   error: (...args: unknown[]): void => {
-    capture('error', args);
     if (__DEV__) console.error(...args); // NOSONAR
   },
-  getLogFilePath,
 };
 
 export default logger;


### PR DESCRIPTION
## What

Two fixes in this PR:

**1. Disable persistent file logging (stops UI stalls/ANRs)**

`logger.*` is now a no-op in release builds (dev still mirrors to the console) — effectively a revert to the pre-0.0.88 logger behavior.

**2. Fix Ollama vision capability detection for newer models (Gemma 4, etc.)**

Models pulled from Ollama v0.6.4+ (released April 2025) report vision support via a top-level `capabilities` array rather than `model_info` keys. The old detection only checked `model_info`, so models like `gemma4` were never detected as vision-capable and the image attachment button would not appear.

---

## Why

**Logger:**
In 0.0.88+ the logger was changed so `capture()` ran on **every** `logger.log/warn/error` call without a `__DEV__` guard. In production that meant each call did:
- a synchronous `JSON.stringify` / string build on the JS thread, then
- a `react-native-fs` append (plus a periodic full-file read + 2MB trim) on a serial write queue.

With ~480 call sites concentrated in hot paths (tool loop, LiteRT, downloads, whisper), this contended with the bridge and is a strong contributor to reported UI freezes / 20s+ button lag / ANRs. Nothing reads the log file — it was write-only.

**Vision detection:**
Ollama PR #10066 (v0.6.4, April 2025) added a top-level `capabilities` array to `/api/show`. Newer model formats like Gemma 4 only populate this array — they don't put clip/vision keys in `model_info`. Our code only knew about the old location, so these models were always detected as non-vision.

---

## Changes

**`src/utils/logger.ts`** — remove `appendPersistentLog` / `formatArg` / the write-queue / the 2MB-trim and the `react-native-fs` dependency. `logger.*` is a pure console wrapper, no-op in release.

**`src/stores/remoteModelCapabilities.ts`** — check `capabilities` array first, fall back to `model_info` key scan, then `projector_info` keys. Also wires `supportsToolCalling` from the `capabilities` array.

Both changes are deliberately minimal and safe for an immediate release.

---

## Testing

- `eslint` clean on changed files.
- All logger consumers mock the logger; full related test suite (127 suites) passes.
- `remoteModelCapabilities` unit tests: 25/25 pass.
- Vision detection verified end-to-end on device against a live Ollama server with `huihui_ai/gemma-4-abliterated:12b`.