### PR TITLE
fix(chat): input controls no longer sit under the Android nav bar

### DIFF
--- a/__tests__/unit/audio/ttsDownloadProvider.test.ts
+++ b/__tests__/unit/audio/ttsDownloadProvider.test.ts
@@ -1,8 +1,9 @@
 /**
  * TTS download provider (pro) — wraps the executorch engine under the uniform
- * contract. Verifies list maps downloaded/downloading engines, capabilities reflect
- * the executorch gaps (cancel:false, retry:false, determinateProgress:false), and
- * remove routes through the TTS store's delete.
+ * contract. Verifies list maps downloaded/downloading/FAILED engines, capabilities
+ * reflect the executorch gaps (cancel:false, determinateProgress:false) while retry
+ * IS supported (re-running downloadAssets resumes from cache), and remove/retry
+ * route through the TTS store.
  */
 const mockEngine = {
   displayName: 'Kokoro TTS',
@@ -10,12 +11,18 @@ const mockEngine = {
   isFullyDownloaded: jest.fn(() => true),
   getOverallDownloadProgress: jest.fn(() => 1),
   getPhase: jest.fn(() => 'ready'),
+  getLastDownloadError: jest.fn(() => null as string | null),
   getRequiredAssets: jest.fn(() => [{ sizeBytes: 80_000_000 }]),
 };
 jest.mock('../../../pro/audio/engine', () => ({
   ttsRegistry: { getRegisteredIds: () => ['kokoro'], getEngine: () => mockEngine },
 }));
-const mockTts = { settings: { engineId: 'kokoro' }, setEngine: jest.fn(async () => {}), deleteModels: jest.fn(async () => {}) };
+const mockTts = {
+  settings: { engineId: 'kokoro' },
+  setEngine: jest.fn(async () => {}),
+  deleteModels: jest.fn(async () => {}),
+  downloadModels: jest.fn(async () => {}),
+};
 jest.mock('../../../pro/audio/ttsStore', () => ({
   useTTSStore: { getState: () => mockTts, subscribe: () => () => {} },
 }));
@@ -27,17 +34,56 @@ beforeEach(() => {
   mockEngine.isFullyDownloaded.mockReturnValue(true);
   mockEngine.getOverallDownloadProgress.mockReturnValue(1);
   mockEngine.getPhase.mockReturnValue('ready');
+  mockEngine.getLastDownloadError.mockReturnValue(null);
 });
 
 describe('ttsProvider', () => {
-  it('lists a downloaded engine as completed with executorch capability gaps', async () => {
+  it('lists a downloaded engine as completed; retry supported, cancel is not', async () => {
     const d = (await ttsProvider.list())[0];
     expect(d.id).toBe('tts:kokoro');
     expect(d.status).toBe('completed');
     expect(d.capabilities.cancel).toBe(false);
-    expect(d.capabilities.retry).toBe(false);
+    expect(d.capabilities.retry).toBe(true);
     expect(d.capabilities.determinateProgress).toBe(false);
     expect(d.capabilities.resumable).toBe(true);
+  });
+
+  it('surfaces a FAILED download as status "error" with the failure message', async () => {
+    // Regression: a failed Kokoro fetch used to vanish from the Download Manager
+    // (list() dropped anything not downloaded/downloading). It must now show as a
+    // retryable error carrying the engine's failure message.
+    mockEngine.isFullyDownloaded.mockReturnValue(false);
+    mockEngine.getOverallDownloadProgress.mockReturnValue(0.3);
+    mockEngine.getPhase.mockReturnValue('error');
+    mockEngine.getLastDownloadError.mockReturnValue('Download interrupted or missing resource');
+    const d = (await ttsProvider.list())[0];
+    expect(d.status).toBe('error');
+    expect(d.error).toBe('Download interrupted or missing resource');
+    expect(d.capabilities.retry).toBe(true);
+  });
+
+  it('falls back to a generic error message when the engine reports none', async () => {
+    mockEngine.isFullyDownloaded.mockReturnValue(false);
+    mockEngine.getPhase.mockReturnValue('error');
+    mockEngine.getLastDownloadError.mockReturnValue(null);
+    const d = (await ttsProvider.list())[0];
+    expect(d.status).toBe('error');
+    expect(d.error).toBe('Download failed');
+  });
+
+  it('retry re-runs the download for the engine via the store', async () => {
+    await ttsProvider.retry('tts:kokoro');
+    // Already the active engine → no switch, just re-download.
+    expect(mockTts.setEngine).not.toHaveBeenCalled();
+    expect(mockTts.downloadModels).toHaveBeenCalled();
+  });
+
+  it('retry switches to the target engine first when it is not active', async () => {
+    mockTts.settings.engineId = 'outetts';
+    await ttsProvider.retry('tts:kokoro');
+    expect(mockTts.setEngine).toHaveBeenCalledWith('kokoro');
+    expect(mockTts.downloadModels).toHaveBeenCalled();
+    mockTts.settings.engineId = 'kokoro';
   });
 
   it('lists an in-progress download as downloading with fractional progress', async () => {

--- a/__tests__/unit/engine/kokoroEngine.test.ts
+++ b/__tests__/unit/engine/kokoroEngine.test.ts
@@ -237,14 +237,34 @@ describe('KokoroEngine install status', () => {
     await engine.checkAssetStatus();
     expect(engine.isFullyDownloaded()).toBe(true);
 
+    // deleteAssets re-scans disk at the end; simulate the files being gone so the
+    // post-delete scan is conclusive-empty.
+    listDownloadedFiles.mockResolvedValue([]);
     await engine.deleteAssets();
     expect(deleteResources).toHaveBeenCalled();
 
-    // After deletion, disk is empty → not-downloaded.
-    listDownloadedFiles.mockResolvedValue([]);
+    // deleteAssets re-scanned → already not-downloaded without a manual re-check.
+    expect(engine.isFullyDownloaded()).toBe(false);
     const [state] = await engine.checkAssetStatus();
     expect(state.status).toBe('not-downloaded');
-    expect(engine.isFullyDownloaded()).toBe(false);
+  });
+
+  it('REGRESSION: deleteAssets removes the FULL active-voice set, not just the core .pte', async () => {
+    // The bug: deleteAssets deleted only the two core .pte files, leaving the
+    // voice embedding/tagger/lexicon on disk. The completeness scan checks the
+    // full set, so the Download Manager kept showing Kokoro "downloaded" after a
+    // Remove. Delete must target the same set download + completeness use.
+    listDownloadedFiles.mockResolvedValue(allOnDisk());
+    const engine = new KokoroEngine();
+    await engine.checkAssetStatus();
+
+    await engine.deleteAssets();
+
+    const deleted: string[] = deleteResources.mock.calls[0] ?? [];
+    // Every required source (core + voice/tagger/lexicon) must be in the delete set.
+    for (const f of KOKORO_FILES) {
+      expect(deleted.some((url) => url.split(/[?#]/)[0].split('/').pop() === f)).toBe(true);
+    }
   });
 
   it('a conclusive empty disk scan beats stale in-session progress', async () => {

--- a/__tests__/unit/screens/ChatScreen/footerPadding.test.ts
+++ b/__tests__/unit/screens/ChatScreen/footerPadding.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Unit tests for computeFooterPaddingBottom — the bottom safe-area padding under
+ * the chat input row. The regression this guards: on a device with an opaque
+ * 3-button navigation bar (a tall bottom inset), the old 4px cap left the input
+ * controls rendered UNDERNEATH the nav buttons. A thin iOS home-indicator /
+ * gesture-nav overlay inset must still be capped so it doesn't look like a dead
+ * band. The keyboard-open case collapses to 0.
+ */
+import { computeFooterPaddingBottom } from '../../../../src/screens/ChatScreen/ChatMessageArea';
+
+describe('computeFooterPaddingBottom', () => {
+  it('collapses to 0 while the keyboard is visible, regardless of inset', () => {
+    expect(computeFooterPaddingBottom(true, 0)).toBe(0);
+    expect(computeFooterPaddingBottom(true, 24)).toBe(0);
+    expect(computeFooterPaddingBottom(true, 48)).toBe(0);
+  });
+
+  it('caps a thin overlay inset (iOS home indicator / gesture nav) at 4', () => {
+    expect(computeFooterPaddingBottom(false, 0)).toBe(0);
+    expect(computeFooterPaddingBottom(false, 4)).toBe(4);
+    expect(computeFooterPaddingBottom(false, 24)).toBe(4); // at the overlay ceiling
+  });
+
+  it('honors the full inset for an opaque 3-button nav bar (tall inset)', () => {
+    // Regression: OnePlus/Oppo 3-button nav bar. Must NOT cap to 4 or the input
+    // controls sit under the nav buttons.
+    expect(computeFooterPaddingBottom(false, 48)).toBe(48);
+    expect(computeFooterPaddingBottom(false, 36)).toBe(36);
+    expect(computeFooterPaddingBottom(false, 25)).toBe(25); // just above the ceiling
+  });
+});

--- a/__tests__/unit/screens/DownloadManager/useVoiceDownloadItems.test.ts
+++ b/__tests__/unit/screens/DownloadManager/useVoiceDownloadItems.test.ts
@@ -114,7 +114,20 @@ describe('useVoiceDownloadItems', () => {
     const tts = result.current.voiceItems.find(i => i.modelType === 'tts')!;
     expect(tts.type).toBe('active');
     expect(tts.status).toBe('failed');
+    // Engine message present → prefer it verbatim; leave reasonCode undefined so
+    // the label helper shows the engine text, not a canned code message. Retry
+    // still renders because isRetryable(undefined) === true.
     expect(tts.reason).toBe('Download interrupted or missing resource');
+    expect(tts.reasonCode).toBeUndefined();
+  });
+
+  it('falls back to the retryable code when the engine gives no failure message', async () => {
+    mockServiceList = [ttsEntry({ status: 'error', progress: 0, bytesDownloaded: 0 })];
+    const { result } = renderHook(() => useVoiceDownloadItems(jest.fn()));
+    await waitFor(() => expect(result.current.voiceItems.some(i => i.modelType === 'tts')).toBe(true));
+
+    const tts = result.current.voiceItems.find(i => i.modelType === 'tts')!;
+    expect(tts.status).toBe('failed');
     expect(tts.reasonCode).toBe('download_interrupted');
   });
 

--- a/__tests__/unit/screens/DownloadManager/useVoiceDownloadItems.test.ts
+++ b/__tests__/unit/screens/DownloadManager/useVoiceDownloadItems.test.ts
@@ -99,6 +99,25 @@ describe('useVoiceDownloadItems', () => {
     expect(tts.status).toBe('completed');
   });
 
+  it('surfaces a FAILED voice download as a retryable failed item', async () => {
+    // Regression: a failed Kokoro download used to be dropped entirely (nothing
+    // shown, no way to retry). A service status of 'error' must render as a
+    // failed ACTIVE item with a retryable reason code so the Download Manager
+    // shows the Retry button.
+    mockServiceList = [ttsEntry({
+      status: 'error', progress: 0.3, bytesDownloaded: 24_000_000,
+      error: 'Download interrupted or missing resource',
+    })];
+    const { result } = renderHook(() => useVoiceDownloadItems(jest.fn()));
+    await waitFor(() => expect(result.current.voiceItems.some(i => i.modelType === 'tts')).toBe(true));
+
+    const tts = result.current.voiceItems.find(i => i.modelType === 'tts')!;
+    expect(tts.type).toBe('active');
+    expect(tts.status).toBe('failed');
+    expect(tts.reason).toBe('Download interrupted or missing resource');
+    expect(tts.reasonCode).toBe('download_interrupted');
+  });
+
   it('omits voice models when the service reports no tts entries', async () => {
     mockServiceList = [];
     const { result } = renderHook(() => useVoiceDownloadItems(jest.fn()));

--- a/__tests__/unit/services/generationToolLoop.branches.test.ts
+++ b/__tests__/unit/services/generationToolLoop.branches.test.ts
@@ -354,21 +354,30 @@ describe('runToolLoop — LiteRT loop branches', () => {
 describe('runToolLoop — precise date/time context for calendar tools', () => {
   beforeEach(resetMocks);
 
-  it('augments the system prompt with a precise timestamp when a calendar tool is enabled', async () => {
+  it('appends a precise time-of-day note to the latest user message when a calendar tool is enabled', async () => {
     mockedGenerateResponseWithTools.mockResolvedValue({ fullResponse: 'ok', toolCalls: [] });
 
     const ctx = createContext({
       enabledToolIds: ['create_calendar_event'],
-      messages: [makeMessage({ role: 'system', content: 'You are helpful.' })],
+      messages: [
+        makeMessage({ role: 'system', content: 'You are helpful.' }),
+        makeMessage({ role: 'user', content: 'Schedule a sync' }),
+      ],
     });
     await runToolLoop(ctx);
 
     const sentMessages = mockedGenerateResponseWithTools.mock.calls[0][0];
+    // The STABLE date stays in the system prefix (kept cacheable turn-to-turn)...
     const sysContent = sentMessages.find((m: Message) => m.role === 'system')!.content as string;
-    // precise=true produces the YYYY-MM-DDTHH:MM:SS phrasing (not the date-only variant)
-    expect(sysContent).toContain('current date and time is');
-    expect(sysContent).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
-    expect(sysContent).toContain('in half an hour');
+    expect(sysContent).toContain('The current date is');
+    // ...while the EXACT time-of-day is appended to the latest user message instead,
+    // so the large system+tools prefix is not invalidated each turn (the TTFT fix).
+    const userContent = [...sentMessages]
+      .reverse()
+      .find((m: Message) => m.role === 'user')!.content as string;
+    expect(userContent).toContain('Current local date and time');
+    expect(userContent).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(userContent).toContain('in half an hour');
   });
 
   it('uses the date-only context when no time-sensitive tool is enabled', async () => {

--- a/src/screens/ChatScreen/ChatMessageArea.tsx
+++ b/src/screens/ChatScreen/ChatMessageArea.tsx
@@ -41,9 +41,23 @@ export type ChatMessageAreaProps = {
 // safe-area inset — that made the bottom feel like a large dead band vs the top.
 // The container already pads its bottom by 8, so cap the extra footer at 4 → 12
 // total, symmetric with the top. Collapses to 0 while the keyboard is up.
+//
+// BUT that cap only applies to a thin overlay inset (iOS home indicator / gesture
+// nav), which draws *over* content. A 3-button navigation bar is opaque and owns
+// real space at the bottom — capping there renders the input controls UNDER the
+// nav buttons. We distinguish by the inset size (not Platform.OS): anything above
+// the overlay threshold is a real nav bar, so honor the full inset and clear it.
 const FOOTER_SAFE_CAP = 4;
-const computeFooterPaddingBottom = (keyboardVisible: boolean, insetBottom: number): number =>
-  keyboardVisible ? 0 : Math.min(insetBottom, FOOTER_SAFE_CAP);
+// Home-indicator / gesture-nav overlays sit at ~24px or below on the devices we
+// target; a 3-button nav bar is taller. Above this, treat the inset as opaque.
+const OVERLAY_INSET_MAX = 24;
+export const computeFooterPaddingBottom = (keyboardVisible: boolean, insetBottom: number): number => {
+  if (keyboardVisible) return 0;
+  // Opaque nav bar (tall inset): pad the full inset so controls clear it.
+  if (insetBottom > OVERLAY_INSET_MAX) return insetBottom;
+  // Thin overlay inset: keep the symmetric-with-top cap.
+  return Math.min(insetBottom, FOOTER_SAFE_CAP);
+};
 
 // Small status bar above the input: classifying takes precedence over the
 // background model-load indicator.

--- a/src/screens/DownloadManagerScreen/useVoiceDownloadItems.ts
+++ b/src/screens/DownloadManagerScreen/useVoiceDownloadItems.ts
@@ -55,14 +55,19 @@ async function loadItems(): Promise<DownloadItem[]> {
       } else if (d.status === 'error') {
         // A failed Kokoro fetch. Surface it as a failed active item so the
         // Download Manager shows it with a Retry button (executorch resumes from
-        // its cache). 'download_interrupted' is a retryable reason code; the
-        // Retry action routes back through modelDownloadService.retry() →
-        // ttsProvider.retry() → the engine's downloadAssets().
+        // its cache); the Retry action routes back through
+        // modelDownloadService.retry() → ttsProvider.retry() → downloadAssets().
+        // Prefer the engine's own message: when d.error is present, leave
+        // reasonCode undefined so getDownloadStatusLabel shows that text rather
+        // than the canned message a known code maps to. Retry still renders
+        // because isRetryable(undefined) === true. Fall back to the retryable
+        // 'download_interrupted' code only when the engine gave no message.
         items.push({
           type: 'active', modelType: 'tts', modelId: engineId, fileName: d.name,
           author: 'Voice', quantization: '', fileSize: d.sizeBytes,
           bytesDownloaded: d.bytesDownloaded, progress: d.progress, status: 'failed', name: d.name,
-          reason: d.error, reasonCode: 'download_interrupted',
+          reason: d.error,
+          ...(d.error ? {} : { reasonCode: 'download_interrupted' as const }),
         });
       }
     }
@@ -113,9 +118,11 @@ export function useVoiceDownloadItems(onAlertClose: () => void): VoiceDownloadIt
 
   // Kokoro's download has no store to subscribe to (it's executorch's own fetcher),
   // so while a voice model is actively downloading, poll to advance its progress
-  // bar in the Download Manager. Stops as soon as nothing is in-progress.
+  // bar in the Download Manager. Gate on the in-progress status specifically — a
+  // failed item is also type:'active' (so ActiveDownloadCard renders its Retry),
+  // but it's terminal and must NOT keep an 800ms interval alive.
   useEffect(() => {
-    if (!voiceItems.some((i) => i.type === 'active')) return;
+    if (!voiceItems.some((i) => i.type === 'active' && i.status === 'downloading')) return;
     const t = setInterval(() => { refreshVoiceItems(); }, 800);
     return () => clearInterval(t);
   }, [voiceItems, refreshVoiceItems]);

--- a/src/screens/DownloadManagerScreen/useVoiceDownloadItems.ts
+++ b/src/screens/DownloadManagerScreen/useVoiceDownloadItems.ts
@@ -52,8 +52,19 @@ async function loadItems(): Promise<DownloadItem[]> {
           author: 'Voice', quantization: '', fileSize: d.sizeBytes,
           bytesDownloaded: d.bytesDownloaded, progress: d.progress, status: 'downloading', name: d.name,
         });
+      } else if (d.status === 'error') {
+        // A failed Kokoro fetch. Surface it as a failed active item so the
+        // Download Manager shows it with a Retry button (executorch resumes from
+        // its cache). 'download_interrupted' is a retryable reason code; the
+        // Retry action routes back through modelDownloadService.retry() →
+        // ttsProvider.retry() → the engine's downloadAssets().
+        items.push({
+          type: 'active', modelType: 'tts', modelId: engineId, fileName: d.name,
+          author: 'Voice', quantization: '', fileSize: d.sizeBytes,
+          bytesDownloaded: d.bytesDownloaded, progress: d.progress, status: 'failed', name: d.name,
+          reason: d.error, reasonCode: 'download_interrupted',
+        });
       }
-      // status 'error' for an executorch fetch → user re-taps download; nothing to show.
     }
   } catch {
     // ignore — listing failures leave items empty

--- a/src/services/generationToolLoop.ts
+++ b/src/services/generationToolLoop.ts
@@ -499,8 +499,8 @@ function nowParts() {
  * of being re-prefilled every turn. The exact time lives elsewhere (see below) so it
  * never busts this prefix.
  */
-function buildDateContext(): string {
-  const { dateStr, dayOfWeek, tz } = nowParts();
+function buildDateContext(parts: ReturnType<typeof nowParts>): string {
+  const { dateStr, dayOfWeek, tz } = parts;
   const dayPart = dayOfWeek ? ` Today is ${dayOfWeek}.` : '';
   const tzPart = tz ? ` Timezone: ${tz}.` : '';
   return `\n\nThe current date is ${dateStr} (device local date, format YYYY-MM-DD).${dayPart}${tzPart} When the user refers to relative dates such as "today", "tomorrow", or "next Friday", resolve them against this current date.`;
@@ -513,8 +513,8 @@ function buildDateContext(): string {
  * stable for cache reuse. Lets the model resolve "now" / "in half an hour" precisely.
  * Only added when a time-sensitive (calendar) tool is enabled.
  */
-function buildExactTimeNote(): string {
-  const { dateStr, timeStr, tz } = nowParts();
+function buildExactTimeNote(parts: ReturnType<typeof nowParts>): string {
+  const { dateStr, timeStr, tz } = parts;
   const tzPart = tz ? `, ${tz}` : '';
   return `\n\n(Current local date and time: ${dateStr}T${timeStr}${tzPart}. Resolve "now", "right now", "in half an hour", and similar against this exact time.)`;
 }
@@ -539,9 +539,12 @@ function augmentSystemPromptForTools(
   const extHints = nativeToolCalling
     ? ''
     : getToolExtensions().map(e => e.getSystemPromptHint()).filter(Boolean).join('');
+  // Snapshot the current time ONCE so the system-prompt date and the exact-time note
+  // can never disagree across a midnight/second rollover (both read the same snapshot).
+  const parts = nowParts();
   // System prompt gets only the STABLE date (changes once a day) + tool guidance, so the
   // system+tools prefix stays cacheable turn-to-turn.
-  const updatedSys = { ...sys, content: existing + TOOL_BEHAVIOR_GUIDANCE + buildDateContext() + extHints };
+  const updatedSys = { ...sys, content: existing + TOOL_BEHAVIOR_GUIDANCE + buildDateContext(parts) + extHints };
   const out = [...messages.slice(0, sysIdx), updatedSys, ...messages.slice(sysIdx + 1)];
 
   // For time-sensitive (calendar) tools, append the EXACT time to the latest user
@@ -552,7 +555,7 @@ function augmentSystemPromptForTools(
   if (precise) {
     for (let i = out.length - 1; i >= 0; i--) {
       if (out[i].role === 'user' && typeof out[i].content === 'string') {
-        out[i] = { ...out[i], content: (out[i].content as string) + buildExactTimeNote() };
+        out[i] = { ...out[i], content: (out[i].content as string) + buildExactTimeNote(parts) };
         exactTimeAppended = true;
         break;
       }

--- a/src/services/generationToolLoop.ts
+++ b/src/services/generationToolLoop.ts
@@ -474,24 +474,12 @@ const TOOL_BEHAVIOR_GUIDANCE = '\n\nMake good use of the tools available to you.
 /** Tools that need precise time-of-day to resolve relative phrases like "in half an hour". */
 const TIME_SENSITIVE_TOOL_IDS = ['create_calendar_event', 'read_calendar_events'];
 
-/**
- * Build a current-date(/time) context line for the system prompt. On-device models
- * have no built-in clock, so without this they cannot resolve relative dates
- * ("tomorrow", "next Friday") into the ISO timestamps the calendar tools need.
- *
- * `precise` controls the prompt-cache tradeoff:
- *  - true  -> full minute/second timestamp, so "in half an hour" resolves correctly.
- *    The timestamp changes every turn, which breaks llama.rn prefix-cache reuse from
- *    this point on. Only used when a time-sensitive tool (calendar) is enabled.
- *  - false -> date only. Stable for the whole day, so the prompt cache is preserved;
- *    day-relative phrasing still works, but sub-day phrasing does not.
- *
- * Computed at send-time (not module load) so it stays current across a session.
- */
-function buildDateTimeContext(precise: boolean): string {
+// Shared current-time parts, computed at send-time (on-device models have no clock).
+function nowParts() {
   const now = new Date();
   const pad = (n: number) => String(n).padStart(2, '0');
   const dateStr = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+  const timeStr = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
   let dayOfWeek = '';
   let tz = '';
   try {
@@ -500,13 +488,35 @@ function buildDateTimeContext(precise: boolean): string {
   } catch {
     // toLocaleDateString/Intl can be unavailable on some JS engines; date alone still helps.
   }
+  return { dateStr, timeStr, dayOfWeek, tz };
+}
+
+/**
+ * Date-only context for the SYSTEM prompt. On-device models have no clock, so this
+ * lets them resolve day-relative phrasing ("tomorrow", "next Friday"). The date only
+ * changes once a day, so the system prompt + tool schemas stay byte-identical across
+ * turns and the (expensive ~800-token) prefix is reused from llama.rn's cache instead
+ * of being re-prefilled every turn. The exact time lives elsewhere (see below) so it
+ * never busts this prefix.
+ */
+function buildDateContext(): string {
+  const { dateStr, dayOfWeek, tz } = nowParts();
   const dayPart = dayOfWeek ? ` Today is ${dayOfWeek}.` : '';
   const tzPart = tz ? ` Timezone: ${tz}.` : '';
-  if (precise) {
-    const local = `${dateStr}T${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
-    return `\n\nThe current date and time is ${local} (device local time, format YYYY-MM-DDTHH:MM:SS).${dayPart}${tzPart} When the user refers to relative dates or times such as "today", "tomorrow", "next Friday", or "in half an hour", resolve them against this current date and time.`;
-  }
   return `\n\nThe current date is ${dateStr} (device local date, format YYYY-MM-DD).${dayPart}${tzPart} When the user refers to relative dates such as "today", "tomorrow", or "next Friday", resolve them against this current date.`;
+}
+
+/**
+ * Exact current time, appended to the LATEST USER MESSAGE rather than the system
+ * prompt. The latest user turn is new (uncached) every time anyway, so carrying the
+ * volatile timestamp here costs nothing extra and keeps the system+tools prefix
+ * stable for cache reuse. Lets the model resolve "now" / "in half an hour" precisely.
+ * Only added when a time-sensitive (calendar) tool is enabled.
+ */
+function buildExactTimeNote(): string {
+  const { dateStr, timeStr, tz } = nowParts();
+  const tzPart = tz ? `, ${tz}` : '';
+  return `\n\n(Current local date and time: ${dateStr}T${timeStr}${tzPart}. Resolve "now", "right now", "in half an hour", and similar against this exact time.)`;
 }
 
 function augmentSystemPromptForTools(
@@ -515,7 +525,10 @@ function augmentSystemPromptForTools(
   nativeToolCalling = false,
 ): Message[] {
   const sysIdx = messages.findIndex(m => m.role === 'system');
-  if (sysIdx === -1) return messages;
+  if (sysIdx === -1) {
+    logger.log(`[ToolLoop] augmentSystemPrompt: NO system message - date NOT injected (enabledToolIds=[${enabledToolIds.join(',')}])`);
+    return messages;
+  }
   const sys = messages[sysIdx];
   const existing = typeof sys.content === 'string' ? sys.content : '';
   // Extension text hints (e.g. MCP's "call tools using <mcp_tool_call>{…}") only make
@@ -526,9 +539,31 @@ function augmentSystemPromptForTools(
   const extHints = nativeToolCalling
     ? ''
     : getToolExtensions().map(e => e.getSystemPromptHint()).filter(Boolean).join('');
+  // System prompt gets only the STABLE date (changes once a day) + tool guidance, so the
+  // system+tools prefix stays cacheable turn-to-turn.
+  const updatedSys = { ...sys, content: existing + TOOL_BEHAVIOR_GUIDANCE + buildDateContext() + extHints };
+  const out = [...messages.slice(0, sysIdx), updatedSys, ...messages.slice(sysIdx + 1)];
+
+  // For time-sensitive (calendar) tools, append the EXACT time to the latest user
+  // message instead of the system prefix — keeps the big prefix cacheable while still
+  // giving the model sub-day precision.
   const precise = enabledToolIds.some(id => TIME_SENSITIVE_TOOL_IDS.includes(id));
-  const updated = { ...sys, content: existing + TOOL_BEHAVIOR_GUIDANCE + buildDateTimeContext(precise) + extHints };
-  return [...messages.slice(0, sysIdx), updated, ...messages.slice(sysIdx + 1)];
+  let exactTimeAppended = false;
+  if (precise) {
+    for (let i = out.length - 1; i >= 0; i--) {
+      if (out[i].role === 'user' && typeof out[i].content === 'string') {
+        out[i] = { ...out[i], content: (out[i].content as string) + buildExactTimeNote() };
+        exactTimeAppended = true;
+        break;
+      }
+    }
+  }
+  logger.log(
+    `[ToolLoop] augmentSystemPrompt: enabledToolIds=[${enabledToolIds.join(',')}] ` +
+      `timeSensitive(precise)=${precise} nativeToolCalling=${nativeToolCalling} ` +
+      `dateInSystem=true exactTimeOnLatestUser=${exactTimeAppended}`,
+  );
+  return out;
 }
 
 interface CallLLMOptions { onStream?: (data: StreamToken) => void; forceRemote?: boolean; disableThinking?: boolean; conversationId?: string; ctx?: ToolLoopContext; }
@@ -550,6 +585,11 @@ async function callLLMWithRetry(
   // LiteRT (OpenApiTool), remote providers, and llama with a Jinja tool template all do
   // native tool calling — the text hint must be suppressed for them (see augmentSystemPromptForTools).
   const nativeToolCalling = (isLiteRTActive() && !!conversationId) || useRemote || llmService.supportsToolCalling();
+  logger.log(
+    `[ToolLoop] preLLM: tools=${tools.length} extCount=${extCount} ` +
+      `enabledToolIds=[${(ctx?.enabledToolIds ?? []).join(',')}] ` +
+      `willAugment=${tools.length > 0 || extCount > 0} liteRT=${isLiteRTActive()} useRemote=${useRemote} nativeToolCalling=${nativeToolCalling}`,
+  );
   const augmentedMessages = (tools.length > 0 || extCount > 0)
     ? augmentSystemPromptForTools(messages, ctx?.enabledToolIds, nativeToolCalling)
     : messages;

--- a/src/services/generationToolLoop.ts
+++ b/src/services/generationToolLoop.ts
@@ -516,7 +516,7 @@ function buildDateContext(parts: ReturnType<typeof nowParts>): string {
 function buildExactTimeNote(parts: ReturnType<typeof nowParts>): string {
   const { dateStr, timeStr, tz } = parts;
   const tzPart = tz ? `, ${tz}` : '';
-  return `\n\n(Current local date and time: ${dateStr}T${timeStr}${tzPart}. Resolve "now", "right now", "in half an hour", and similar against this exact time.)`;
+  return `\n\n(Current local date and time: ${dateStr}T${timeStr}${tzPart}. Use this only to resolve relative times like "now", "right now", or "in half an hour" — do not mention or comment on the current date or time in your reply unless the user explicitly asks.)`;
 }
 
 function augmentSystemPromptForTools(


### PR DESCRIPTION
The chat input footer capped its bottom safe-area padding at 4px. That is correct for a thin iOS home-indicator / gesture-nav overlay (it draws *over* content) but wrong for an opaque 3-button navigation bar, which owns real space at the bottom. On devices with 3-button nav the input controls (+/settings/mic) rendered underneath the nav buttons.

## Fix
Distinguish the two inset types by size, **not** `Platform.OS` (per the platform-abstraction rule against branching on OS for layout mechanism):
- Inset > 24px → opaque nav bar → honor the **full** inset so the controls clear it.
- Inset ≤ 24px → thin overlay (home indicator / gesture nav) → keep the 4px symmetric-with-top cap.
- Keyboard open → collapses to 0 (the keyboard already covers the gesture area).

The inset value itself tells us which case we're in, so this corrects Android 3-button nav and any tall-inset device without a per-platform branch.

## Test
Exported `computeFooterPaddingBottom` and added a unit test covering all three cases (keyboard-open, thin overlay capped at 4, tall nav bar honoring the full inset). It fails against the pre-fix code (which returned 4 for a 48px nav bar) and passes after.

Verified on a OnePlus/Oppo device with 3-button navigation (`navigation_mode = 0`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat input footer spacing so bottom padding now respects the type of safe-area inset.
  * Keyboard-visible states now collapse padding to zero.
  * Thin bottom overlays use a small capped padding, while larger navigation bars keep their full inset for better layout consistency.

* **Tests**
  * Added regression coverage for footer padding behavior across keyboard and safe-area scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->