### PR TITLE
fix(remote): show a clean model name, not the raw file path

### DIFF
--- a/__tests__/unit/stores/displayModelName.test.ts
+++ b/__tests__/unit/stores/displayModelName.test.ts
@@ -27,6 +27,18 @@ describe('displayModelName', () => {
     expect(displayModelName('gpt-4o-mini')).toBe('gpt-4o-mini');
   });
 
+  it('keeps a namespace-style slug intact (does NOT treat / as a path separator)', () => {
+    // Regression (qodo #438): "org/model" slugs must not be basename-stripped —
+    // that would drop the namespace and collapse distinct models to the same label.
+    expect(displayModelName('meta-llama/Llama-3.1-8B')).toBe('meta-llama/Llama-3.1-8B');
+    expect(displayModelName('qwen/qwen3')).toBe('qwen/qwen3');
+    expect(displayModelName('org/model')).toBe('org/model');
+  });
+
+  it('still strips a namespaced id that ends in a model extension (a real path)', () => {
+    expect(displayModelName('models/Qwen3.5-9B-Q4_K_M.gguf')).toBe('Qwen3.5-9B-Q4_K_M');
+  });
+
   it('keeps a dotted name that is not a known model extension', () => {
     expect(displayModelName('Qwen3.5-9B')).toBe('Qwen3.5-9B');
   });

--- a/__tests__/unit/stores/displayModelName.test.ts
+++ b/__tests__/unit/stores/displayModelName.test.ts
@@ -1,0 +1,33 @@
+/**
+ * displayModelName — the picker label for a remote model. Some gateways report
+ * the model id as a full file path; the picker must show a clean basename without
+ * the extension, while the raw id is still used for loading.
+ */
+import { displayModelName } from '../../../src/stores/remoteServerHelpers';
+
+describe('displayModelName', () => {
+  it('strips a full file path down to the basename without extension', () => {
+    expect(displayModelName('/Users/admin/.offgrid/models/Qwen3.5-9B-Q4_K_M.gguf'))
+      .toBe('Qwen3.5-9B-Q4_K_M');
+  });
+
+  it('handles Windows-style backslash paths', () => {
+    expect(displayModelName('C:\\models\\Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf'))
+      .toBe('Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M');
+  });
+
+  it('strips the extension for various model formats', () => {
+    expect(displayModelName('/m/model.safetensors')).toBe('model');
+    expect(displayModelName('/m/model.task')).toBe('model');
+    expect(displayModelName('/m/model.litertlm')).toBe('model');
+  });
+
+  it('leaves a plain id (no path, no extension) unchanged', () => {
+    expect(displayModelName('llama3.1:8b')).toBe('llama3.1:8b');
+    expect(displayModelName('gpt-4o-mini')).toBe('gpt-4o-mini');
+  });
+
+  it('keeps a dotted name that is not a known model extension', () => {
+    expect(displayModelName('Qwen3.5-9B')).toBe('Qwen3.5-9B');
+  });
+});

--- a/src/stores/remoteServerHelpers.ts
+++ b/src/stores/remoteServerHelpers.ts
@@ -34,15 +34,29 @@ function isTextModel(model: { id?: string; name?: string; kind?: unknown }): boo
   return isGenerativeModel(model.id ?? model.name ?? '');
 }
 
