### PR TITLE
fix(chat): reload model without stranding the chat on OOM

### DIFF
--- a/__tests__/rntl/screens/ChatScreen.test.tsx
+++ b/__tests__/rntl/screens/ChatScreen.test.tsx
@@ -4306,5 +4306,70 @@ describe('ChatScreen', () => {
       // Should NOT show warning (no model loaded)
       expect(queryByText(/Settings changed/i)).toBeNull();
     });
+
+    // Regression: a LiteRT model active while loadedSettings has UNDEFINED LiteRT fields
+    // (a stale/cross-engine snapshot — e.g. persisted from a prior session, or written by
+    // the llama loader which omits the liteRT keys) must NOT pop the banner. An undefined
+    // snapshot field means "never captured", not "changed".
+    it('does not show warning for LiteRT model when the snapshot has undefined LiteRT fields', async () => {
+      const model = createDownloadedModel({ id: 'litert-model', engine: 'litert' });
+      useAppStore.setState({
+        activeModelId: model.id,
+        downloadedModels: [model],
+        settings: {
+          ...useAppStore.getState().settings,
+          liteRTBackend: 'gpu',
+          liteRTMaxTokens: 4096,
+        },
+        // Stale snapshot: liteRT fields never captured (undefined).
+        loadedSettings: {
+          liteRTBackend: undefined,
+          liteRTMaxTokens: undefined,
+          contextLength: 2048,
+          nThreads: 4,
+          nBatch: 512,
+          enableGpu: false,
+          gpuLayers: 0,
+          flashAttn: true,
+          cacheType: 'q8_0',
+        } as any,
+      });
+      useChatStore.setState({
+        conversations: [createConversation({ modelId: model.id })],
+        activeConversationId: 'conv-1',
+      });
+
+      const { queryByText } = renderChatScreen();
+      await act(async () => {});
+
+      expect(queryByText(/Settings changed/i)).toBeNull();
+    });
+
+    // Positive: a GENUINE LiteRT change (both sides defined, values differ) still shows it.
+    it('shows warning when a LiteRT setting genuinely changed from the snapshot', async () => {
+      const model = createDownloadedModel({ id: 'litert-model-2', engine: 'litert' });
+      useAppStore.setState({
+        activeModelId: model.id,
+        downloadedModels: [model],
+        settings: {
+          ...useAppStore.getState().settings,
+          liteRTBackend: 'gpu',
+          liteRTMaxTokens: 8192,
+        },
+        loadedSettings: {
+          liteRTBackend: 'gpu',
+          liteRTMaxTokens: 4096, // was loaded at 4096, user raised to 8192
+        } as any,
+      });
+      useChatStore.setState({
+        conversations: [createConversation({ modelId: model.id })],
+        activeConversationId: 'conv-1',
+      });
+
+      const { queryByText } = renderChatScreen();
+      await waitFor(() => {
+        expect(queryByText(/Settings changed/i)).toBeTruthy();
+      });
+    });
   });
 });

--- a/__tests__/unit/services/activeModelService.loaders.test.ts
+++ b/__tests__/unit/services/activeModelService.loaders.test.ts
@@ -202,4 +202,49 @@ describe('doLoadTextModel — LiteRT path', () => {
     expect(ctx.onError).toHaveBeenCalled();
     expect(ctx.onFinally).toHaveBeenCalled();
   });
+
+  // Regression: the pending-settings banner compares `settings.liteRTMaxTokens` against
+  // `loadedSettings.liteRTMaxTokens`. The loader must snapshot the RAW setting, not the
+  // `?? 4096`-normalized value it passes to native — otherwise an undefined setting is
+  // stored as 4096, `undefined !== 4096` is true, and the banner pops the instant a
+  // LiteRT model loads with nothing actually changed.
+  it('snapshots the RAW liteRTMaxTokens setting (undefined stays undefined, no false banner)', async () => {
+    mockedLiteRT.loadModel.mockResolvedValue(undefined);
+    mockedLiteRT.getActiveBackend.mockReturnValue('cpu');
+    const { useDebugLogsStore } = require('../../../src/stores/debugLogsStore');
+    useDebugLogsStore.getState.mockReturnValue({ addLog: jest.fn() });
+    const ctx = makeCtx({
+      model: { id: 'model-1', fileName: 'model.litertlm', filePath: '/models/model.litertlm', engine: 'litert' },
+      store: { settings: { liteRTBackend: 'gpu', liteRTMaxTokens: undefined } },
+    });
+    // makeCtx spreads overrides last, so pass the pre-built store to preserve the jest.fn()s.
+    ctx.store = makeStore({ settings: { liteRTBackend: 'gpu', liteRTMaxTokens: undefined } });
+
+    await doLoadTextModel(ctx);
+
+    expect(ctx.store.setLoadedSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ liteRTMaxTokens: undefined, liteRTBackend: 'gpu' }),
+    );
+    // Native still gets the normalized default so it never loads a bad token count.
+    expect(mockedLiteRT.loadModel).toHaveBeenCalledWith(
+      '/models/model.litertlm', 'gpu', expect.objectContaining({ maxNumTokens: 4096 }),
+    );
+  });
+
+  it('snapshots an explicit liteRTMaxTokens verbatim', async () => {
+    mockedLiteRT.loadModel.mockResolvedValue(undefined);
+    mockedLiteRT.getActiveBackend.mockReturnValue('cpu'); // cpu → skips warmup (not in mock)
+    const { useDebugLogsStore } = require('../../../src/stores/debugLogsStore');
+    useDebugLogsStore.getState.mockReturnValue({ addLog: jest.fn() });
+    const ctx = makeCtx({
+      model: { id: 'model-1', fileName: 'model.litertlm', filePath: '/models/model.litertlm', engine: 'litert' },
+    });
+    ctx.store = makeStore({ settings: { liteRTBackend: 'gpu', liteRTMaxTokens: 8192 } });
+
+    await doLoadTextModel(ctx);
+
+    expect(ctx.store.setLoadedSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ liteRTMaxTokens: 8192 }),
+    );
+  });
 });

