### PR TITLE
perf(chat): cacheable tool/date prompt prefix (TTFT fix)

### DIFF
--- a/__tests__/unit/services/generationToolLoop.branches.test.ts
+++ b/__tests__/unit/services/generationToolLoop.branches.test.ts
@@ -354,21 +354,30 @@ describe('runToolLoop — LiteRT loop branches', () => {
 describe('runToolLoop — precise date/time context for calendar tools', () => {
   beforeEach(resetMocks);
 
-  it('augments the system prompt with a precise timestamp when a calendar tool is enabled', async () => {
+  it('appends a precise time-of-day note to the latest user message when a calendar tool is enabled', async () => {
     mockedGenerateResponseWithTools.mockResolvedValue({ fullResponse: 'ok', toolCalls: [] });
 
     const ctx = createContext({
       enabledToolIds: ['create_calendar_event'],
-      messages: [makeMessage({ role: 'system', content: 'You are helpful.' })],
+      messages: [
+        makeMessage({ role: 'system', content: 'You are helpful.' }),
+        makeMessage({ role: 'user', content: 'Schedule a sync' }),
+      ],
     });
     await runToolLoop(ctx);
 
     const sentMessages = mockedGenerateResponseWithTools.mock.calls[0][0];
+    // The STABLE date stays in the system prefix (kept cacheable turn-to-turn)...
     const sysContent = sentMessages.find((m: Message) => m.role === 'system')!.content as string;
-    // precise=true produces the YYYY-MM-DDTHH:MM:SS phrasing (not the date-only variant)
-    expect(sysContent).toContain('current date and time is');
-    expect(sysContent).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
-    expect(sysContent).toContain('in half an hour');
+    expect(sysContent).toContain('The current date is');
+    // ...while the EXACT time-of-day is appended to the latest user message instead,
+    // so the large system+tools prefix is not invalidated each turn (the TTFT fix).
+    const userContent = [...sentMessages]
+      .reverse()
+      .find((m: Message) => m.role === 'user')!.content as string;
+    expect(userContent).toContain('Current local date and time');
+    expect(userContent).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(userContent).toContain('in half an hour');
   });
 
   it('uses the date-only context when no time-sensitive tool is enabled', async () => {

--- a/src/services/generationToolLoop.ts
+++ b/src/services/generationToolLoop.ts
@@ -499,8 +499,8 @@ function nowParts() {
  * of being re-prefilled every turn. The exact time lives elsewhere (see below) so it
  * never busts this prefix.
  */
-function buildDateContext(): string {
-  const { dateStr, dayOfWeek, tz } = nowParts();
+function buildDateContext(parts: ReturnType<typeof nowParts>): string {
+  const { dateStr, dayOfWeek, tz } = parts;
   const dayPart = dayOfWeek ? ` Today is ${dayOfWeek}.` : '';
   const tzPart = tz ? ` Timezone: ${tz}.` : '';
   return `\n\nThe current date is ${dateStr} (device local date, format YYYY-MM-DD).${dayPart}${tzPart} When the user refers to relative dates such as "today", "tomorrow", or "next Friday", resolve them against this current date.`;
@@ -513,8 +513,8 @@ function buildDateContext(): string {
  * stable for cache reuse. Lets the model resolve "now" / "in half an hour" precisely.
  * Only added when a time-sensitive (calendar) tool is enabled.
  */
-function buildExactTimeNote(): string {
-  const { dateStr, timeStr, tz } = nowParts();
+function buildExactTimeNote(parts: ReturnType<typeof nowParts>): string {
+  const { dateStr, timeStr, tz } = parts;
   const tzPart = tz ? `, ${tz}` : '';
   return `\n\n(Current local date and time: ${dateStr}T${timeStr}${tzPart}. Resolve "now", "right now", "in half an hour", and similar against this exact time.)`;
 }
@@ -539,9 +539,12 @@ function augmentSystemPromptForTools(
   const extHints = nativeToolCalling
     ? ''
     : getToolExtensions().map(e => e.getSystemPromptHint()).filter(Boolean).join('');
+  // Snapshot the current time ONCE so the system-prompt date and the exact-time note
+  // can never disagree across a midnight/second rollover (both read the same snapshot).
+  const parts = nowParts();
   // System prompt gets only the STABLE date (changes once a day) + tool guidance, so the
   // system+tools prefix stays cacheable turn-to-turn.
-  const updatedSys = { ...sys, content: existing + TOOL_BEHAVIOR_GUIDANCE + buildDateContext() + extHints };
+  const updatedSys = { ...sys, content: existing + TOOL_BEHAVIOR_GUIDANCE + buildDateContext(parts) + extHints };
   const out = [...messages.slice(0, sysIdx), updatedSys, ...messages.slice(sysIdx + 1)];
 
   // For time-sensitive (calendar) tools, append the EXACT time to the latest user
@@ -552,7 +555,7 @@ function augmentSystemPromptForTools(
   if (precise) {
     for (let i = out.length - 1; i >= 0; i--) {
       if (out[i].role === 'user' && typeof out[i].content === 'string') {
-        out[i] = { ...out[i], content: (out[i].content as string) + buildExactTimeNote() };
+        out[i] = { ...out[i], content: (out[i].content as string) + buildExactTimeNote(parts) };
         exactTimeAppended = true;
         break;
       }

--- a/src/services/generationToolLoop.ts
+++ b/src/services/generationToolLoop.ts
@@ -474,24 +474,12 @@ const TOOL_BEHAVIOR_GUIDANCE = '\n\nMake good use of the tools available to you.
 /** Tools that need precise time-of-day to resolve relative phrases like "in half an hour". */
 const TIME_SENSITIVE_TOOL_IDS = ['create_calendar_event', 'read_calendar_events'];
 
-/**
- * Build a current-date(/time) context line for the system prompt. On-device models
- * have no built-in clock, so without this they cannot resolve relative dates
- * ("tomorrow", "next Friday") into the ISO timestamps the calendar tools need.
- *
- * `precise` controls the prompt-cache tradeoff:
- *  - true  -> full minute/second timestamp, so "in half an hour" resolves correctly.
- *    The timestamp changes every turn, which breaks llama.rn prefix-cache reuse from
- *    this point on. Only used when a time-sensitive tool (calendar) is enabled.
- *  - false -> date only. Stable for the whole day, so the prompt cache is preserved;
- *    day-relative phrasing still works, but sub-day phrasing does not.
- *
- * Computed at send-time (not module load) so it stays current across a session.
- */
-function buildDateTimeContext(precise: boolean): string {
+// Shared current-time parts, computed at send-time (on-device models have no clock).
+function nowParts() {
   const now = new Date();
   const pad = (n: number) => String(n).padStart(2, '0');
   const dateStr = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+  const timeStr = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
   let dayOfWeek = '';
   let tz = '';
   try {
@@ -500,13 +488,35 @@ function buildDateTimeContext(precise: boolean): string {
   } catch {
     // toLocaleDateString/Intl can be unavailable on some JS engines; date alone still helps.
   }
+  return { dateStr, timeStr, dayOfWeek, tz };
+}
+
+/**
+ * Date-only context for the SYSTEM prompt. On-device models have no clock, so this
+ * lets them resolve day-relative phrasing ("tomorrow", "next Friday"). The date only
+ * changes once a day, so the system prompt + tool schemas stay byte-identical across
+ * turns and the (expensive ~800-token) prefix is reused from llama.rn's cache instead
+ * of being re-prefilled every turn. The exact time lives elsewhere (see below) so it
+ * never busts this prefix.
+ */
+function buildDateContext(): string {
+  const { dateStr, dayOfWeek, tz } = nowParts();
   const dayPart = dayOfWeek ? ` Today is ${dayOfWeek}.` : '';
   const tzPart = tz ? ` Timezone: ${tz}.` : '';
-  if (precise) {
-    const local = `${dateStr}T${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
-    return `\n\nThe current date and time is ${local} (device local time, format YYYY-MM-DDTHH:MM:SS).${dayPart}${tzPart} When the user refers to relative dates or times such as "today", "tomorrow", "next Friday", or "in half an hour", resolve them against this current date and time.`;
-  }
   return `\n\nThe current date is ${dateStr} (device local date, format YYYY-MM-DD).${dayPart}${tzPart} When the user refers to relative dates such as "today", "tomorrow", or "next Friday", resolve them against this current date.`;
+}
+
+/**
+ * Exact current time, appended to the LATEST USER MESSAGE rather than the system
+ * prompt. The latest user turn is new (uncached) every time anyway, so carrying the
+ * volatile timestamp here costs nothing extra and keeps the system+tools prefix
+ * stable for cache reuse. Lets the model resolve "now" / "in half an hour" precisely.
+ * Only added when a time-sensitive (calendar) tool is enabled.
+ */
+function buildExactTimeNote(): string {
+  const { dateStr, timeStr, tz } = nowParts();
+  const tzPart = tz ? `, ${tz}` : '';
+  return `\n\n(Current local date and time: ${dateStr}T${timeStr}${tzPart}. Resolve "now", "right now", "in half an hour", and similar against this exact time.)`;
 }
 
 function augmentSystemPromptForTools(
@@ -515,7 +525,10 @@ function augmentSystemPromptForTools(
   nativeToolCalling = false,
 ): Message[] {
   const sysIdx = messages.findIndex(m => m.role === 'system');
-  if (sysIdx === -1) return messages;
+  if (sysIdx === -1) {
+    logger.log(`[ToolLoop] augmentSystemPrompt: NO system message - date NOT injected (enabledToolIds=[${enabledToolIds.join(',')}])`);
+    return messages;
+  }
   const sys = messages[sysIdx];
   const existing = typeof sys.content === 'string' ? sys.content : '';
   // Extension text hints (e.g. MCP's "call tools using <mcp_tool_call>{…}") only make
@@ -526,9 +539,31 @@ function augmentSystemPromptForTools(
   const extHints = nativeToolCalling
     ? ''
     : getToolExtensions().map(e => e.getSystemPromptHint()).filter(Boolean).join('');
+  // System prompt gets only the STABLE date (changes once a day) + tool guidance, so the
+  // system+tools prefix stays cacheable turn-to-turn.
+  const updatedSys = { ...sys, content: existing + TOOL_BEHAVIOR_GUIDANCE + buildDateContext() + extHints };
+  const out = [...messages.slice(0, sysIdx), updatedSys, ...messages.slice(sysIdx + 1)];
+
+  // For time-sensitive (calendar) tools, append the EXACT time to the latest user
+  // message instead of the system prefix — keeps the big prefix cacheable while still
+  // giving the model sub-day precision.
   const precise = enabledToolIds.some(id => TIME_SENSITIVE_TOOL_IDS.includes(id));
-  const updated = { ...sys, content: existing + TOOL_BEHAVIOR_GUIDANCE + buildDateTimeContext(precise) + extHints };
-  return [...messages.slice(0, sysIdx), updated, ...messages.slice(sysIdx + 1)];
+  let exactTimeAppended = false;
+  if (precise) {
+    for (let i = out.length - 1; i >= 0; i--) {
+      if (out[i].role === 'user' && typeof out[i].content === 'string') {
+        out[i] = { ...out[i], content: (out[i].content as string) + buildExactTimeNote() };
+        exactTimeAppended = true;
+        break;
+      }
+    }
+  }
+  logger.log(
+    `[ToolLoop] augmentSystemPrompt: enabledToolIds=[${enabledToolIds.join(',')}] ` +
+      `timeSensitive(precise)=${precise} nativeToolCalling=${nativeToolCalling} ` +
+      `dateInSystem=true exactTimeOnLatestUser=${exactTimeAppended}`,
+  );
+  return out;
 }
 
 interface CallLLMOptions { onStream?: (data: StreamToken) => void; forceRemote?: boolean; disableThinking?: boolean; conversationId?: string; ctx?: ToolLoopContext; }
@@ -550,6 +585,11 @@ async function callLLMWithRetry(
   // LiteRT (OpenApiTool), remote providers, and llama with a Jinja tool template all do
   // native tool calling — the text hint must be suppressed for them (see augmentSystemPromptForTools).
   const nativeToolCalling = (isLiteRTActive() && !!conversationId) || useRemote || llmService.supportsToolCalling();
+  logger.log(
+    `[ToolLoop] preLLM: tools=${tools.length} extCount=${extCount} ` +
+      `enabledToolIds=[${(ctx?.enabledToolIds ?? []).join(',')}] ` +
+      `willAugment=${tools.length > 0 || extCount > 0} liteRT=${isLiteRTActive()} useRemote=${useRemote} nativeToolCalling=${nativeToolCalling}`,
+  );
   const augmentedMessages = (tools.length > 0 || extCount > 0)
     ? augmentSystemPromptForTools(messages, ctx?.enabledToolIds, nativeToolCalling)
     : messages;

--- a/src/services/generationToolLoop.ts
+++ b/src/services/generationToolLoop.ts
@@ -516,7 +516,7 @@ function buildDateContext(parts: ReturnType<typeof nowParts>): string {
 function buildExactTimeNote(parts: ReturnType<typeof nowParts>): string {
   const { dateStr, timeStr, tz } = parts;
   const tzPart = tz ? `, ${tz}` : '';
-  return `\n\n(Current local date and time: ${dateStr}T${timeStr}${tzPart}. Resolve "now", "right now", "in half an hour", and similar against this exact time.)`;
+  return `\n\n(Current local date and time: ${dateStr}T${timeStr}${tzPart}. Use this only to resolve relative times like "now", "right now", or "in half an hour" — do not mention or comment on the current date or time in your reply unless the user explicitly asks.)`;
 }
 
 function augmentSystemPromptForTools(


### PR DESCRIPTION
**Stacked on `fix/kokoro-download-manager-sync`** (base of this PR), which itself carries
the stability/perf work. Review/merge that one first.

## What & why

On-device models re-prefill the whole prompt prefix each turn unless it is byte-stable
(llama.rn prefix cache). The tool + date context sat in the **system prompt** and, when a
time-sensitive (calendar) tool was enabled, embedded a **precise timestamp that changes
every turn** - so the ~800-token system+tools prefix was invalidated every turn, tanking
time-to-first-token.

## The fix (`src/services/generationToolLoop.ts`)

Split the timestamp by cache-locality:
- **System prompt** keeps only the **stable date** (`buildDateContext`, changes once a
  day) -> the system+tools prefix stays byte-identical turn-to-turn and is reused from
  llama.rn's cache instead of re-prefilled.
- **Latest user message** carries the **exact time-of-day** (`buildExactTimeNote`) - that
  turn is new/uncached anyway, so the volatile timestamp costs nothing there while still
  letting the model resolve "now" / "in half an hour". Only appended when a time-sensitive
  tool is enabled.
- Adds tool-loop diagnostic logging.

## Test

`generationToolLoop.branches.test.ts` updated: with a calendar tool enabled, the system
prompt carries only the stable date, and the precise "Current local date and time" note
lands on the **latest user message**.

## Risk

One file + its test. Behaviour unchanged for non-time-sensitive tools and when there is no
system message. Net effect: prefix-cache reuse -> lower TTFT when calendar tools are on;
correctness of relative-time phrasing preserved via the user-message note.
