### PR TITLE
fix(whisper): repair Android download verification and live Download Manager visibility

### DIFF
--- a/__tests__/unit/services/whisperService.test.ts
+++ b/__tests__/unit/services/whisperService.test.ts
@@ -19,6 +19,15 @@ jest.mock('../../../src/services/backgroundDownloadService', () => ({
   },
 }));
 
+// Names prefixed with `mock` so jest.mock's hoisting allows referencing them.
+const mockDownloadStoreAdd = jest.fn();
+const mockDownloadStoreRemove = jest.fn();
+jest.mock('../../../src/stores/downloadStore', () => ({
+  useDownloadStore: {
+    getState: () => ({ add: mockDownloadStoreAdd, remove: mockDownloadStoreRemove }),
+  },
+}));
+
 const mockedBDS = backgroundDownloadService as jest.Mocked<typeof backgroundDownloadService>;
 const mockedAudioSessionIos = AudioSessionIos as jest.Mocked<typeof AudioSessionIos>;
 
@@ -171,6 +180,52 @@ describe('WhisperService', () => {
 
       await expect(whisperService.downloadModel('tiny.en')).rejects.toThrow('network_lost');
       expect(RNFS.unlink).toHaveBeenCalledWith('/mock/documents/whisper-models/ggml-tiny.en.bin');
+    });
+
+    it('registers the in-flight download in the download store so it shows live, then clears it on completion', async () => {
+      mockedRNFS.exists
+        .mockResolvedValueOnce(true)  // dir exists
+        .mockResolvedValueOnce(false) // model not yet downloaded
+        .mockResolvedValueOnce(true); // validateModelFile: file exists
+      mockedRNFS.stat.mockResolvedValueOnce({ size: 75 * 1024 * 1024, isFile: () => true } as any);
+      mockedBDS.downloadFileTo.mockReturnValue({
+        downloadId: 7,
+        downloadIdPromise: Promise.resolve(7),
+        promise: Promise.resolve(),
+      } as any);
+
+      await whisperService.downloadModel('tiny.en');
+
+      // Registered as an STT entry keyed by whisper-<id>/<fileName> so the
+      // Download Manager renders it under Voice while in flight (issue: STT
+      // downloads were invisible until a screen switch re-scanned disk).
+      expect(mockDownloadStoreAdd).toHaveBeenCalledWith(expect.objectContaining({
+        modelKey: 'whisper-tiny.en/ggml-tiny.en.bin',
+        downloadId: 7,
+        modelId: 'whisper-tiny.en',
+        fileName: 'ggml-tiny.en.bin',
+        modelType: 'stt',
+        status: 'pending',
+      }));
+      // Cleared on success — completed STT models are listed from disk instead.
+      expect(mockDownloadStoreRemove).toHaveBeenCalledWith('whisper-tiny.en/ggml-tiny.en.bin');
+    });
+
+    it('clears the download store entry even when the download fails', async () => {
+      mockedRNFS.exists
+        .mockResolvedValueOnce(true)  // dir exists
+        .mockResolvedValueOnce(false); // model not yet downloaded
+      mockedRNFS.unlink.mockResolvedValue(undefined as any);
+      mockedBDS.downloadFileTo.mockReturnValue({
+        downloadId: 8,
+        downloadIdPromise: Promise.resolve(8),
+        promise: Promise.reject(new Error('network_lost')),
+      } as any);
+
+      await expect(whisperService.downloadModel('tiny.en')).rejects.toThrow('network_lost');
+
+      expect(mockDownloadStoreAdd).toHaveBeenCalled();
+      expect(mockDownloadStoreRemove).toHaveBeenCalledWith('whisper-tiny.en/ggml-tiny.en.bin');
     });
   });
 

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -154,14 +154,6 @@ class WorkerDownload(
         }
     }
 