+const MODEL_FILE_EXT = /\.(gguf|bin|safetensors|task|litertlm|pte)$/i;
+
 /**
  * Human-readable label for a remote model. Some gateways report the model id as a
  * full file path (e.g. "/Users/admin/.offgrid/models/Qwen3.5-9B-Q4_K_M.gguf"),
  * which is unreadable in the picker. Show the basename without the extension while
- * keeping the raw id for loading. A plain id (no path/extension) is returned as-is.
+ * keeping the raw id for loading.
+ *
+ * Only basename-strip when the id actually LOOKS like a filesystem path — an
+ * absolute POSIX path ("/…"), a Windows path ("C:\…" / "C:/…"), or any string
+ * that ends in a known model file extension. A namespace-style slug ("org/model",
+ * "meta-llama/Llama-3.1-8B") is NOT a path: stripping its prefix would drop the
+ * meaningful namespace and could collapse distinct models to the same label, so
+ * it's returned unchanged.
  */
 export function displayModelName(id: string): string {
-  const base = id.split(/[\\/]/).pop() || id;
-  return base.replace(/\.(gguf|bin|safetensors|task|litertlm|pte)$/i, '');
+  const looksLikePath =
+    id.startsWith('/') ||
+    /^[A-Za-z]:[\\/]/.test(id) ||
+    id.includes('\\') ||
+    MODEL_FILE_EXT.test(id);
+  const base = looksLikePath ? (id.split(/[\\/]/).pop() || id) : id;
+  return base.replace(MODEL_FILE_EXT, '');
 }
 
 export async function testServerConnection(server: RemoteServer): Promise<ServerTestResult> {

--- a/src/stores/remoteServerHelpers.ts
+++ b/src/stores/remoteServerHelpers.ts
@@ -34,6 +34,17 @@ function isTextModel(model: { id?: string; name?: string; kind?: unknown }): boo
   return isGenerativeModel(model.id ?? model.name ?? '');
 }
 
+/**
+ * Human-readable label for a remote model. Some gateways report the model id as a
+ * full file path (e.g. "/Users/admin/.offgrid/models/Qwen3.5-9B-Q4_K_M.gguf"),
+ * which is unreadable in the picker. Show the basename without the extension while
+ * keeping the raw id for loading. A plain id (no path/extension) is returned as-is.
+ */
+export function displayModelName(id: string): string {
+  const base = id.split(/[\\/]/).pop() || id;
+  return base.replace(/\.(gguf|bin|safetensors|task|litertlm|pte)$/i, '');
+}
+
 export async function testServerConnection(server: RemoteServer): Promise<ServerTestResult> {
   try {
     const testResult = await testEndpoint(server.endpoint, 10000, server.apiKey);
@@ -153,7 +164,7 @@ export async function fetchModelsFromServer(server: RemoteServer): Promise<Remot
         );
         return generativeModels.map((model: { id: string; owned_by?: string; max_context_length?: number }, i: number) => ({
           id: model.id,
-          name: model.id,
+          name: displayModelName(model.id),
           serverId: server.id,
           capabilities: {
             supportsVision: modelInfos[i].supportsVision,
@@ -178,7 +189,7 @@ export async function fetchModelsFromServer(server: RemoteServer): Promise<Remot
         return generativeModels.map(
           (model: { name: string; details?: Record<string, unknown> }, i: number) => ({
             id: model.name,
-            name: model.name,
+            name: displayModelName(model.name),
             serverId: server.id,
             capabilities: {
               supportsVision: modelInfos[i].supportsVision,
@@ -226,7 +237,7 @@ export async function fetchModelsFromServer(server: RemoteServer): Promise<Remot
         return generativeModels.map(
           (model: { name: string; details?: Record<string, unknown> }, i: number) => ({
             id: model.name,
-            name: model.name,
+            name: displayModelName(model.name),
             serverId: server.id,
             capabilities: {
               supportsVision: modelInfos[i].supportsVision,


### PR DESCRIPTION
Stacked on perf/chat-ttft-prompt-cache.

Some gateways report a remote model's id as a full file path (e.g. `/Users/admin/.offgrid/models/Qwen3.5-9B-Q4_K_M.gguf`), and the model picker set `name = id`, so the list showed the whole path instead of a readable name.

## Fix
Added `displayModelName(id)` — the basename without the model extension (`.gguf`/`.bin`/`.safetensors`/`.task`/`.litertlm`/`.pte`) — and used it for the `name` field in all three discovery mappers (OpenAI `/v1/models`, Ollama `/v1/models`, Ollama `/api/tags`). The raw `id` is unchanged, so model loading still works; only the displayed label changes.

- Path-style ids (`/` and `\`) → basename; extension stripped.
- Plain ids (`llama3.1:8b`) and non-extension dotted names (`Qwen3.5-9B`) pass through untouched.

## Test
5 unit tests for `displayModelName` covering path stripping, Windows paths, each extension, and pass-through cases. tsc + eslint clean; existing remoteServerStore tests still green.