### PR TITLE
docs: fix expired Slack invite links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![App Store](https://img.shields.io/badge/App%20Store-Download-blue?logo=apple)](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882)
 [![Platform](https://img.shields.io/badge/Platform-Android%20%7C%20iOS%20%7C%20macOS-green.svg)](#install)
 [![codecov](https://codecov.io/gh/alichherawalla/off-grid-mobile/graph/badge.svg)](https://codecov.io/gh/alichherawalla/off-grid-mobile)
-[![Slack](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack)](https://join.slack.com/t/off-grid-mobile/shared_invite/zt-3q7kj5gr6-rVzx5gl5LKPQh4mUE2CCvA)
+[![Slack](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack)](https://join.slack.com/t/off-grid-mobile/shared_invite/zt-411pbtz7r-lcOK4YCeY40vh_~FUdcvLA)
 [![Pro](https://img.shields.io/badge/Off%20Grid%20Pro-%2450%20lifetime-000000?style=flat)](https://offgridmobileai.co/pay/)
 
 </div>
@@ -183,7 +183,7 @@ This project is tested with BrowserStack.
 
 ## Community
 
-Join the conversation on [**Slack**](https://join.slack.com/t/off-grid-mobile/shared_invite/zt-3q7kj5gr6-rVzx5gl5LKPQh4mUE2CCvA) — ask questions, share feedback, and connect with other Off Grid users and contributors.
+Join the conversation on [**Slack**](https://join.slack.com/t/off-grid-mobile/shared_invite/zt-411pbtz7r-lcOK4YCeY40vh_~FUdcvLA) — ask questions, share feedback, and connect with other Off Grid users and contributors.
 
 ---
 


### PR DESCRIPTION
## Problem
PR #410 updated only **one of the three** Slack invite links in the README — the footer link (line 214) got the new invite `zt-411pbtz7r`, while the badge (line 17) and the inline link (line 186) were left on the old, now-expired invite `zt-3q7kj5gr6`.

Result: clicking the badge or the inline link gave "This link has expired," while copy-pasting the footer link worked. Same README, two different invites.

## Fix
Point all three links at the current invite (`zt-411pbtz7r`) so every Slack entry point in the README resolves to the same live invite.

## Note on link longevity
This only fixes the README pointing at the right invite. Whether that invite stays valid is controlled in Slack's admin settings — the invite should be generated with **no time expiry** and a high/unlimited max-signups so it doesn't lapse after 30 days or N joins. Verify it loads in an incognito window before relying on it.