### PR TITLE
fix(llm): recover from a remote tool-grammar 400 + grammar-safe schemas

### DIFF
--- a/__tests__/unit/services/generationToolLoop.test.ts
+++ b/__tests__/unit/services/generationToolLoop.test.ts
@@ -1582,6 +1582,19 @@ describe('callRemoteLLMWithTools via forceRemote', () => {
     await expect(runToolLoop(ctx)).rejects.toThrow('internal server error');
     expect(call).toBe(1); // no retry for unrelated errors
   });
+
+  it('does NOT retry a grammar error if tokens already streamed (avoids duplicate output)', async () => {
+    let call = 0;
+    mockProvider.generate.mockImplementation((_msgs: any, _opts: any, callbacks: any) => {
+      call++;
+      callbacks.onToken('partial ');   // streamed before failing
+      callbacks.onError(new Error('HTTP 400: failed to parse grammar'));
+    });
+
+    const ctx = createContext({ forceRemote: true });
+    await expect(runToolLoop(ctx)).rejects.toThrow(/parse grammar/);
+    expect(call).toBe(1); // retry suppressed — a second stream would duplicate output
+  });
 });
 
 describe('isToolGrammarError', () => {

--- a/__tests__/unit/services/generationToolLoop.test.ts
+++ b/__tests__/unit/services/generationToolLoop.test.ts
@@ -6,7 +6,7 @@
  * Priority: P0 (Critical) - Core tool-calling functionality.
  */
 
-import { runToolLoop, ToolLoopContext, parseToolCallsFromText } from '../../../src/services/generationToolLoop';
+import { runToolLoop, ToolLoopContext, parseToolCallsFromText, isToolGrammarError } from '../../../src/services/generationToolLoop';
 import { llmService } from '../../../src/services/llm';
 import { liteRTService } from '../../../src/services/litert';
 import { Message } from '../../../src/types';
@@ -1545,6 +1545,55 @@ describe('callRemoteLLMWithTools via forceRemote', () => {
 
     const ctx = createContext({ forceRemote: true });
     await expect(runToolLoop(ctx)).rejects.toThrow('Remote provider not found');
+  });
+
+  it('retries WITHOUT tools when the server rejects the tool grammar (llama.cpp)', async () => {
+    // 1st generate: server can't compile the tool schemas → grammar error. 2nd generate
+    // (retry, tools stripped) succeeds. The user gets an answer instead of a hard failure.
+    let call = 0;
+    const toolCounts: number[] = [];
+    mockProvider.generate.mockImplementation((_msgs: any, opts: any, callbacks: any) => {
+      call++;
+      toolCounts.push(opts.tools?.length ?? 0);
+      if (call === 1) {
+        callbacks.onError(new Error('HTTP 400: Failed to initialize samplers: failed to parse grammar'));
+      } else {
+        callbacks.onComplete({ content: 'answer without tools', toolCalls: [] });
+      }
+    });
+
+    const ctx = createContext({ forceRemote: true });
+    await runToolLoop(ctx);
+
+    expect(call).toBe(2);
+    expect(toolCounts[0]).toBeGreaterThan(0); // first attempt sent tools
+    expect(toolCounts[1]).toBe(0);            // retry sent NO tools
+    expect(ctx.onFinalResponse).toHaveBeenCalledWith('answer without tools');
+  });
+
+  it('does NOT retry on a non-grammar remote error (still rejects)', async () => {
+    let call = 0;
+    mockProvider.generate.mockImplementation((_msgs: any, _opts: any, callbacks: any) => {
+      call++;
+      callbacks.onError(new Error('HTTP 500: internal server error'));
+    });
+
+    const ctx = createContext({ forceRemote: true });
+    await expect(runToolLoop(ctx)).rejects.toThrow('internal server error');
+    expect(call).toBe(1); // no retry for unrelated errors
+  });
+});
+
+describe('isToolGrammarError', () => {
+  it('matches llama.cpp grammar / sampler-init failures', () => {
+    expect(isToolGrammarError('HTTP 400: failed to parse grammar')).toBe(true);
+    expect(isToolGrammarError('Failed to initialize samplers: failed to parse grammar')).toBe(true);
+    expect(isToolGrammarError('FAILED TO PARSE GRAMMAR')).toBe(true); // case-insensitive
+  });
+  it('does not match unrelated errors', () => {
+    expect(isToolGrammarError('HTTP 500: internal server error')).toBe(false);
+    expect(isToolGrammarError('Network request failed')).toBe(false);
+    expect(isToolGrammarError('context is full')).toBe(false);
   });
 });
 

--- a/src/services/generationToolLoop.ts
+++ b/src/services/generationToolLoop.ts
@@ -283,29 +283,28 @@ const CONTEXT_RELEASE_PAUSE_MS = 500;
 function isNonRetryableError(msg: string): boolean {
   return msg.includes('No model loaded') || msg.includes('aborted') || msg.includes('Remote provider');
 }