-    private fun calculateTotalBytes(code: Int, currentFileBytes: Long, contentLength: Long, existingTotal: Long): Long {
-        return when (code) {
-            206 -> currentFileBytes + contentLength
-            200 -> contentLength
-            else -> maxOf(existingTotal, contentLength)
-        }.coerceAtLeast(existingTotal)
-    }
-
     private suspend fun streamToFile(params: StreamParams): Result {
         val (input, targetFile, code, download, downloadId, currentFileBytes, totalBytes, progressInterval) = params
         val appendMode = targetFile.exists() && code == 206
@@ -283,6 +275,27 @@ class WorkerDownload(
         const val KEY_PROGRESS = "progress"
         const val KEY_TOTAL = "total"
         const val KEY_PROGRESS_INTERVAL = "progress_interval"
+
+        /**
+         * The authoritative total size for the download. A successful response's
+         * Content-Length is the source of truth and MUST win over the caller's
+         * seeded estimate.
+         *
+         * Callers seed `existingTotal` only so progress can render before the first
+         * byte arrives — and some (e.g. Whisper) seed it from a rounded MB figure
+         * (`sizeMB * 1024 * 1024`) that never equals the exact byte count. Clamping
+         * the real Content-Length UP to that rounded estimate made the completion
+         * size check (which tolerates only a 0.1% delta) reject every such file as
+         * FILE_CORRUPTED when no SHA-256 was available to vouch for it. Fall back to
+         * the seeded estimate only when the server reports no length (<= 0).
+         */
+        internal fun calculateTotalBytes(code: Int, currentFileBytes: Long, contentLength: Long, existingTotal: Long): Long {
+            return when (code) {
+                206 -> if (contentLength > 0L) currentFileBytes + contentLength else existingTotal
+                200 -> if (contentLength > 0L) contentLength else existingTotal
+                else -> maxOf(existingTotal, contentLength)
+            }
+        }
 
         internal fun computeFileSha256(file: File): String {
             val digest = MessageDigest.getInstance("SHA-256")

--- a/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
+++ b/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
@@ -209,5 +209,76 @@ class DownloadManagerModuleTest {
         assertEquals("queued", retryQueuedStatus.name.lowercase())
     }
 
+    // ── WorkerDownload.calculateTotalBytes ────────────────────────────────────
+
+    @Test
+    fun calculateTotalBytesUsesServerContentLengthOn200() {
+        // A fresh 200 download: the server's Content-Length is authoritative.
+        val total = WorkerDownload.calculateTotalBytes(
+            code = 200,
+            currentFileBytes = 0L,
+            contentLength = 77_704_715L,
+            existingTotal = 0L,
+        )
+        assertEquals(77_704_715L, total)
+    }
+
+    @Test
+    fun calculateTotalBytesDoesNotClampRealLengthUpToSeededEstimate() {
+        // Regression: Whisper seeds existingTotal from a rounded MB figure
+        // (75 * 1024 * 1024 = 78_643_200) while the real file is 77_704_715 bytes.
+        // The old code did .coerceAtLeast(existingTotal), inflating the expected
+        // size to the rounded seed; the completion size check (0.1% tolerance) then
+        // deleted every Whisper model as FILE_CORRUPTED. The real Content-Length
+        // must win so actual == expected and validation passes.
+        val seeded = 75L * 1024L * 1024L
+        val total = WorkerDownload.calculateTotalBytes(
+            code = 200,
+            currentFileBytes = 0L,
+            contentLength = 77_704_715L,
+            existingTotal = seeded,
+        )
+        assertEquals(77_704_715L, total)
+        assertTrue("real length must not be inflated to the seeded estimate", total < seeded)
+    }
+
+    @Test
+    fun calculateTotalBytesFallsBackToSeededEstimateWhenServerOmitsLength() {
+        // OkHttp returns -1 from contentLength() when the server sends no length.
+        // Only then do we fall back to the caller's seeded estimate.
+        val seeded = 78_643_200L
+        val total = WorkerDownload.calculateTotalBytes(
+            code = 200,
+            currentFileBytes = 0L,
+            contentLength = -1L,
+            existingTotal = seeded,
+        )
+        assertEquals(seeded, total)
+    }
+
+    @Test
+    fun calculateTotalBytesAddsExistingBytesForRangedResume() {
+        // 206 Partial Content: total = bytes already on disk + remaining length.
+        val total = WorkerDownload.calculateTotalBytes(
+            code = 206,
+            currentFileBytes = 10_000_000L,
+            contentLength = 67_704_715L,
+            existingTotal = 0L,
+        )
+        assertEquals(77_704_715L, total)
+    }
+
+    @Test
+    fun calculateTotalBytesResumeFallsBackToSeededEstimateWhenLengthMissing() {
+        val seeded = 77_704_715L
+        val total = WorkerDownload.calculateTotalBytes(
+            code = 206,
+            currentFileBytes = 10_000_000L,
+            contentLength = -1L,
+            existingTotal = seeded,
+        )
+        assertEquals(seeded, total)
+    }
+
 }
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -44,7 +44,7 @@ import {
   RootStackParamList,
   MainTabParamList,
 } from './types';
-import { getRegisteredScreens } from './screenRegistry';
+import { useRegisteredScreens } from './screenRegistry';
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator<MainTabParamList>();
@@ -192,6 +192,9 @@ export const AppNavigator: React.FC = () => {
   const hasCompletedOnboarding = useAppStore((s) => s.hasCompletedOnboarding);
   const downloadedModels = useAppStore((s) => s.downloadedModels);
   const steps = useMemo(() => createSpotlightSteps(), []);
+  // Reactive: screens registered at runtime (Pro activation re-runs loadProFeatures)
+  // mount as real routes live, so navigate('McpServers') works without an app restart.
+  const registeredScreens = useRegisteredScreens();
 
   // Determine initial route
   let initialRoute: keyof RootStackParamList = 'Onboarding';
@@ -255,7 +258,7 @@ export const AppNavigator: React.FC = () => {
           component={GalleryScreen}
           options={{ presentation: 'modal', animation: 'slide_from_bottom' }}
         />
-        {getRegisteredScreens().map(s => (
+        {registeredScreens.map(s => (
           <RootStack.Screen key={s.name} name={s.name as any} component={s.component} />
         ))}
       </RootStack.Navigator>

--- a/src/navigation/screenRegistry.ts
+++ b/src/navigation/screenRegistry.ts
@@ -5,11 +5,19 @@ export interface RegisteredScreen {
   component: ComponentType<any>;
 }
 
-const screens: RegisteredScreen[] = [];
+// Immutable list: registerScreen replaces the array with a new reference, so
+// useSyncExternalStore detects a change by identity — no version counter needed.
+// Mirrors slotRegistry, where useSlot's snapshot is a value that changes.
+let screens: RegisteredScreen[] = [];
 const listeners = new Set<() => void>();
 
 function emitChange(): void {
   for (const l of listeners) l();
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => listeners.delete(onStoreChange);
 }
 
 export function registerScreen(screen: RegisteredScreen): void {
@@ -18,7 +26,7 @@ export function registerScreen(screen: RegisteredScreen): void {
   // crash the navigator (the duplicate-screen render bug). First wins. Mirrors
   // the guard in sectionRegistry.
   if (screens.some(s => s.name === screen.name)) return;
-  screens.push(screen);
+  screens = [...screens, screen];
   emitChange();
 }
 
@@ -33,16 +41,21 @@ export function getRegisteredScreens(): RegisteredScreen[] {
  * the consumer re-render. Mirrors useSlot in slotRegistry.
  */
 export function useHasRegisteredScreen(name: string): boolean {
-  return useSyncExternalStore(
-    (onStoreChange) => {
-      listeners.add(onStoreChange);
-      return () => listeners.delete(onStoreChange);
-    },
-    () => screens.some(s => s.name === name),
-  );
+  return useSyncExternalStore(subscribe, () => screens.some(s => s.name === name));
+}
+
+/**
+ * Reactive read of the full registered-screen list. The navigator subscribes via
+ * useSyncExternalStore so a screen registered AFTER it mounted — Pro activated at
+ * runtime, which re-runs loadProFeatures — re-renders the navigator and mounts the
+ * route live, with no app restart. This is what makes navigate('McpServers') work
+ * the instant a license activates.
+ */
+export function useRegisteredScreens(): RegisteredScreen[] {
+  return useSyncExternalStore(subscribe, () => screens);
 }
 
 export function _clearScreensForTesting(): void {
-  screens.length = 0;
+  screens = [];
   emitChange();
 }

--- a/src/screens/ChatScreen/ChatMessageArea.tsx
+++ b/src/screens/ChatScreen/ChatMessageArea.tsx
@@ -19,6 +19,7 @@ import { useAppStore } from '../../stores';
 import { getToolExtensions } from '../../services/tools/extensions';
 import { AVAILABLE_TOOLS } from '../../services/tools';
 import { useOpenProTools } from '../../hooks/useOpenProTools';
+import { useIsProActive } from '../../hooks/useIsProActive';
 import { getSlot, SLOTS } from '../../bootstrap/slotRegistry';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -76,6 +77,13 @@ export const ChatMessageArea: React.FC<ChatMessageAreaProps> = ({
   const interfaceMode = useUiModeStore((s) => s.interfaceMode);
   const tabNav = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { toolCountHintDismissed } = useAppStore();
+  // Subscribe to Pro activation so this re-renders the moment a license is
+  // activated. loadProFeatures() registers the tool extensions + the Pro Tools
+  // screen in one pass; without this subscription the getToolExtensions() reads
+  // below are non-reactive and the Pro Tools badge stayed stale until an app
+  // restart. Return is intentionally unused — the count is naturally 0 when Pro
+  // is inactive (no extensions registered); we only need the re-render.
+  useIsProActive();
   // extToolCount is the live MCP tool count (the email/calendar extension reports 0
   // here because those live in settings.enabledTools — see EmailCalendarExtension).
   const extToolCount = getToolExtensions().reduce((n, e) => n + e.enabledToolCount(), 0);

--- a/src/services/whisperService.ts
+++ b/src/services/whisperService.ts
@@ -3,6 +3,8 @@ import { Platform, PermissionsAndroid } from 'react-native';
 import RNFS from 'react-native-fs';
 import logger from '../utils/logger';
 import { backgroundDownloadService } from './backgroundDownloadService';
+import { useDownloadStore } from '../stores/downloadStore';
+import { makeModelKey } from '../utils/modelKey';
 
 export interface TranscriptionResult {
   text: string;
@@ -55,6 +57,11 @@ class WhisperService {
     if (await RNFS.exists(destPath)) return destPath;
     logger.log(`[Whisper] Downloading ${model.name} via background download service...`);
     const fileName = `ggml-${modelId}.bin`;
+    // WHISPER_MODELS sizes are in MB; seed totalBytes so progress renders before
+    // the first byte arrives. The native layer refines this from the server's
+    // Content-Length once the download starts.
+    const totalBytes = model.size * 1024 * 1024;
+    const modelKey = makeModelKey(`whisper-${modelId}`, fileName);
     const { downloadIdPromise, promise } = backgroundDownloadService.downloadFileTo({
       params: {
         url: model.url,
@@ -64,34 +71,57 @@ class WhisperService {
         // download under Voice. Without it the entry defaulted to 'text' and
         // STT models showed up under Text (and never under the Voice filter).
         modelType: 'stt',
-        // WHISPER_MODELS sizes are in MB; seed totalBytes so progress renders
-        // before the first byte arrives. The native layer refines this from the
-        // server's Content-Length once the download starts.
-        totalBytes: model.size * 1024 * 1024,
+        totalBytes,
       },
       destPath,
       onProgress: onProgress
-        ? (bytesDownloaded, totalBytes) => {
-            onProgress(totalBytes > 0 ? bytesDownloaded / totalBytes : 0);
+        ? (bytesDownloaded, total) => {
+            onProgress(total > 0 ? bytesDownloaded / total : 0);
           }
         : undefined,
       silent: true,
     });
     try {
-      this.activeDownloadId = await downloadIdPromise;
-      await promise;
-    } catch (error) {
-      logger.error('[Whisper] Download failed:', error);
-      await RNFS.unlink(destPath).catch(() => {});
-      throw error;
+      try {
+        this.activeDownloadId = await downloadIdPromise;
+        // Register the in-flight download so the Download Manager shows it live
+        // (filed under Voice via modelType 'stt'). Progress is then driven by the
+        // global onAnyProgress listener in useDownloadListeners. Without this the
+        // row only appeared after switching screens re-scanned disk.
+        useDownloadStore.getState().add({
+          modelKey,
+          downloadId: this.activeDownloadId,
+          modelId: `whisper-${modelId}`,
+          fileName,
+          quantization: '',
+          modelType: 'stt',
+          status: 'pending',
+          bytesDownloaded: 0,
+          totalBytes,
+          combinedTotalBytes: totalBytes,
+          progress: 0,
+          createdAt: Date.now(),
+        });
+        await promise;
+      } catch (error) {
+        logger.error('[Whisper] Download failed:', error);
+        await RNFS.unlink(destPath).catch(() => {});
+        throw error;
+      } finally {
+        this.activeDownloadId = null;
+      }
+      try {
+        await this.validateModelFile(destPath);
+      } catch (validationError) {
+        await RNFS.unlink(destPath).catch(err => logger.error('[Whisper] Failed to delete invalid model file:', err));
+        throw new Error(`Downloaded model file is invalid: ${validationError instanceof Error ? validationError.message : 'unknown error'}`);
+      }
     } finally {
-      this.activeDownloadId = null;
-    }
-    try {
-      await this.validateModelFile(destPath);
-    } catch (validationError) {
-      await RNFS.unlink(destPath).catch(err => logger.error('[Whisper] Failed to delete invalid model file:', err));
-      throw new Error(`Downloaded model file is invalid: ${validationError instanceof Error ? validationError.message : 'unknown error'}`);
+      // Completed STT models are listed from disk by useVoiceDownloadItems, so
+      // the in-flight store entry must be dropped on success AND failure: leaving
+      // it would show a stale/duplicate active row and block a re-download (add()
+      // refuses when an entry already exists for this modelKey).
+      useDownloadStore.getState().remove(modelKey);
     }
     logger.log(`[Whisper] Downloaded to ${destPath}`);
     return destPath;


### PR DESCRIPTION
## What

Fixes two Whisper (speech-to-text) model download bugs.

### 1. Android: every Whisper model failed with "verification failed"

On a fresh download, `WorkerDownload.calculateTotalBytes` clamped the server's real `Content-Length` **up** to the rounded-MB size seeded from JS (`model.size * 1024 * 1024`) via `.coerceAtLeast(existingTotal)`.

Example — `tiny.en`:
- Seeded expected: `75 * 1024 * 1024 = 78,643,200` bytes
- Real file (server `Content-Length`): `77,704,715` bytes

The completion size check (0.1% tolerance) then saw `actual (77.7MB) < expected (78.6MB)`, a 1.19% delta, and — because Whisper models ship **no SHA-256** to vouch for the file — deleted it as `FILE_CORRUPTED`. Every model failed because every `WHISPER_MODELS.size` is a rounded approximation that can't equal the exact byte count.

**Fix:** a successful (2xx) response's `Content-Length` is authoritative and now wins; the seeded estimate is used only when the server omits a length (`contentLength <= 0`). Size/truncation validation stays active — a genuinely short download is still caught.

### 2. Whisper downloads were invisible in the Download Manager until a screen switch

`whisperService.downloadModel` started the download via `backgroundDownloadService.downloadFileTo` but never registered an entry in `useDownloadStore` (unlike text/image downloads). The manager's active list subscribes to that store, so an in-flight STT download didn't appear until navigating away and back re-scanned disk.

**Fix:** register an `stt` entry in `useDownloadStore` when the download starts (progress is then driven by the existing global `onAnyProgress` listener) and remove it on completion/failure. Completed models continue to be listed from disk by `useVoiceDownloadItems`, so there is no duplicate row, and a stale entry can't block a re-download.

## Why

- Whisper / transcription model downloads were completely broken on Android.
- The Download Manager didn't reflect in-progress STT downloads, so users had no feedback that a download was running.

## Tests

- **5 Kotlin unit tests** for `calculateTotalBytes` (in `DownloadManagerModuleTest`), including a regression for the exact 77.7MB-vs-78.6MB case, plus server-omits-length fallback and 206 ranged-resume behaviour.
- **2 JS unit tests** for `whisperService.downloadModel` asserting the store entry is registered while in flight and cleared on both success and failure.
- Full JS suite green locally (`eslint`, `tsc --noEmit`, jest).

## Note for reviewers

CI's Kotlin pre-push gate could not run in the author's local environment due to an unrelated Gradle toolchain issue (`foojay-resolver` references `JvmVendorSpec.IBM_SEMERU`, removed in Gradle 9.1.0). The Kotlin change is a small, self-contained pure-function fix with unit tests; please confirm it compiles in CI.
