### PR TITLE
fix(whisper): per-model download progress + skip strict size check for STT models

### DIFF
--- a/__tests__/rntl/components/TranscriptionModelsTab.test.tsx
+++ b/__tests__/rntl/components/TranscriptionModelsTab.test.tsx
@@ -71,7 +71,7 @@ describe('TranscriptionModelsTab', () => {
     mockWhisperState = {
       downloadedModelId: null,
       presentModelIds: [],
-      downloadProgress: 0,
+      downloadProgressById: {},
       error: null,
       ...mockWhisperActions,
     };

--- a/__tests__/unit/services/backgroundDownloadService.test.ts
+++ b/__tests__/unit/services/backgroundDownloadService.test.ts
@@ -220,6 +220,53 @@ describe('BackgroundDownloadService', () => {
       );
       NativeModules.DownloadManagerModule = savedModule;
     });
+
+    it('notifies error listeners with a user_cancelled event so awaiters can settle', async () => {
+      // Native cancel emits nothing, so the service synthesizes a cancellation
+      // event — without it, anything awaiting downloadFileTo() hangs forever.
+      mockDownloadManagerModule.cancelDownload.mockResolvedValue(undefined);
+      const onError = jest.fn();
+      service.onError(42, onError);
+
+      await service.cancelDownload(42);
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ downloadId: 42, reasonCode: 'user_cancelled' }),
+      );
+    });
+
+    it('rejects a downloadFileTo() promise as cancelled when its download is cancelled', async () => {
+      mockDownloadManagerModule.startDownload.mockResolvedValue({
+        downloadId: 7,
+        fileName: 'f.bin',
+        modelId: 'm',
+      });
+      mockDownloadManagerModule.cancelDownload.mockResolvedValue(undefined);
+
+      const { downloadIdPromise, promise } = service.downloadFileTo({
+        params: { url: 'https://x/f.bin', fileName: 'f.bin', modelId: 'm' },
+        destPath: '/tmp/f.bin',
+        silent: true,
+      });
+      const id = await downloadIdPromise;
+      expect(id).toBe(7);
+
+      await service.cancelDownload(7);
+
+      await expect(promise).rejects.toMatchObject({ cancelled: true });
+    });
+
+    it('synthesizes the cancellation even if the native cancel throws', async () => {
+      mockDownloadManagerModule.cancelDownload.mockRejectedValue(new Error('bridge down'));
+      const onError = jest.fn();
+      service.onError(99, onError);
+
+      await service.cancelDownload(99);
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ downloadId: 99, reasonCode: 'user_cancelled' }),
+      );
+    });
   });
 
   // ========================================================================

--- a/__tests__/unit/stores/whisperStore.test.ts
+++ b/__tests__/unit/stores/whisperStore.test.ts
@@ -188,6 +188,18 @@ describe('whisperStore', () => {
       expect(getState().error).toBe('Download failed');
     });
 