-/** Call remote LLM provider with tools */
-async function callRemoteLLMWithTools(
-  messages: Message[], tools: any[],
-  opts?: { onStream?: (data: StreamToken) => void; disableThinking?: boolean },
+/** A server rejected the request because it couldn't compile the tool schemas into a
+ *  grammar (llama.cpp: "failed to parse grammar" / "failed to initialize samplers").
+ *  We can't know a server's grammar-compiler limits up front, so we detect it from the
+ *  error and retry without tools rather than hard-failing the turn. Exported for tests. */
+export function isToolGrammarError(msg: string): boolean {
+  return /parse grammar|initialize samplers/i.test(msg);
+}
+
+/** One remote generation attempt with the given tool set. */
+function remoteGenerateOnce(
+  provider: any,
+  args: { messages: Message[]; tools: any[]; thinkingEnabled: boolean; onStream?: (data: StreamToken) => void },
 ): Promise<{ fullResponse: string; toolCalls: ToolCall[] }> {
-  const activeServerId = useRemoteServerStore.getState().activeServerId;
-  if (!activeServerId) throw new Error('No remote provider active');
-  const provider = providerRegistry.getProvider(activeServerId);
-  if (!provider) throw new Error('Remote provider not found');
+  const { messages, tools, thinkingEnabled, onStream } = args;
   const settings = useAppStore.getState().settings;
-  const thinkingEnabled = !opts?.disableThinking && settings.thinkingEnabled && provider.capabilities.supportsThinking;
   const options: GenerationOptions = { temperature: settings.temperature, maxTokens: settings.maxTokens, topP: settings.topP, tools, enableThinking: thinkingEnabled };
-  let _fullContent = '', toolCalls: ToolCall[] = [];
-  const onStream = opts?.onStream;
+  let _fullContent = '';
+  let toolCalls: ToolCall[] = [];
   return new Promise((resolve, reject) => {
     provider.generate(messages, options, {
-      onToken: (token: string) => {
-        _fullContent += token;
-        onStream?.({ content: token });
-      },
-      onReasoning: (content: string) => {
-        onStream?.({ reasoningContent: content });
-      },
+      onToken: (token: string) => { _fullContent += token; onStream?.({ content: token }); },
+      onReasoning: (content: string) => { onStream?.({ reasoningContent: content }); },
       onComplete: (result: CompletionResult) => {
         if (result.toolCalls && result.toolCalls.length > 0) {
           toolCalls = result.toolCalls.map(tc => ({
@@ -318,12 +317,36 @@ async function callRemoteLLMWithTools(
         }
         resolve({ fullResponse: result.content, toolCalls });
       },
-      onError: (error: Error) => {
-        logger.error(`[ToolLoop] onError — ${error.message}`);
-        reject(error);
-      },
+      onError: (error: Error) => { logger.error(`[ToolLoop] onError — ${error.message}`); reject(error); },
     });
   });
+}
+
+/** Call remote LLM provider with tools */
+async function callRemoteLLMWithTools(
+  messages: Message[], tools: any[],
+  opts?: { onStream?: (data: StreamToken) => void; disableThinking?: boolean },
+): Promise<{ fullResponse: string; toolCalls: ToolCall[] }> {
+  const activeServerId = useRemoteServerStore.getState().activeServerId;
+  if (!activeServerId) throw new Error('No remote provider active');
+  const provider = providerRegistry.getProvider(activeServerId);
+  if (!provider) throw new Error('Remote provider not found');
+  const settings = useAppStore.getState().settings;
+  const thinkingEnabled = !opts?.disableThinking && settings.thinkingEnabled && provider.capabilities.supportsThinking;
+  try {
+    return await remoteGenerateOnce(provider, { messages, tools, thinkingEnabled, onStream: opts?.onStream });
+  } catch (e: any) {
+    const msg = e?.message || String(e) || '';
+    // The server couldn't compile our tool schemas into a grammar. Rather than strand the
+    // turn on a "Generation Error", retry once WITHOUT tools so the user still gets an
+    // answer. (The real fix is sending grammar-safe schemas — see pruneToolNoise — this
+    // is the safety net for a schema/server combo we didn't anticipate.)
+    if (tools.length > 0 && isToolGrammarError(msg)) {
+      logger.warn(`[ToolLoop] remote rejected tool grammar; retrying without tools: ${msg.slice(0, 140)}`);
+      return remoteGenerateOnce(provider, { messages, tools: [], thinkingEnabled, onStream: opts?.onStream });
+    }
+    throw e;
+  }
 }
 
 async function callLocalWithRetry(

--- a/src/services/generationToolLoop.ts
+++ b/src/services/generationToolLoop.ts
@@ -292,6 +292,10 @@ export function isToolGrammarError(msg: string): boolean {
 }
 
 /** One remote generation attempt with the given tool set. */
+/** A stream that emitted at least one token before failing — carried on the rejection so
+ *  callers know a retry would DUPLICATE already-streamed output into the same consumer. */
+type StreamedError = Error & { streamed?: boolean };
+
 function remoteGenerateOnce(
   provider: any,
   args: { messages: Message[]; tools: any[]; thinkingEnabled: boolean; onStream?: (data: StreamToken) => void },
@@ -300,11 +304,12 @@ function remoteGenerateOnce(
   const settings = useAppStore.getState().settings;
   const options: GenerationOptions = { temperature: settings.temperature, maxTokens: settings.maxTokens, topP: settings.topP, tools, enableThinking: thinkingEnabled };
   let _fullContent = '';
+  let streamed = false;
   let toolCalls: ToolCall[] = [];
   return new Promise((resolve, reject) => {
     provider.generate(messages, options, {
-      onToken: (token: string) => { _fullContent += token; onStream?.({ content: token }); },
-      onReasoning: (content: string) => { onStream?.({ reasoningContent: content }); },
+      onToken: (token: string) => { _fullContent += token; streamed = true; onStream?.({ content: token }); },
+      onReasoning: (content: string) => { streamed = true; onStream?.({ reasoningContent: content }); },
       onComplete: (result: CompletionResult) => {
         if (result.toolCalls && result.toolCalls.length > 0) {
           toolCalls = result.toolCalls.map(tc => ({
@@ -317,7 +322,11 @@ function remoteGenerateOnce(
         }
         resolve({ fullResponse: result.content, toolCalls });
       },
-      onError: (error: Error) => { logger.error(`[ToolLoop] onError — ${error.message}`); reject(error); },
+      onError: (error: Error) => {
+        logger.error(`[ToolLoop] onError — ${error.message}`);
+        (error as StreamedError).streamed = streamed;
+        reject(error);
+      },
     });
   });
 }
@@ -341,7 +350,10 @@ async function callRemoteLLMWithTools(
     // turn on a "Generation Error", retry once WITHOUT tools so the user still gets an
     // answer. (The real fix is sending grammar-safe schemas — see pruneToolNoise — this
     // is the safety net for a schema/server combo we didn't anticipate.)
-    if (tools.length > 0 && isToolGrammarError(msg)) {
+    // Only retry if the failed attempt streamed NOTHING — otherwise the retry would
+    // stream a second answer into the same consumer, duplicating/corrupting the output.
+    // A grammar 400 fails at request time (before any token), so the common case is clean.
+    if (tools.length > 0 && isToolGrammarError(msg) && !(e as StreamedError).streamed) {
       logger.warn(`[ToolLoop] remote rejected tool grammar; retrying without tools: ${msg.slice(0, 140)}`);
       return remoteGenerateOnce(provider, { messages, tools: [], thinkingEnabled, onStream: opts?.onStream });
     }

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -221,6 +221,9 @@ export async function createStreamingRequest(
             reject(err);
           }
         } else {
+          // Log the full server error body — a bare "HTTP 400" is undiagnosable; the body
+          // (e.g. llama.cpp's "failed to parse grammar") is what tells you what to fix.
+          logger.error(`[HttpClient] HTTP ${xhr.status} error body: ${xhr.responseText || '(empty)'}`);
           reject(new Error(`HTTP ${xhr.status}: ${xhr.responseText || 'Unknown error'}`));
         }
       }
@@ -329,6 +332,9 @@ export async function createNDJSONStreamingRequest(
           }
           resolve();
         } else {
+          // Log the full server error body — a bare "HTTP 400" is undiagnosable; the body
+          // (e.g. llama.cpp's "failed to parse grammar") is what tells you what to fix.
+          logger.error(`[HttpClient] HTTP ${xhr.status} error body: ${xhr.responseText || '(empty)'}`);
           reject(new Error(`HTTP ${xhr.status}: ${xhr.responseText || 'Unknown error'}`));
         }
       }


### PR DESCRIPTION
## Summary
Stacked on #441 (download-queue fix).

A remote **llama.cpp** server compiles the `tools` schemas into a GBNF grammar and returns `HTTP 400: failed to initialize samplers: failed to parse grammar` when a schema is too complex for its converter (e.g. the Notion MCP tool, with `\$schema`/nested `\$ref`). The app was sending remote servers the **raw, untrimmed** schema on the assumption "remote = big model" — wrong when the remote is llama.cpp.

## Fix (two layers)
1. **Grammar-safe schemas (pro submodule):** `pruneToolNoise` strips grammar-breaking JSON-Schema keywords for **every** backend, keeping all params/enums. (See off-grid-ai/mobile-pro#13; submodule bumped here.)
2. **Retry-without-tools safety net (core):** we can't know a server's grammar-compiler limits up front, so `callRemoteLLMWithTools` catches a grammar 400 (`isToolGrammarError`) and retries once without tools — the user gets an answer instead of a Generation Error sheet. Unrelated errors (500, network) still propagate.
3. `httpClient` now logs the full server error body (a bare "HTTP 400" was undiagnosable).

## Tests
Retries without tools on a grammar error; does NOT retry on unrelated errors; `isToolGrammarError` matching.

## Note
This PR's submodule bump (`5ed8e4b9` → `f1c3f61`) also advances the pro pointer past intervening merged pro PRs (#11/#12) since the base branch's pro pointer was behind. Rebase onto the merged pro `main` before merge if a cleaner bump is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)