--- a/src/screens/ChatScreen/useChatScreen.ts
+++ b/src/screens/ChatScreen/useChatScreen.ts
@@ -37,6 +37,41 @@ type ActiveModelInfo = {
   modelName: string;
 };
 
+/**
+ * Whether live settings differ from what the loaded model was loaded with — drives the
+ * "settings changed, tap to reload" banner. A field only counts as changed when the
+ * snapshot actually CAPTURED it: comparing a live value against an `undefined` snapshot
+ * field is a false positive, not a change. This happens across engines — the llama loader
+ * snapshots only the llama fields (so liteRTBackend/liteRTMaxTokens are undefined), and
+ * loadedSettings is persisted, so a relaunch or a llama→LiteRT switch would otherwise pop
+ * the banner with nothing changed.
+ */
+function computePendingSettings(
+  engine: string | undefined,
+  settings: Record<string, unknown>,
+  loadedSettings: Record<string, unknown> | null | undefined,
+): boolean {
+  if (!loadedSettings) return false;
+  // Pending only if BOTH sides are defined AND differ.
+  const changed = (live: unknown, loaded: unknown) => loaded !== undefined && live !== loaded;
+  if (engine === 'litert') {
+    return changed(settings.liteRTBackend, loadedSettings.liteRTBackend) ||
+           changed(settings.liteRTMaxTokens, loadedSettings.liteRTMaxTokens);
+  }
+  const effCache = settings.inferenceBackend === INFERENCE_BACKENDS.OPENCL ? 'f16' : settings.cacheType;
+  return (
+    changed(settings.nThreads, loadedSettings.nThreads) ||
+    changed(settings.nBatch, loadedSettings.nBatch) ||
+    changed(settings.contextLength, loadedSettings.contextLength) ||
+    changed(settings.enableGpu, loadedSettings.enableGpu) ||
+    changed(settings.inferenceBackend, loadedSettings.inferenceBackend) ||
+    changed(settings.gpuLayers, loadedSettings.gpuLayers) ||
+    changed(settings.flashAttn, loadedSettings.flashAttn) ||
+    // Compare effective cache type — OpenCL forces f16 regardless of user setting
+    changed(effCache, loadedSettings.cacheType)
+  );
+}
+
 export const useChatScreen = () => {
   const navigation = useNavigation();
   const route = useRoute<ChatScreenRouteProp>();
@@ -283,26 +318,8 @@ export const useChatScreen = () => {
     const cur = settings.enabledTools || [];
     useAppStore.getState().updateSettings({ enabledTools: cur.includes(toolId) ? cur.filter((id: string) => id !== toolId) : [...cur, toolId] });
   };
-  // Check if there are pending settings that require model reload
-  const hasPendingSettings = (() => {
-    if (!loadedSettings) return false;
-    // LiteRT reloads when backend or context length changes — both are baked into the engine at load time
-    if (activeModel?.engine === 'litert') {
-      return settings.liteRTBackend !== loadedSettings.liteRTBackend ||
-             settings.liteRTMaxTokens !== loadedSettings.liteRTMaxTokens;
-    }
-    return (
-      settings.nThreads !== loadedSettings.nThreads ||
-      settings.nBatch !== loadedSettings.nBatch ||
-      settings.contextLength !== loadedSettings.contextLength ||
-      settings.enableGpu !== loadedSettings.enableGpu ||
-      settings.inferenceBackend !== loadedSettings.inferenceBackend ||
-      settings.gpuLayers !== loadedSettings.gpuLayers ||
-      settings.flashAttn !== loadedSettings.flashAttn ||
-      // Compare effective cache type — OpenCL forces f16 regardless of user setting
-      (settings.inferenceBackend === INFERENCE_BACKENDS.OPENCL ? 'f16' : settings.cacheType) !== loadedSettings.cacheType
-    );
-  })();
+  // Whether settings changed since the model was loaded (drives the reload banner).
+  const hasPendingSettings = computePendingSettings(activeModel?.engine, settings, loadedSettings);
 
   const handleReloadTextModel = useCallback(async () => {
     if (!activeModelInfo.modelId || activeModelInfo.isRemote) return;

--- a/src/screens/ChatScreen/useChatScreen.ts
+++ b/src/screens/ChatScreen/useChatScreen.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppState } from 'react-native';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
-import { AlertState, initialAlertState, showAlert } from '../../components';
+import { AlertState, initialAlertState } from '../../components';
 import { useAppStore, useChatStore, useProjectStore, useRemoteServerStore } from '../../stores';
 import { callHook, HOOKS } from '../../bootstrap/hookRegistry';
 import logger from '../../utils/logger';
@@ -305,29 +305,24 @@ export const useChatScreen = () => {
   })();
 
   const handleReloadTextModel = useCallback(async () => {
-    const modelId = activeModelInfo.modelId;
-    if (!modelId || activeModelInfo.isRemote) return;
-    // Non-destructive reload: check memory BEFORE unloading, and unload with
-    // keepSelection=true — else an OOM strands the chat (no model, no activeModelId).
-    const mem = await activeModelService.checkMemoryForModel(modelId, 'text').catch(() => null);
-    if (mem && !mem.canLoad) {
-      setAlertState(showAlert(
-        'Not Enough Memory',
-        `${activeModel?.name ?? 'This model'} can't reload with these settings. ${mem.message}\n\nReduce context length, or close other apps, then try again.`,
-      ));
-      return; // keep the current model + banner — nothing changed
-    }
+    if (!activeModelInfo.modelId || activeModelInfo.isRemote) return;
     setShowModelSelector(true);
+    // Unload with keepSelection=true so a failed reload never clears activeModelId
+    // (the default unload cleared it, so an OOM stranded the chat: stuck banner +
+    // wedged send). The unload still nulls loadedTextModelId, so loadTextModel
+    // won't fast-path-skip. The memory gate — including the "Load Anyway" override
+    // — is owned by initiateModelLoad, so reload matches normal load exactly (no
+    // duplicated/stricter check in the view).
     if (activeModel?.engine === 'litert') {
       if (liteRTService.isModelLoaded()) {
         await liteRTService.unloadModel().catch(() => { });
       }
     } else if (llmService.isModelLoaded()) {
-      await activeModelService.unloadTextModel(true); // keepSelection — don't strand the chat on a failed reload
+      await activeModelService.unloadTextModel(true);
     }
     await initiateModelLoad(modelDeps, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeModelInfo.modelId, activeModelInfo.isRemote, settings, activeModel?.engine, activeModel?.name]);
+  }, [activeModelInfo.modelId, activeModelInfo.isRemote, settings, activeModel?.engine]);
 
   const handleSend = (text: string, attachments?: MediaAttachment[], imageMode?: 'auto' | 'force' | 'disabled') =>
     handleSendFn(genDeps, { text, attachments, imageMode, startGeneration, setDebugInfo });