+    it('clears progress without surfacing an error when the download is cancelled', async () => {
+      // A user cancel (from the Download Manager) rejects with a marked error.
+      // It must clear the in-flight entry but not show a failure on the model row.
+      const cancelled = Object.assign(new Error('Download cancelled'), { cancelled: true });
+      mockWhisperService.downloadModel.mockRejectedValue(cancelled);
+
+      await getState().downloadModel('ggml-tiny');
+
+      expect(getState().error).toBeNull();
+      expect(getState().downloadProgressById['ggml-tiny']).toBeUndefined();
+    });
+
     it('tracks concurrent downloads independently with no cross-talk', async () => {
       // Reproduces issue #3: two models downloading at once. The old single
       // downloadingId/downloadProgress made one bar jump between them; per-model

--- a/__tests__/unit/stores/whisperStore.test.ts
+++ b/__tests__/unit/stores/whisperStore.test.ts
@@ -52,11 +52,11 @@ describe('whisperStore', () => {
     });
 
     it('is not downloading', () => {
-      expect(getState().isDownloading).toBe(false);
+      expect(getState().downloadProgressById).toEqual({});
     });
 
-    it('has zero download progress', () => {
-      expect(getState().downloadProgress).toBe(0);
+    it('has no per-model download progress', () => {
+      expect(getState().downloadProgressById['ggml-tiny']).toBeUndefined();
     });
 
     it('is not loading a model', () => {
@@ -76,7 +76,7 @@ describe('whisperStore', () => {
   // downloadModel
   // ============================================================================
   describe('downloadModel', () => {
-    it('sets isDownloading to true and clears error at start', async () => {
+    it('records the model in downloadProgressById and clears error at start', async () => {
       // Set a pre-existing error
       useWhisperStore.setState({ error: 'old error' });
 
@@ -95,9 +95,8 @@ describe('whisperStore', () => {
       // Allow microtask for the set() inside downloadModel to run
       await Promise.resolve();
 
-      // While downloading, state should reflect in-progress
-      expect(getState().isDownloading).toBe(true);
-      expect(getState().downloadProgress).toBe(0);
+      // While downloading, this model has a progress entry (starting at 0)
+      expect(getState().downloadProgressById['ggml-tiny']).toBe(0);
       expect(getState().error).toBeNull();
 
       resolveDownload();
@@ -129,9 +128,9 @@ describe('whisperStore', () => {
       mockWhisperService.downloadModel.mockImplementation(
         async (_id: string, onProgress?: (p: number) => void) => {
           onProgress?.(0.25);
-          progressValues.push(getState().downloadProgress);
+          progressValues.push(getState().downloadProgressById['ggml-tiny']);
           onProgress?.(0.75);
-          progressValues.push(getState().downloadProgress);
+          progressValues.push(getState().downloadProgressById['ggml-tiny']);
           return '/path/to/model';
         },
       );
@@ -143,7 +142,7 @@ describe('whisperStore', () => {
       expect(progressValues).toEqual([0.25, 0.75]);
     });
 
-    it('sets downloadedModelId and progress to 1 on success', async () => {
+    it('sets downloadedModelId and clears the progress entry on success', async () => {
       mockWhisperService.downloadModel.mockResolvedValue('/path/to/model');
       mockWhisperService.getModelPath.mockReturnValue('/path/to/model');
       mockWhisperService.loadModel.mockResolvedValue(undefined);
@@ -151,8 +150,8 @@ describe('whisperStore', () => {
       await getState().downloadModel('ggml-base');
 
       expect(getState().downloadedModelId).toBe('ggml-base');
-      expect(getState().isDownloading).toBe(false);
-      expect(getState().downloadProgress).toBe(1);
+      // Entry removed once the download settles — the model now shows as present.
+      expect(getState().downloadProgressById['ggml-base']).toBeUndefined();
     });
 
     it('auto-loads the model after successful download', async () => {
@@ -169,15 +168,14 @@ describe('whisperStore', () => {
       expect(getState().isModelLoaded).toBe(true);
     });
 
-    it('sets error and resets progress on download failure', async () => {
+    it('sets error and clears the progress entry on download failure', async () => {
       mockWhisperService.downloadModel.mockRejectedValue(
         new Error('Network error'),
       );
 
       await getState().downloadModel('ggml-tiny');
 
-      expect(getState().isDownloading).toBe(false);
-      expect(getState().downloadProgress).toBe(0);
+      expect(getState().downloadProgressById['ggml-tiny']).toBeUndefined();
       expect(getState().error).toBe('Network error');
       expect(getState().downloadedModelId).toBeNull();
     });
@@ -188,6 +186,43 @@ describe('whisperStore', () => {
       await getState().downloadModel('ggml-tiny');
 
       expect(getState().error).toBe('Download failed');
+    });
+
+    it('tracks concurrent downloads independently with no cross-talk', async () => {
+      // Reproduces issue #3: two models downloading at once. The old single
+      // downloadingId/downloadProgress made one bar jump between them; per-model
+      // progress keeps each model's value separate.
+      const resolvers: Record<string, () => void> = {};
+      const progressCbs: Record<string, (p: number) => void> = {};
+      mockWhisperService.downloadModel.mockImplementation(
+        (id: string, onProgress?: (p: number) => void) =>
+          new Promise<string>((resolve) => {
+            if (onProgress) progressCbs[id] = onProgress;
+            resolvers[id] = () => resolve(`/models/${id}`);
+          }),
+      );
+      mockWhisperService.getModelPath.mockImplementation((id: string) => `/models/${id}`);
+      mockWhisperService.loadModel.mockResolvedValue(undefined);
+
+      const p1 = getState().downloadModel('ggml-tiny');
+      const p2 = getState().downloadModel('ggml-base');
+      await Promise.resolve();
+
+      // Each download drives only its own entry.
+      progressCbs['ggml-tiny'](0.3);
+      progressCbs['ggml-base'](0.7);
+      expect(getState().downloadProgressById['ggml-tiny']).toBe(0.3);
+      expect(getState().downloadProgressById['ggml-base']).toBe(0.7);
+
+      // Finishing one leaves the other's progress intact.
+      resolvers['ggml-tiny']();
+      await p1;
+      expect(getState().downloadProgressById['ggml-tiny']).toBeUndefined();
+      expect(getState().downloadProgressById['ggml-base']).toBe(0.7);
+
+      resolvers['ggml-base']();
+      await p2;
+      expect(getState().downloadProgressById).toEqual({});
     });
   });
 
@@ -336,7 +371,6 @@ describe('whisperStore', () => {
       useWhisperStore.setState({
         downloadedModelId: 'ggml-tiny',
         isModelLoaded: true,
-        downloadProgress: 1,
       });
       mockWhisperService.unloadModel.mockResolvedValue(undefined);
       mockWhisperService.deleteModel.mockResolvedValue(undefined);
@@ -347,7 +381,6 @@ describe('whisperStore', () => {
       expect(mockWhisperService.deleteModel).toHaveBeenCalledWith('ggml-tiny');
       expect(getState().downloadedModelId).toBeNull();
       expect(getState().isModelLoaded).toBe(false);
-      expect(getState().downloadProgress).toBe(0);
     });
 
     it('calls unloadModel before deleteModel', async () => {

--- a/__tests__/utils/testHelpers.ts
+++ b/__tests__/utils/testHelpers.ts
@@ -126,8 +126,7 @@ export const resetStores = (): void => {
   // Reset whisper store
   useWhisperStore.setState({
     downloadedModelId: null,
-    isDownloading: false,
-    downloadProgress: 0,
+    downloadProgressById: {},
     isModelLoading: false,
     isModelLoaded: false,
     error: null,
@@ -537,8 +536,7 @@ export const resetWhisperStore = (): void => {
   useWhisperStore.setState({
     downloadedModelId: null,
     presentModelIds: [],
-    isDownloading: false,
-    downloadProgress: 0,
+    downloadProgressById: {},
     isModelLoading: false,
     isModelLoaded: false,
     error: null,

--- a/src/components/VoiceRecordButton/index.tsx
+++ b/src/components/VoiceRecordButton/index.tsx
@@ -119,7 +119,11 @@ export const VoiceRecordButton: React.FC<VoiceRecordButtonProps> = ({
   asSendButton = false,
 }) => {
   const styles = useThemedStyles(createStyles);
-  const { downloadModel, isDownloading, downloadProgress } = useWhisperStore();
+  const downloadModel = useWhisperStore((s) => s.downloadModel);
+  // Scope to the model this button downloads, so a concurrent download of a
+  // different transcription model doesn't drive this button's progress.
+  const downloadProgress = useWhisperStore((s) => s.downloadProgressById[DOWNLOAD_MODEL_ID]);
+  const isDownloading = downloadProgress !== undefined;
 
   const pulseAnim = useRef(new Animated.Value(1)).current;
   const loadingAnim = useRef(new Animated.Value(0)).current;

--- a/src/components/models/WhisperPickerSheet.tsx
+++ b/src/components/models/WhisperPickerSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { View, Text, ActivityIndicator } from 'react-native';
+import { View, Text } from 'react-native';
 import Icon from 'react-native-vector-icons/Feather';
 import { AppSheet } from '../../components/AppSheet';
 import { AnimatedPressable } from '../../components/AnimatedPressable';
@@ -23,18 +23,18 @@ export const WhisperPickerSheet: React.FC<Props> = ({ visible, onClose }) => {
   const styles = useThemedStyles(createStyles);
   const downloadedModelId = useWhisperStore((s) => s.downloadedModelId);
   const presentModelIds = useWhisperStore((s) => s.presentModelIds);
-  const isDownloading = useWhisperStore((s) => s.isDownloading);
-  const downloadingId = useWhisperStore((s) => s.downloadingId);
-  const downloadProgress = useWhisperStore((s) => s.downloadProgress);
+  const downloadProgressById = useWhisperStore((s) => s.downloadProgressById);
   const downloadModel = useWhisperStore((s) => s.downloadModel);
   const selectModel = useWhisperStore((s) => s.selectModel);
   const deleteModelById = useWhisperStore((s) => s.deleteModelById);
   const refreshPresentModels = useWhisperStore((s) => s.refreshPresentModels);
 
+  const anyDownloading = Object.keys(downloadProgressById).length > 0;
+
   useEffect(() => {
-    if (visible && !isDownloading) refreshPresentModels();
+    if (visible && !anyDownloading) refreshPresentModels();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible, isDownloading]);
+  }, [visible, anyDownloading]);
 
   return (
     <AppSheet visible={visible} onClose={onClose} title="TRANSCRIPTION MODEL" enableDynamicSizing>
@@ -42,15 +42,17 @@ export const WhisperPickerSheet: React.FC<Props> = ({ visible, onClose }) => {
         {WHISPER_MODELS.map((m) => {
           const active = downloadedModelId === m.id;
           const present = presentModelIds.includes(m.id);
-          // Spin ONLY the model actually downloading — not every not-yet-present
-          // row (the old `isDownloading && !present` lit them all up at once).
-          const busy = downloadingId === m.id;
+          // Per-model: show this row's own progress, and disable only this row
+          // while it downloads — several models can download at once, each with
+          // its own percentage (the old single-slot value jumped between them).
+          const progress = downloadProgressById[m.id];
+          const busy = progress !== undefined;
           return (
             <AnimatedPressable
               key={m.id}
               style={[styles.row, active && styles.rowActive]}
               hapticType="selection"
-              disabled={isDownloading}
+              disabled={busy}
               onPress={() => { if (present) { if (!active) selectModel(m.id); } else downloadModel(m.id); }}
             >
               <View style={styles.rowInfo}>
@@ -61,7 +63,7 @@ export const WhisperPickerSheet: React.FC<Props> = ({ visible, onClose }) => {
                 <Text style={styles.meta}>{m.size} MB</Text>
               </View>
               {(() => {
-                if (busy) return <ActivityIndicator size="small" color={colors.primary} />;
+                if (busy) return <Text style={styles.percent}>{Math.round(progress * 100)}%</Text>;
                 if (active) return <Icon name="check" size={16} color={colors.primary} />;
                 if (present) {
                   return (
@@ -75,9 +77,6 @@ export const WhisperPickerSheet: React.FC<Props> = ({ visible, onClose }) => {
             </AnimatedPressable>
           );
         })}
-        {isDownloading && (
-          <Text style={styles.progress}>Downloading… {Math.round(downloadProgress * 100)}%</Text>
-        )}
       </View>
     </AppSheet>
   );
@@ -100,5 +99,5 @@ const createStyles = (colors: ThemeColors) => ({
   name: { ...TYPOGRAPHY.body, color: colors.text },
   desc: { ...TYPOGRAPHY.bodySmall, color: colors.textSecondary },
   meta: { ...TYPOGRAPHY.meta, color: colors.textMuted },
-  progress: { ...TYPOGRAPHY.meta, color: colors.textMuted, textAlign: 'center' as const, marginTop: SPACING.sm },
+  percent: { ...TYPOGRAPHY.meta, color: colors.primary },
 });

--- a/src/screens/ModelsScreen/TranscriptionModelsTab.tsx
+++ b/src/screens/ModelsScreen/TranscriptionModelsTab.tsx
@@ -34,7 +34,7 @@ interface WhisperCardProps {
   index: number;
   downloadedModelId: string | null;
   presentModelIds: string[];
-  downloadingId: string | null;
+  downloading: boolean;
   downloadProgress: number;
   onDownload: (id: string) => void;
   onSelect: (id: string) => void;
@@ -42,11 +42,10 @@ interface WhisperCardProps {
 }
 
 const WhisperCard: React.FC<WhisperCardProps> = ({
-  model, index, downloadedModelId, presentModelIds, downloadingId, downloadProgress, onDownload, onSelect, onDelete,
+  model, index, downloadedModelId, presentModelIds, downloading, downloadProgress, onDownload, onSelect, onDelete,
 }) => {
   const present = presentModelIds.includes(model.id);
   const active = downloadedModelId === model.id;
-  const downloading = downloadingId === model.id;
   return (
     <ModelCard
       compact
@@ -72,25 +71,29 @@ export const TranscriptionModelsTab: React.FC = () => {
   const [alertState, setAlertState] = useState<AlertState>(initialAlertState);
 
   const {
-    downloadedModelId, presentModelIds, downloadProgress, downloadingId, downloadModel,
+    downloadedModelId, presentModelIds, downloadProgressById, downloadModel,
     selectModel, deleteModelById, refreshPresentModels, error: whisperError, clearError,
   } = useWhisperStore();
 
-  // Probe disk on mount and whenever a download finishes, so every on-disk model
+  // True while any transcription model is downloading. Disk probes are deferred
+  // until everything settles so an in-flight file isn't mistaken for absent.
+  const anyDownloading = Object.keys(downloadProgressById).length > 0;
+
+  // Probe disk on mount and whenever downloads finish, so every on-disk model
   // (not just the active one) shows as downloaded.
   useEffect(() => {
-    if (!downloadingId) refreshPresentModels();
+    if (!anyDownloading) refreshPresentModels();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [downloadingId]);
+  }, [anyDownloading]);
 
   // Re-derive from disk whenever the Models screen regains focus (e.g. returning
   // from the Download Manager after a download or delete). Disk is the source of
   // truth, so this keeps the list in sync without any cross-screen wiring.
   useFocusEffect(
     useCallback(() => {
-      if (!downloadingId) refreshPresentModels();
+      if (!anyDownloading) refreshPresentModels();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [downloadingId]),
+    }, [anyDownloading]),
   );
 
   const handleDownload = useCallback((id: string) => {
@@ -110,20 +113,23 @@ export const TranscriptionModelsTab: React.FC = () => {
     ]));
   }, [deleteModelById]);
 
-  const renderWhisperCard = (model: typeof WHISPER_MODELS[number], index: number) => (
-    <WhisperCard
-      key={model.id}
-      model={model}
-      index={index}
-      downloadedModelId={downloadedModelId}
-      presentModelIds={presentModelIds}
-      downloadingId={downloadingId}
-      downloadProgress={downloadProgress}
-      onDownload={handleDownload}
-      onSelect={handleSelect}
-      onDelete={handleDelete}
-    />
-  );
+  const renderWhisperCard = (model: typeof WHISPER_MODELS[number], index: number) => {
+    const progress = downloadProgressById[model.id];
+    return (
+      <WhisperCard
+        key={model.id}
+        model={model}
+        index={index}
+        downloadedModelId={downloadedModelId}
+        presentModelIds={presentModelIds}
+        downloading={progress !== undefined}
+        downloadProgress={progress ?? 0}
+        onDownload={handleDownload}
+        onSelect={handleSelect}
+        onDelete={handleDelete}
+      />
+    );
+  };
 
   return (
     <ScrollView style={styles.flex} contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">

--- a/src/services/backgroundDownloadService.ts
+++ b/src/services/backgroundDownloadService.ts
@@ -72,6 +72,20 @@ class BackgroundDownloadService {
     } catch (e) {
       logger.log('[BackgroundDownload] cancelDownload failed (bridge may be torn down):', e);
     }
+    // Native cancel emits no complete/error event and tears down its observer, so
+    // anything awaiting this download via downloadFileTo() would hang forever.
+    // Synthesize a cancellation so that promise settles and callers can clean up
+    // (e.g. whisperService clears its in-flight progress, the transcription screen
+    // stops showing the model as downloading). reasonCode marks it user-cancelled
+    // so callers treat it as a cancel, not a download failure.
+    this.dispatchToListeners(this.errorListeners, 'error', {
+      downloadId,
+      fileName: '',
+      modelId: '',
+      status: 'failed',
+      reason: 'Download cancelled',
+      reasonCode: 'user_cancelled',
+    });
   }
 
   async getActiveDownloads(): Promise<BackgroundDownloadInfo[]> {
@@ -214,7 +228,11 @@ class BackgroundDownloadService {
         });
         const removeError = this.onError(info.downloadId, (err) => {
           done();
-          reject(new Error(err.reason || 'Download failed'));
+          const error = new Error(err.reason || 'Download failed') as Error & { cancelled?: boolean };
+          // Let callers distinguish a user cancel from a real failure so they can
+          // clean up quietly instead of surfacing a "download failed" error.
+          if (err.reasonCode === 'user_cancelled') error.cancelled = true;
+          reject(error);
         });
         this.startProgressPolling();
       });

--- a/src/services/backgroundDownloadService.ts
+++ b/src/services/backgroundDownloadService.ts
@@ -186,7 +186,7 @@ class BackgroundDownloadService {
   }
 
   downloadFileTo(opts: {
-    params: Pick<DownloadParams, 'url' | 'fileName' | 'modelId' | 'totalBytes' | 'modelType'>;
+    params: Pick<DownloadParams, 'url' | 'fileName' | 'modelId' | 'totalBytes' | 'modelType' | 'metadataJson'>;
     destPath: string;
     onProgress?: (bytesDownloaded: number, totalBytes: number) => void;
     silent?: boolean;

--- a/src/services/whisperService.ts
+++ b/src/services/whisperService.ts
@@ -113,7 +113,13 @@ class WhisperService {
         });
         await promise;
       } catch (error) {
-        logger.error('[Whisper] Download failed:', error);
+        if ((error as { cancelled?: boolean })?.cancelled) {
+          logger.log(`[Whisper] Download cancelled: ${modelId}`);
+        } else {
+          logger.error('[Whisper] Download failed:', error);
+        }
+        // Remove any partial file (a user cancel already deletes it natively; this
+        // also covers the error case). Rethrow so the store clears its progress.
         await RNFS.unlink(destPath).catch(() => {});
         throw error;
       } finally {

--- a/src/services/whisperService.ts
+++ b/src/services/whisperService.ts
@@ -72,6 +72,15 @@ class WhisperService {
         // STT models showed up under Text (and never under the Voice filter).
         modelType: 'stt',
         totalBytes,
+        // Skip the Android worker's strict final-size check. `totalBytes` above
+        // is a rounded-MB approximation (e.g. base.en 142 MB = 148,897,792 B vs
+        // the real 147,964,211 B) — the discrepancy is largest for smaller
+        // models. The worker compares the downloaded size to the expected total
+        // within 0.1%, and since whisper.cpp ships no SHA to verify against, a
+        // fully-downloaded file was deleted as FILE_CORRUPTED. The URL is pinned
+        // to ggerganov/whisper.cpp; integrity is covered by HTTPS + the host
+        // allowlist (matches how curated offgrid/* models opt out).
+        metadataJson: JSON.stringify({ skipSizeValidation: true }),
       },
       destPath,
       onProgress: onProgress

--- a/src/stores/whisperStore.ts
+++ b/src/stores/whisperStore.ts
@@ -81,7 +81,11 @@ export const useWhisperStore = create<WhisperState>()(
           // Auto-load after download
           await get().loadModel();
         } catch (error) {
-          set({ error: error instanceof Error ? error.message : 'Download failed' });
+          // A user-initiated cancel rejects with a marked error — don't show it as
+          // a failure on the model row, just let the finally clear its progress.
+          if (!(error as { cancelled?: boolean })?.cancelled) {
+            set({ error: error instanceof Error ? error.message : 'Download failed' });
+          }
         } finally {
           // Clear this model's progress entry, even if auto-load hangs/fails —
           // the file is already on disk by this point. Other in-flight downloads
@@ -103,7 +107,9 @@ export const useWhisperStore = create<WhisperState>()(
           }));
           await get().loadModel();
         } catch (error) {
-          set({ error: error instanceof Error ? error.message : 'Download failed' });
+          if (!(error as { cancelled?: boolean })?.cancelled) {
+            set({ error: error instanceof Error ? error.message : 'Download failed' });
+          }
         } finally {
           clearProgress(set, modelId);
         }

--- a/src/stores/whisperStore.ts
+++ b/src/stores/whisperStore.ts
@@ -9,11 +9,15 @@ interface WhisperState {
   downloadedModelId: string | null;
   // All models present on disk (multiple can be downloaded; one is active).
   presentModelIds: string[];
-  isDownloading: boolean;
-  /** Which model id is currently downloading (null when idle). Per-model so the
-   *  UI spins only that row, not every not-yet-downloaded model. */
-  downloadingId: string | null;
-  downloadProgress: number;
+  /**
+   * Per-model download progress (0..1). A model id is a key here only while it is
+   * downloading; the key is removed on completion or failure. Tracking progress
+   * per id (instead of a single downloadingId + downloadProgress) lets several
+   * models download at once, each driving its own bar. The single-slot version
+   * shared one progress value, so concurrent downloads made the bar jump between
+   * them. Read with downloadProgressById[id] and "downloading" = id in the map.
+   */
+  downloadProgressById: Record<string, number>;
   isModelLoading: boolean;
   isModelLoaded: boolean;
   error: string | null;
@@ -33,69 +37,75 @@ interface WhisperState {
   clearError: () => void;
 }
 
+type SetState = (partial: Partial<WhisperState> | ((s: WhisperState) => Partial<WhisperState>)) => void;
+
+/** Set one model's in-flight progress without disturbing other concurrent downloads. */
+function setProgress(set: SetState, modelId: string, progress: number): void {
+  set((s) => ({ downloadProgressById: { ...s.downloadProgressById, [modelId]: progress } }));
+}
+
+/** Remove one model's progress entry (download finished or failed). */
+function clearProgress(set: SetState, modelId: string): void {
+  set((s) => {
+    if (!(modelId in s.downloadProgressById)) return {};
+    const next = { ...s.downloadProgressById };
+    delete next[modelId];
+    return { downloadProgressById: next };
+  });
+}
+
 export const useWhisperStore = create<WhisperState>()(
   persist(
     (set, get) => ({
       downloadedModelId: null,
       presentModelIds: [],
-      isDownloading: false,
-      downloadingId: null,
-      downloadProgress: 0,
+      downloadProgressById: {},
       isModelLoading: false,
       isModelLoaded: false,
       error: null,
 
       downloadModel: async (modelId: string) => {
-        set({ isDownloading: true, downloadingId: modelId, downloadProgress: 0, error: null });
+        setProgress(set, modelId, 0);
+        set({ error: null });
 
         try {
           await whisperService.downloadModel(modelId, (progress) => {
-            set({ downloadProgress: progress });
+            setProgress(set, modelId, progress);
           });
 
           set((s) => ({
             downloadedModelId: modelId,
             presentModelIds: s.presentModelIds.includes(modelId) ? s.presentModelIds : [...s.presentModelIds, modelId],
-            isDownloading: false,
-            downloadProgress: 1,
           }));
 
           // Auto-load after download
           await get().loadModel();
         } catch (error) {
-          set({
-            isDownloading: false,
-            downloadProgress: 0,
-            error: error instanceof Error ? error.message : 'Download failed',
-          });
+          set({ error: error instanceof Error ? error.message : 'Download failed' });
         } finally {
-          // Always clear the per-model spinner, even if auto-load hangs/fails —
-          // the file is already on disk by this point.
-          set({ downloadingId: null });
+          // Clear this model's progress entry, even if auto-load hangs/fails —
+          // the file is already on disk by this point. Other in-flight downloads
+          // keep their own entries.
+          clearProgress(set, modelId);
         }
       },
 
       downloadFromUrl: async (url: string, modelId: string) => {
-        set({ isDownloading: true, downloadingId: modelId, downloadProgress: 0, error: null });
+        setProgress(set, modelId, 0);
+        set({ error: null });
         try {
           await whisperService.downloadFromUrl(url, modelId, (progress) => {
-            set({ downloadProgress: progress });
+            setProgress(set, modelId, progress);
           });
           set((s) => ({
             downloadedModelId: modelId,
             presentModelIds: s.presentModelIds.includes(modelId) ? s.presentModelIds : [...s.presentModelIds, modelId],
-            isDownloading: false,
-            downloadProgress: 1,
           }));
           await get().loadModel();
         } catch (error) {
-          set({
-            isDownloading: false,
-            downloadProgress: 0,
-            error: error instanceof Error ? error.message : 'Download failed',
-          });
+          set({ error: error instanceof Error ? error.message : 'Download failed' });
         } finally {
-          set({ downloadingId: null });
+          clearProgress(set, modelId);
         }
       },
 
@@ -137,7 +147,6 @@ export const useWhisperStore = create<WhisperState>()(
             isModelLoaded: false,
             isModelLoading: false,
             downloadedModelId: isFileError ? null : downloadedModelId,
-            downloadProgress: isFileError ? 0 : get().downloadProgress,
             error: errorMsg,
           });
         }
@@ -166,7 +175,6 @@ export const useWhisperStore = create<WhisperState>()(
           set({
             downloadedModelId: null,
             isModelLoaded: false,
-            downloadProgress: 0,
           });
         } catch (error) {
           set({


### PR DESCRIPTION
## What

Two fixes for transcription (Whisper) model downloads.

### 1. Per-model download progress (concurrent downloads)

Downloading more than one Whisper model at once showed a single progress bar that jumped between them. The store tracked one `downloadingId` + one `downloadProgress`, so both in-flight downloads wrote to the same value.

Replaced those with a per-model map:

```ts
downloadProgressById: Record<string, number>  // id -> 0..1, present only while downloading
```

- A key is added when a model starts downloading, updated by its own progress callback, and removed on completion/failure.
- `downloadModel` / `downloadFromUrl` write only their model's entry (helpers `setProgress`/`clearProgress`), so concurrent downloads never clobber each other.

Updated the three consumers:
- **TranscriptionModelsTab** — each card reads `downloadProgressById[id]`; disk re-probe now keys off "any downloading".
- **WhisperPickerSheet** — per-row percentage, and only the busy row is disabled (you can start others).
- **VoiceRecordButton** — scoped to the `base.en` model it downloads, so another model's download doesn't drive its progress.

`ChatScreen` / `HomeScreen` only read `downloadedModelId` and are unaffected.

### 2. Skip strict size validation for Whisper downloads

The seeded `totalBytes` is a rounded-MB approximation (e.g. `base.en` 142 MB = 148,897,792 B vs the real 147,964,211 B — the gap is proportionally largest for smaller models). The Android worker compares the downloaded size against that expected total within 0.1%, and since whisper.cpp ships no SHA to verify against, a fully-downloaded file was deleted as `FILE_CORRUPTED`.

`whisperService.downloadModel` now passes `metadataJson: { skipSizeValidation: true }` (the same opt-out curated `offgrid/*` models use). `downloadFileTo`'s param type is widened to allow `metadataJson`. Integrity is covered by HTTPS + the host allowlist on the pinned `ggerganov/whisper.cpp` URL. This complements the `calculateTotalBytes` fix already on main.

## Tests

- New whisperStore test for concurrent downloads (no cross-talk: each model's progress is independent; finishing one leaves the other's intact).
- Updated store/helper/component tests to the per-model shape.
- Full related suite green via the pre-push gate (eslint, tsc, 3988 tests).

## Note

No native changes in this PR, so the Android gradle gate doesn't apply.

### 3. Cancelling a download now updates the screen

Cancelling from the Download Manager removed the manager row but left the model showing as "downloading" everywhere else. Native `cancelDownload` emits no complete/error event and tears down its work observer, so any `downloadFileTo()` promise awaiting that id (`whisperService.downloadModel`) hung forever — its `finally` never ran, so `downloadProgressById` was never cleared and the Transcription tab / picker / voice button stayed stuck.

- `backgroundDownloadService.cancelDownload` now synthesizes a `user_cancelled` error event after the native cancel (even if the bridge throws), so awaiting `downloadFileTo()` promises settle. `downloadFileTo` marks the rejected error `.cancelled` so callers treat it as a cancel, not a failure.
- `whisperService` logs the cancel quietly and still removes the partial file.
- `whisperStore` clears the per-model progress entry on cancel without surfacing an error on the row.

This also fixes the same latent hang for every `downloadFileTo()` consumer (TTS, image zips), not just Whisper. Added tests for the synthetic cancel event, `downloadFileTo` rejecting as cancelled, native-throw resilience, and the quiet store cleanup.
