### PR TITLE
fix(device): download-state identity/finalize + chat-screen freeze (device-test bugs)

### DIFF
--- a/__tests__/rntl/screens/DownloadManagerScreen.test.tsx
+++ b/__tests__/rntl/screens/DownloadManagerScreen.test.tsx
@@ -698,8 +698,9 @@ describe('DownloadManagerScreen', () => {
       fireEvent.press(getByTestId('alert-button-Yes'));
     });
 
-    // View dispatches cancel by the canonical id; the provider performs the native cancel.
-    expect(mockServiceCancel).toHaveBeenCalledWith('text:author/model-id');
+    // View dispatches cancel by the canonical id (text = the modelKey, matching the
+    // finished model's id); the provider performs the native cancel.
+    expect(mockServiceCancel).toHaveBeenCalledWith('text:author/model-id/model-file.gguf');
   });
 
   it('confirming remove download for image model cancels it', async () => {
@@ -860,7 +861,7 @@ describe('DownloadManagerScreen', () => {
       fireEvent.press(getByTestId('failed-retry-button'));
     });
 
-    expect(mockServiceRetry).toHaveBeenCalledWith('text:author/vision');
+    expect(mockServiceRetry).toHaveBeenCalledWith('text:author/vision/vision.gguf');
   });
 
   // ===== BRANCH COVERAGE TESTS =====

--- a/__tests__/unit/screens/ChatScreen/messageRendererMemo.test.ts
+++ b/__tests__/unit/screens/ChatScreen/messageRendererMemo.test.ts
@@ -1,0 +1,53 @@
+/**
+ * MessageRenderer memo comparator — guards the chat-screen freeze fix.
+ *
+ * A ChatScreen re-render (streaming token, focus after the document picker, keyboard,
+ * unrelated store tick) must NOT re-render + re-parse the markdown of every message.
+ * getDisplayMessages keeps stable refs for historical messages, so the comparator
+ * skips them and only the changed (streaming) item re-renders.
+ */
+import { messageRendererPropsEqual } from '../../../../src/screens/ChatScreen/MessageRenderer';
+
+const base = () => ({
+  item: { id: 'm1', role: 'assistant' as const, content: 'hello', timestamp: 1 } as any,
+  index: 0,
+  displayMessagesLength: 3,
+  animateLastN: 0,
+  imageModelLoaded: false,
+  isStreaming: false,
+  isGeneratingImage: false,
+  showGenerationDetails: false,
+  onCopy: () => {}, onRetry: () => {}, onEdit: () => {}, onGenerateImage: () => {}, onImagePress: () => {},
+});
+
+describe('messageRendererPropsEqual', () => {
+  it('skips re-render when the message ref and flags are unchanged (the freeze fix)', () => {
+    const prev = base();
+    const next = { ...prev, item: prev.item }; // same message object ref
+    expect(messageRendererPropsEqual(prev as any, next as any)).toBe(true);
+  });
+
+  it('IGNORES the always-fresh on* callbacks (else the memo would never skip)', () => {
+    const prev = base();
+    // Every parent render recreates these inline in useChatScreen — new refs must not
+    // force a re-render, or the whole list re-parses markdown every render (the freeze).
+    const next = { ...prev, onCopy: () => {}, onRetry: () => {}, onImagePress: () => {} };
+    expect(messageRendererPropsEqual(prev as any, next as any)).toBe(true);
+  });
+
+  it('re-renders when the message object changes (new content → new ref, e.g. the streaming item)', () => {
+    const prev = base();
+    const next = { ...prev, item: { ...prev.item, content: 'hello world' } };
+    expect(messageRendererPropsEqual(prev as any, next as any)).toBe(false);
+  });
+
+  it('re-renders when a render-affecting flag changes (streaming end, animation, image state)', () => {
+    const prev = base();
+    for (const patch of [
+      { isStreaming: true }, { isGeneratingImage: true }, { imageModelLoaded: true },
+      { showGenerationDetails: true }, { animateLastN: 2 }, { displayMessagesLength: 4 }, { index: 1 },
+    ]) {
+      expect(messageRendererPropsEqual(prev as any, { ...prev, ...patch } as any)).toBe(false);
+    }
+  });
+});