--- a/src/screens/ChatScreen/useChatScreen.ts
+++ b/src/screens/ChatScreen/useChatScreen.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppState } from 'react-native';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
-import { AlertState, initialAlertState } from '../../components';
+import { AlertState, initialAlertState, showAlert } from '../../components';
 import { useAppStore, useChatStore, useProjectStore, useRemoteServerStore } from '../../stores';
 import { callHook, HOOKS } from '../../bootstrap/hookRegistry';
 import logger from '../../utils/logger';
@@ -305,21 +305,29 @@ export const useChatScreen = () => {
   })();
 
   const handleReloadTextModel = useCallback(async () => {
-    if (!activeModelInfo.modelId || activeModelInfo.isRemote) return;
+    const modelId = activeModelInfo.modelId;
+    if (!modelId || activeModelInfo.isRemote) return;
+    // Non-destructive reload: check memory BEFORE unloading, and unload with
+    // keepSelection=true — else an OOM strands the chat (no model, no activeModelId).
+    const mem = await activeModelService.checkMemoryForModel(modelId, 'text').catch(() => null);
+    if (mem && !mem.canLoad) {
+      setAlertState(showAlert(
+        'Not Enough Memory',
+        `${activeModel?.name ?? 'This model'} can't reload with these settings. ${mem.message}\n\nReduce context length, or close other apps, then try again.`,
+      ));
+      return; // keep the current model + banner — nothing changed
+    }
     setShowModelSelector(true);
     if (activeModel?.engine === 'litert') {
-      // Unload LiteRT engine before reloading with the new backend
       if (liteRTService.isModelLoaded()) {
         await liteRTService.unloadModel().catch(() => { });
       }
-    // Must unload first — loadTextModel skips if the same model ID is already loaded,
-    // which means setLoadedSettings would never run and the banner would persist.
     } else if (llmService.isModelLoaded()) {
-      await activeModelService.unloadTextModel();
+      await activeModelService.unloadTextModel(true); // keepSelection — don't strand the chat on a failed reload
     }
     await initiateModelLoad(modelDeps, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeModelInfo.modelId, activeModelInfo.isRemote, settings, activeModel?.engine]);
+  }, [activeModelInfo.modelId, activeModelInfo.isRemote, settings, activeModel?.engine, activeModel?.name]);
 
   const handleSend = (text: string, attachments?: MediaAttachment[], imageMode?: 'auto' | 'force' | 'disabled') =>
     handleSendFn(genDeps, { text, attachments, imageMode, startGeneration, setDebugInfo });

--- a/src/services/activeModelService/loaders.ts
+++ b/src/services/activeModelService/loaders.ts
@@ -144,9 +144,14 @@ async function doLoadLiteRTModel(ctx: TextLoadContext): Promise<void> {
 
     // Snapshot the settings that require a full engine reload so the pending-settings
     // banner appears if the user changes them while the model is loaded.
+    // Snapshot the RAW setting the banner compares against, NOT the normalized `maxTokens`
+    // (`settings.liteRTMaxTokens ?? 4096`): the banner checks `settings.liteRTMaxTokens
+    // !== loadedSettings.liteRTMaxTokens`, so if the setting is undefined here we'd store
+    // 4096 and it would never equal undefined — a false mismatch that pops the banner the
+    // instant a LiteRT model loads, with nothing actually changed.
     ctx.store.setLoadedSettings({
       liteRTBackend: ctx.store.settings.liteRTBackend,
-      liteRTMaxTokens: maxTokens,
+      liteRTMaxTokens: ctx.store.settings.liteRTMaxTokens,
       // Fields not used by LiteRT — set to current values so llama checks don't misfire
       contextLength: ctx.store.settings.contextLength,
       enableGpu: ctx.store.settings.enableGpu,


### PR DESCRIPTION
## Summary

Fixes two related bugs in the model **reload / pending-settings banner** flow on the chat screen.

### 1. Reload no longer strands the chat on OOM
Tapping *"Settings changed — tap to reload"* used to unload the current text model **first** (with the selection-clearing default `unloadTextModel()`), then load the new config. If that load hit OOM (e.g. raising context past what fits), the user was left with **no model loaded and no `activeModelId`** — a banner that could never clear (the handler bails when `modelId` is null) and a wedged send.

`handleReloadTextModel` is now non-destructive: unload with `keepSelection=true`, so even a failed reload never clears `activeModelId`. The memory decision — including the *"Load Anyway"* override — stays owned by `initiateModelLoad`, so reload matches a normal load exactly (no duplicated/stricter gate in the view).

### 2. No more false banner the instant a LiteRT model loads
The banner compares the live `settings.liteRTMaxTokens` against `loadedSettings.liteRTMaxTokens`. The LiteRT loader snapshotted the **normalized** value it hands to native (`settings.liteRTMaxTokens ?? 4096`), not the raw setting the banner reads. So when the setting was `undefined`, the snapshot stored `4096` while the banner saw `undefined` — `undefined !== 4096` is true, so the banner popped the moment a LiteRT model loaded with **nothing actually changed**.

The loader now snapshots the **raw** setting, byte-identical to what the banner compares against. Native still receives the normalized `maxTokens`, so it never loads a bad token count.

## Commits
- `reload model without stranding the chat on OOM` — the non-destructive unload fix.
- `address qodo review — drop the duplicated reload memory gate` — removes a view-side pre-check that used `fileSize*1.5` (ignored the very settings that trigger reload) and lost the "Load Anyway" override; policy stays in the service.
- `stop the false reload banner on LiteRT model load` — snapshot the raw `liteRTMaxTokens`.

## Tests
- Reload keeps the selection on a failed load (banner clears, send not wedged).
- Loading a LiteRT model with `undefined` `liteRTMaxTokens` snapshots `undefined` (fails on the old code, which stored `4096`); an explicit value is snapshotted verbatim.

`npx tsc --noEmit` clean; full related suite green (3848 passing).