--- a/__tests__/unit/services/classifierProvisioning.test.ts
+++ b/__tests__/unit/services/classifierProvisioning.test.ts
@@ -7,14 +7,19 @@ jest.mock('../../../src/stores', () => ({
   useAppStore: { getState: () => mockState },
 }));
 
-const mockDownloadModelBackground = jest.fn();
-const mockWatchDownload = jest.fn();
 jest.mock('../../../src/services/modelManager', () => ({
   modelManager: {
     isBackgroundDownloadSupported: () => true,
-    downloadModelBackground: (...a: any[]) => mockDownloadModelBackground(...a),
-    watchDownload: (...a: any[]) => mockWatchDownload(...a),
   },
+}));
+
+// The classifier now downloads through THE single entry point (startModelDownload),
+// which registers the model AND clears the in-flight row on completion — the old
+// parallel downloadModelBackground + watchDownload left a phantom "downloading 100%"
+// row behind. The test drives startModelDownload's onRegistered hook.
+const mockStartModelDownload = jest.fn();
+jest.mock('../../../src/services/startModelDownload', () => ({
+  startModelDownload: (...a: any[]) => mockStartModelDownload(...a),
 }));
 
 const mockGetModelFiles = jest.fn();
@@ -43,32 +48,34 @@ describe('ensureDefaultClassifier', () => {
     mockState.settings.classifierModelId = 'x/y.gguf';
     mockState.downloadedModels = [{ id: 'x/y.gguf' }];
     await load()();
-    expect(mockDownloadModelBackground).not.toHaveBeenCalled();
+    expect(mockStartModelDownload).not.toHaveBeenCalled();
   });
 
   it('selects an already-downloaded default instead of re-downloading', async () => {
     mockState.downloadedModels = [{ id: `${REPO}/SmolLM2-135M-Instruct-Q8_0.gguf` }];
     await load()();
-    expect(mockDownloadModelBackground).not.toHaveBeenCalled();
+    expect(mockStartModelDownload).not.toHaveBeenCalled();
     expect(mockUpdateSettings).toHaveBeenCalledWith({ classifierModelId: `${REPO}/SmolLM2-135M-Instruct-Q8_0.gguf` });
   });
 
-  it('downloads the Q8_0 GGUF and selects it on completion', async () => {
+  it('downloads the Q8_0 GGUF through the single entry point and selects it on registration', async () => {
     mockGetModelFiles.mockResolvedValue([
       { name: 'SmolLM2-135M-Instruct-Q4_K_M.gguf', size: 90, downloadUrl: 'u1' },
       { name: 'SmolLM2-135M-Instruct-Q8_0.gguf', size: 145, downloadUrl: 'u2' },
     ]);
-    mockDownloadModelBackground.mockResolvedValue({ downloadId: 'dl-1' });
 
     await load()();
 
-    expect(mockDownloadModelBackground).toHaveBeenCalledWith(
+    // Routes through startModelDownload (which clears the in-flight row), NOT a parallel
+    // downloadModelBackground/watchDownload that would leave a phantom row behind.
+    expect(mockStartModelDownload).toHaveBeenCalledWith(
       REPO,
       expect.objectContaining({ name: 'SmolLM2-135M-Instruct-Q8_0.gguf' }),
+      expect.objectContaining({ onRegistered: expect.any(Function), onError: expect.any(Function) }),
     );
-    // Simulate the download completing.
-    const onComplete = mockWatchDownload.mock.calls[0][1];
-    onComplete();
+    // The registered model's id selects the classifier (uses the model, not a re-derived string).
+    const opts = mockStartModelDownload.mock.calls[0][2];
+    opts.onRegistered({ id: `${REPO}/SmolLM2-135M-Instruct-Q8_0.gguf` });
     expect(mockUpdateSettings).toHaveBeenCalledWith({ classifierModelId: `${REPO}/SmolLM2-135M-Instruct-Q8_0.gguf` });
   });
 });

--- a/__tests__/unit/services/parallelMmproj.test.ts
+++ b/__tests__/unit/services/parallelMmproj.test.ts
@@ -556,6 +556,76 @@ describe('Parallel mmproj download', () => {
       expect(onComplete).toHaveBeenCalledTimes(1);
     });
 
+    it('finalizes idempotently when the native move rejects but the file is already on disk (no re-finalize loop)', async () => {
+      // Device case: a record reports completed across relaunch but its localUri was
+      // cleared (moved in a prior session), so moveCompletedDownload rejects NOT_COMPLETED.
+      // The file is already at localPath — finalize from it, and purge the stale native
+      // record so restore can't re-adopt + re-fail it every foreground.
+      stubStartDownload(['42']);
+      const completeCbs = captureCompleteCallbacks();
+      await performBackgroundDownload({
+        modelId: 'test/model',
+        file: createModelFile({ name: 'model.gguf', size: 4_000_000_000 }),
+        modelsDir: MODELS_DIR,
+        backgroundDownloadContext: bgContext,
+        backgroundDownloadMetadataCallback: metadataCallback,
+      });
+
+      const onComplete = jest.fn();
+      const onError = jest.fn();
+      mockService.moveCompletedDownload.mockRejectedValue(new Error('Download 42 not completed yet'));
+      mockedRNFS.exists.mockResolvedValue(true); // the final file IS on disk
+      mockService.cancelDownload.mockResolvedValue(undefined);
+
+      watchBackgroundDownload({
+        downloadId: '42',
+        modelsDir: MODELS_DIR,
+        backgroundDownloadContext: bgContext,
+        backgroundDownloadMetadataCallback: metadataCallback,
+        onComplete,
+        onError,
+      });
+
+      await completeCbs['42']?.({ downloadId: '42', fileName: 'model.gguf' });
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(onComplete).toHaveBeenCalledTimes(1); // finalized from disk, not an error
+      expect(onError).not.toHaveBeenCalled();
+      expect(mockService.cancelDownload).toHaveBeenCalledWith('42'); // stale record purged
+    });
+
+    it('fails (not loops) when the native move rejects AND the file is genuinely absent', async () => {
+      stubStartDownload(['42']);
+      const completeCbs = captureCompleteCallbacks();
+      await performBackgroundDownload({
+        modelId: 'test/model',
+        file: createModelFile({ name: 'model.gguf', size: 4_000_000_000 }),
+        modelsDir: MODELS_DIR,
+        backgroundDownloadContext: bgContext,
+        backgroundDownloadMetadataCallback: metadataCallback,
+      });
+
+      const onComplete = jest.fn();
+      const onError = jest.fn();
+      mockService.moveCompletedDownload.mockRejectedValue(new Error('Download 42 not completed yet'));
+      mockedRNFS.exists.mockResolvedValue(false); // file NOT on disk → genuine failure
+
+      watchBackgroundDownload({
+        downloadId: '42',
+        modelsDir: MODELS_DIR,
+        backgroundDownloadContext: bgContext,
+        backgroundDownloadMetadataCallback: metadataCallback,
+        onComplete,
+        onError,
+      });
+
+      await completeCbs['42']?.({ downloadId: '42', fileName: 'model.gguf' });
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(onComplete).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalled();
+    });
+
     it('moves mmproj file on mmproj completion', async () => {
       const completeCbs = await setupVisionDownload();
 

--- a/__tests__/unit/services/textDownloadProvider.test.ts
+++ b/__tests__/unit/services/textDownloadProvider.test.ts
@@ -46,33 +46,38 @@ beforeEach(() => {
 });
 
 describe('textProvider', () => {
-  it('lists an in-flight text download as downloading', async () => {
-    const d = (await textProvider.list()).find(x => x.id === 'text:author/m');
+  // Canonical text id = text:<modelKey> (modelKey = repo/file), the SAME id the finished
+  // model carries — so an in-flight row and its completed model resolve to one id.
+  it('lists an in-flight text download as downloading (keyed by modelKey)', async () => {
+    const d = (await textProvider.list()).find(x => x.id === 'text:author/m.gguf');
     expect(d?.status).toBe('downloading');
     expect(d?.progress).toBe(0.4);
   });
 
-  it('lists completed appStore models, skipping in-flight ones', async () => {
+  it('lists completed appStore models, skipping in-flight ones (same modelKey id → deduped)', async () => {
     useAppStore.setState({ downloadedModels: [
-      { id: 'author/m', fileName: 'm.gguf', filePath: '/p' },     // dup of in-flight
-      { id: 'other/x', fileName: 'x.gguf', filePath: '/p2' },
+      { id: 'author/m.gguf', fileName: 'm.gguf', filePath: '/p' },   // dup of in-flight (model.id IS the modelKey)
+      { id: 'other/x.gguf', fileName: 'x.gguf', filePath: '/p2' },
     ] } as any);
     const list = await textProvider.list();
-    expect(list.filter(d => d.id === 'text:author/m')).toHaveLength(1);
-    expect(list.find(d => d.id === 'text:other/x')?.status).toBe('completed');
+    // Exactly ONE entry for author/m — the in-flight row and the completed model share
+    // the canonical text:author/m.gguf id, so the dedup collapses them. Pre-fix the
+    // in-flight row was text:author/m (bare repo) and this returned TWO entries for one model.
+    expect(list.filter(d => d.id.startsWith('text:author/m'))).toHaveLength(1);
+    expect(list.find(d => d.id === 'text:other/x.gguf')?.status).toBe('completed');
   });
 
   it('cancel cancels the native download and clears the store row', async () => {
-    await textProvider.cancel('text:author/m');
+    await textProvider.cancel('text:author/m.gguf');
     expect(mockMM.cancelBackgroundDownload).toHaveBeenCalledWith('dl-1');
     expect(useDownloadStore.getState().downloads['author/m.gguf']).toBeUndefined();
   });
 
-  it('remove deletes the model from modelManager + appStore', async () => {
+  it('remove deletes the model from modelManager + appStore by its modelKey id', async () => {
     const removeSpy = jest.spyOn(useAppStore.getState(), 'removeDownloadedModel');
-    await textProvider.remove('text:author/m');
-    expect(mockMM.deleteModel).toHaveBeenCalledWith('author/m');
-    expect(removeSpy).toHaveBeenCalledWith('author/m');
+    await textProvider.remove('text:author/m.gguf');
+    expect(mockMM.deleteModel).toHaveBeenCalledWith('author/m.gguf');
+    expect(removeSpy).toHaveBeenCalledWith('author/m.gguf');
   });
 
   it('reconcile re-queues an interrupted iOS download (pending, re-issued) instead of failing it', async () => {
@@ -90,7 +95,7 @@ describe('textProvider', () => {
 
   it('reconcile drops a stale in-flight row when the model is already downloaded (never 2 guys)', async () => {
     // Model is registered as completed AND has a leftover interrupted row.
-    useAppStore.setState({ downloadedModels: [{ id: 'author/m', fileName: 'm.gguf', filePath: '/p' }] } as any);
+    useAppStore.setState({ downloadedModels: [{ id: 'author/m.gguf', fileName: 'm.gguf', filePath: '/p' }] } as any);
     await textProvider.reconcile!();
     await new Promise((r) => setImmediate(r));
     // Stale row removed; no re-download of an already-downloaded model.
@@ -112,7 +117,7 @@ describe('textProvider', () => {
     afterEach(() => Object.defineProperty(Platform, 'OS', { configurable: true, value: originalOs }));
 
     it('resets both rows to pending, retries native main + mmproj, resets mmproj, reattaches', async () => {
-      await textProvider.retry('text:author/m');
+      await textProvider.retry('text:author/m.gguf');
       // main + mmproj native retried (Android resumes the existing rows in place)
       expect(mockBG.retryDownload).toHaveBeenNthCalledWith(1, 'dl-1');
       expect(mockBG.retryDownload).toHaveBeenNthCalledWith(2, 'dl-mmproj');

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,11 +25,13 @@ apply plugin: "com.facebook.react.rootproject"
 // react-native-audio-api) onto the ONE pinned NDK. Without this, a module that declares
 // no ndkVersion falls back to the AGP-default NDK (27.0.12077973), which the app never
 // pins or installs — CI then fails to configure with "Failed to install ndk;27.0.12077973".
-// One NDK across all modules = one version to have present, and no fragmentation.
-subprojects {
-    afterEvaluate { project ->
-        if (project.hasProperty("android")) {
-            project.android {
+// Applied via plugins.withId (runs when the Android plugin is applied) rather than
+// afterEvaluate — the latter threw "Cannot run afterEvaluate when the project is already
+// evaluated" for subprojects the React root plugin had already configured.
+subprojects { subproject ->
+    ["com.android.application", "com.android.library"].each { pluginId ->
+        subproject.plugins.withId(pluginId) {
+            subproject.android {
                 ndkVersion rootProject.ext.ndkVersion
             }
         }

--- a/src/screens/ChatScreen/MessageRenderer.tsx
+++ b/src/screens/ChatScreen/MessageRenderer.tsx
@@ -22,7 +22,7 @@ type MessageRendererProps = {
   onImagePress: (uri: string) => void;
 };
 
-export const MessageRenderer: React.FC<MessageRendererProps> = (props) => {
+const MessageRendererInner: React.FC<MessageRendererProps> = (props) => {
   const {
     item,
     index,
@@ -89,3 +89,30 @@ export const MessageRenderer: React.FC<MessageRendererProps> = (props) => {
     />
   );
 };
+
+/**
+ * Memoized so a ChatScreen re-render (a streaming token, a focus after returning from
+ * the document picker, a keyboard event, any unrelated store tick) does NOT re-render
+ * and re-parse the markdown of every message — the cause of the chat-screen freeze
+ * (unresponsive until you leave + re-enter). getDisplayMessages returns
+ * [...allMessages, streamingItem], so the historical message objects keep stable refs
+ * across renders; only the 'streaming'/'thinking' item is a new object per token, so
+ * only IT re-renders while the rest skip.
+ *
+ * The on* callbacks are recreated every parent render (defined inline in useChatScreen)
+ * and are deliberately NOT compared: within a conversation they are behaviorally stable,
+ * and a conversation switch replaces every message object (item ref changes → re-render
+ * with fresh handlers). Comparing them would defeat the memo entirely.
+ */
+export function messageRendererPropsEqual(prev: MessageRendererProps, next: MessageRendererProps): boolean {
+  return prev.item === next.item
+    && prev.index === next.index
+    && prev.displayMessagesLength === next.displayMessagesLength
+    && prev.animateLastN === next.animateLastN
+    && prev.imageModelLoaded === next.imageModelLoaded
+    && prev.isStreaming === next.isStreaming
+    && prev.isGeneratingImage === next.isGeneratingImage
+    && prev.showGenerationDetails === next.showGenerationDetails;
+}
+
+export const MessageRenderer = React.memo(MessageRendererInner, messageRendererPropsEqual);

--- a/src/screens/DownloadManagerScreen/useDownloadManager.ts
+++ b/src/screens/DownloadManagerScreen/useDownloadManager.ts
@@ -36,6 +36,12 @@ function getActiveItemModelId(entry: DownloadEntry, isImage: boolean): string {
   if (isImage && entry.modelId.startsWith('image:')) {
     return entry.modelId.replace('image:', '');
   }
+  // Text canonical id = the modelKey (repo/file), which is exactly what the finished
+  // model's id is (buildDownloadedModel: `${modelId}/${fileName}`). Keying the in-flight
+  // row by the bare repo produced a DIFFERENT uniform id than the completed model, so the
+  // dedup + reconcile never collapsed them → phantom "100%" rows and Active+Downloaded
+  // duplicates for one model. Image/STT already normalize to one id per model.
+  if (entry.modelType === 'text') return entry.modelKey;
   return entry.modelId;
 }
 
@@ -81,7 +87,9 @@ function queuedToActiveItem(q: { modelKey: string; modelId: string; fileName: st
     type: 'active',
     modelType: q.modelType as DownloadItem['modelType'],
     modelKey: q.modelKey,
-    modelId: q.modelId,
+    // Match getActiveItemModelId: text routes/dedups on the modelKey (repo/file), the
+    // same id the finished model carries; other types pass the modelId through.
+    modelId: q.modelType === 'text' ? q.modelKey : q.modelId,
     fileName: q.fileName,
     author: '',
     quantization: '',

--- a/src/services/classifierProvisioning.ts
+++ b/src/services/classifierProvisioning.ts
@@ -10,6 +10,7 @@
 import { useAppStore } from '../stores';
 import { modelManager } from './modelManager';
 import { huggingFaceService } from './huggingface';
+import { startModelDownload } from './startModelDownload';
 
 /** SmolLM2-135M-Instruct GGUF — ~100-145MB, runs on llama.rn. */
 const CLASSIFIER_REPO = 'bartowski/SmolLM2-135M-Instruct-GGUF';
@@ -51,17 +52,20 @@ export async function ensureDefaultClassifier(): Promise<void> {
       provisioning = false;
       return;
     }
-    const info = await modelManager.downloadModelBackground(CLASSIFIER_REPO, file);
-    modelManager.watchDownload(
-      info.downloadId,
-      () => {
-        useAppStore.getState().updateSettings({ classifierModelId: `${CLASSIFIER_REPO}/${file.name}` });
+    // Route through THE single download entry point instead of a parallel
+    // downloadModelBackground + watchDownload. startModelDownload registers the model
+    // AND clears the in-flight downloadStore row on completion; the old parallel path
+    // never cleared the row, so after the classifier finished it lingered forever as a
+    // phantom "downloading 100%" entry in the Download Manager (its uniform id —
+    // text:<repo> — never matched the finished model's text:<repo>/<file>, so the
+    // one-entry dedup couldn't collapse it).
+    await startModelDownload(CLASSIFIER_REPO, file, {
+      onRegistered: (model) => {
+        useAppStore.getState().updateSettings({ classifierModelId: model.id });
         provisioning = false;
       },
-      () => {
-        provisioning = false;
-      },
-    );
+      onError: () => { provisioning = false; },
+    });
   } catch {
     provisioning = false;
   }

--- a/src/services/modelDownloadService/providers/textProvider.ts
+++ b/src/services/modelDownloadService/providers/textProvider.ts
@@ -30,11 +30,13 @@ const TEXT_CAPABILITIES = {
   determinateProgress: true,
 } as const;
 
-const modelIdOf = (id: string): string => id.replace(/^text:/, '');
+// The text uniform id is text:<modelKey> (modelKey = repo/file), the same identity the
+// finished model carries — so an in-flight row and its completed model resolve to ONE id.
+const keyOf = (id: string): string => id.replace(/^text:/, '');
 const textEntries = (): DownloadEntry[] =>
   Object.values(useDownloadStore.getState().downloads).filter(e => e.modelType === 'text');
-const findEntry = (modelId: string): DownloadEntry | undefined =>
-  textEntries().find(e => e.modelId === modelId);
+const findEntry = (modelKey: string): DownloadEntry | undefined =>
+  textEntries().find(e => e.modelKey === modelKey);
 
 /** iOS re-start: foreground URLSession can't resume, so re-issue the download from
  *  scratch. It flows through startDownload's 3-slot cap (queued if full). Shared by
@@ -77,7 +79,7 @@ export const textProvider: DownloadProvider = {
     const out: ModelDownload[] = [];
     for (const e of textEntries()) {
       out.push({
-        id: uniformDownloadId('text', e.modelId), modelType: 'text', name: e.fileName || e.modelId,
+        id: uniformDownloadId('text', e.modelKey), modelType: 'text', name: e.fileName || e.modelId,
         sizeBytes: e.combinedTotalBytes || e.totalBytes,
         bytesDownloaded: e.bytesDownloaded + (e.mmProjBytesDownloaded ?? 0),
         progress: e.progress, status: mapStoreStatus(e.status),
@@ -98,7 +100,7 @@ export const textProvider: DownloadProvider = {
   },
 
   async cancel(id: string): Promise<void> {
-    const entry = findEntry(modelIdOf(id));
+    const entry = findEntry(keyOf(id));
     if (!entry) return;
     await modelManager.cancelBackgroundDownload(entry.downloadId)
       .catch(err => logger.log(`[DL-SM] ${id} cancel: native cancel failed err=${msg(err)}`));
@@ -108,8 +110,7 @@ export const textProvider: DownloadProvider = {
   },
 
   async retry(id: string): Promise<void> {
-    const modelId = modelIdOf(id);
-    const entry = findEntry(modelId);
+    const entry = findEntry(keyOf(id));
     if (!entry?.downloadId) return;
     if (Platform.OS === 'android') {
       useDownloadStore.getState().setStatus(entry.downloadId, 'pending');
@@ -127,16 +128,18 @@ export const textProvider: DownloadProvider = {
   },
 
   async remove(id: string): Promise<void> {
-    const modelId = modelIdOf(id);
-    const entry = findEntry(modelId);
+    // keyOf(id) is the modelKey, which for a completed model IS its model.id — so both
+    // deleteModel and removeDownloadedModel receive the right identity.
+    const key = keyOf(id);
+    const entry = findEntry(key);
     if (entry) {
       await modelManager.cancelBackgroundDownload(entry.downloadId)
         .catch(err => logger.log(`[DL-SM] ${id} remove: native cancel failed err=${msg(err)}`));
       useDownloadStore.getState().remove(entry.modelKey);
     }
-    await modelManager.deleteModel(modelId)
+    await modelManager.deleteModel(key)
       .catch(err => logger.log(`[DL-SM] ${id} remove: delete failed err=${msg(err)}`));
-    useAppStore.getState().removeDownloadedModel(modelId);
+    useAppStore.getState().removeDownloadedModel(key);
   },
 
   subscribe(onChange: () => void): () => void {
@@ -149,11 +152,12 @@ export const textProvider: DownloadProvider = {
     const registered = new Set(useAppStore.getState().downloadedModels.map(m => m.id));
     for (const e of textEntries()) {
       if (!isActiveStatus(e.status)) continue;
-      if (registered.has(e.modelId)) {
+      if (registered.has(e.modelKey)) {
         // Already on disk — this in-flight row is stale (a re-start of a completed
-        // model). Drop it so there's never both a "Downloaded" and an "Active" entry
-        // for the same model; never re-download something we already have.
-        logger.log(`[DL-SM] text:${e.modelId} reconcile: already downloaded → dropping stale row`);
+        // model). Compare by modelKey: downloadedModels are keyed by model.id which IS
+        // the modelKey (repo/file); comparing the bare repo (e.modelId) never matched, so
+        // this dedup silently never fired and left both an Active and a Downloaded entry.
+        logger.log(`[DL-SM] text:${e.modelKey} reconcile: already downloaded → dropping stale row`);
         store.remove(e.modelKey);
         continue;
       }

--- a/src/services/modelManager/download.ts
+++ b/src/services/modelManager/download.ts
@@ -459,7 +459,29 @@ export function watchBackgroundDownload(opts: WatchDownloadOpts): void {
     cleanupListeners();
     backgroundDownloadContext.delete(downloadId);
     try {
-      const finalPath = await backgroundDownloadService.moveCompletedDownload(downloadId, ctx.localPath);
+      // Idempotent move: a native record can report 'completed' yet reject the move
+      // (NOT_COMPLETED / NOT_FOUND) when it was already moved in a PRIOR session — its
+      // localUri is cleared but the file is already at ctx.localPath. Restore re-adopts
+      // such a record every foreground, so a plain failure here loops forever
+      // ("Finalization failed: Download N not completed yet" on every launch). If the
+      // final file is already on disk, finalize from it; only a genuinely-absent file is
+      // a real failure.
+      let movedNatively = true;
+      let finalPath: string;
+      try {
+        finalPath = await backgroundDownloadService.moveCompletedDownload(downloadId, ctx.localPath);
+      } catch (moveErr) {
+        if (await RNFS.exists(ctx.localPath)) {
+          movedNatively = false;
+          finalPath = ctx.localPath;
+          logger.log('[DownloadDebug] native move rejected but file present — finalizing from disk (idempotent)', {
+            downloadId, modelId: ctx.modelId, localPath: ctx.localPath,
+            error: moveErr instanceof Error ? moveErr.message : String(moveErr),
+          });
+        } else {
+          throw moveErr;
+        }
+      }
       const mmProjFileExists = ctx.mmProjLocalPath ? await RNFS.exists(ctx.mmProjLocalPath) : false;
       const finalMmProjPath = ctx.mmProjLocalPath && mmProjFileExists ? ctx.mmProjLocalPath : undefined;
       logger.log('[DownloadDebug] Finalization paths resolved', {
@@ -491,6 +513,10 @@ export function watchBackgroundDownload(opts: WatchDownloadOpts): void {
       });
       backgroundDownloadMetadataCallback?.(downloadId, null);
       onComplete?.(model);
+      // When we finalized from an already-on-disk file (native move was skipped), the
+      // stale native record still lingers as 'completed'-without-localUri and restore
+      // would re-adopt + re-finalize it every foreground. Purge it so it can't loop.
+      if (!movedNatively) backgroundDownloadService.cancelDownload(downloadId).catch(() => {});
     } catch (error) {
       ctx.isFinalizing = false;
       logger.error('[DownloadDebug] Finalization failed', {


### PR DESCRIPTION
Stacked on `fix/llm-stability-and-perf` (#425). Fixes found in the on-device test pass (pulled from the debug-log trace + Gungnir recordings), each with a regression test that fails against the pre-fix code.

## Fixes
- **Bug 5 - classifier phantom "downloading 100%"** (`5936d4a4`): the auto-provisioned SmolLM2 classifier ran a parallel download path whose completion never cleared the in-flight store row. Routed it through the single entry point (`startModelDownload`) so the row is cleared like every other download.
- **Finalize re-loop** (`bb8fed88`): a vision model wedged in "Finalization started -> already running -> not completed yet" every foreground. Native reports the record `completed` across relaunch but its localUri was cleared (already moved), so `moveCompletedDownload` rejects. Finalize is now idempotent - if the file is already on disk, finalize from it and purge the stale record; a genuinely-absent file fails without looping.
- **Bugs 1 + 4 - chat-screen freeze** (`f503172a`): returning from the document picker and Resend both froze the chat. `MessageRenderer` was unmemoized, so every ChatScreen re-render re-parsed the markdown of every message (incl. large code blocks) - saturating the JS thread. `React.memo` with a ref-stable comparator: historical messages skip re-render, only the streaming item updates.
- **Canonical download id** (`e6c4f18f`): the identity seam behind the download-state "lies". A finished text model's id is its modelKey (`repo/file`), but the in-flight row was keyed by the bare repo, so one model produced two uniform ids - defeating the dedup and `reconcile`'s already-downloaded check (which compared repo against a set of modelKeys and never fired). Text now uses one identity (the modelKey) on both sides.
- **Android subproject NDK** (`adc3a2c4`): corrects the CI NDK-alignment block that used `afterEvaluate` (threw "already evaluated", breaking the Android build) to `plugins.withId`.

## Verification
JS suite green, tsc + eslint clean; the branch's Kotlin (`compileDebugKotlin`) and iOS (`test:ios`) gates pass locally. Still to do: re-record batches 3/4/5 with Gungnir to confirm the freeze + phantom-100% + finalize-loop are gone on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)