### PR TITLE
fix(chat): show 'No Model Selected' alert on resend/edit when no model is loaded

### DIFF
--- a/__tests__/unit/hooks/useChatMessageHandlers.test.ts
+++ b/__tests__/unit/hooks/useChatMessageHandlers.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for useChatMessageHandlers — the resend/retry + edit-and-resend
+ * handlers.
+ *
+ * Regression: ejecting all models then tapping Resend/Retry used to silently
+ * no-op (no message, no feedback). Now it alerts "No Model Selected", mirroring
+ * the send path (handleSendFn). See handleRetryMessageFn / handleEditMessageFn.
+ */
+
+import { handleRetryMessageFn, handleEditMessageFn } from '../../../src/screens/ChatScreen/useChatMessageHandlers';
+import * as generationActions from '../../../src/screens/ChatScreen/useChatGenerationActions';
+import { createMessage } from '../../utils/factories';
+
+// Light mocks — the no-model path bails before any of these are touched, but
+// they still need to exist so the module imports cleanly.
+jest.mock('../../../src/services/modelResidency', () => ({
+  modelResidencyManager: { getResidents: jest.fn(() => []), reclaimSttForGeneration: jest.fn() },
+}));
+jest.mock('../../../src/services/hardware', () => ({
+  hardwareService: { getAvailableMemoryGB: jest.fn(() => 4), getTotalMemoryGB: jest.fn(() => 8) },
+}));
+
+const makeDeps = (overrides: Partial<any> = {}): any => ({
+  setAlertState: jest.fn(),
+  ...overrides,
+});
+
+describe('handleRetryMessageFn — no active model', () => {
+  let regenSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    regenSpy = jest.spyOn(generationActions, 'regenerateResponseFn').mockResolvedValue(undefined);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('alerts "No Model Selected" and does not regenerate when no model is loaded', async () => {
+    const genDeps = makeDeps();
+    const message = createMessage({ role: 'user', content: 'hi' });
+
+    await handleRetryMessageFn(message, genDeps, {
+      activeConversationId: 'conv-1',
+      hasActiveModel: false,
+      activeConversation: { messages: [message] },
+      deleteMessagesAfter: jest.fn(),
+      setDebugInfo: jest.fn(),
+    });
+
+    expect(genDeps.setAlertState).toHaveBeenCalledWith(
+      expect.objectContaining({ visible: true, title: 'No Model Selected' }),
+    );
+    expect(regenSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT alert and bails quietly when a model exists but there is no conversation', async () => {
+    const genDeps = makeDeps();
+    const message = createMessage({ role: 'user', content: 'hi' });
+
+    await handleRetryMessageFn(message, genDeps, {
+      activeConversationId: null,
+      hasActiveModel: true,
+      activeConversation: null,
+      deleteMessagesAfter: jest.fn(),
+      setDebugInfo: jest.fn(),
+    });
+
+    expect(genDeps.setAlertState).not.toHaveBeenCalled();
+    expect(regenSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleEditMessageFn — no active model', () => {
+  let regenSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    regenSpy = jest.spyOn(generationActions, 'regenerateResponseFn').mockResolvedValue(undefined);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('alerts "No Model Selected" and does not regenerate when no model is loaded', async () => {
+    const genDeps = makeDeps();
+    const message = createMessage({ role: 'user', content: 'original' });
+
+    await handleEditMessageFn(genDeps, {
+      message,
+      newContent: 'edited',
+      activeConversationId: 'conv-1',
+      hasActiveModel: false,
+      updateMessageContent: jest.fn(),
+      deleteMessagesAfter: jest.fn(),
+      setDebugInfo: jest.fn(),
+    });
+
+    expect(genDeps.setAlertState).toHaveBeenCalledWith(
+      expect.objectContaining({ visible: true, title: 'No Model Selected' }),
+    );
+    expect(regenSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/screens/ChatScreen/useChatMessageHandlers.ts
+++ b/src/screens/ChatScreen/useChatMessageHandlers.ts
@@ -32,7 +32,10 @@ export async function handleRetryMessageFn(
     logger.log(`[MEM-SM] resend: residents=[${residents}] availMB=${Math.round(hardwareService.getAvailableMemoryGB() * 1024)} totalMB=${Math.round(hardwareService.getTotalMemoryGB() * 1024)}`);
   } catch { /* diagnostics only */ }
   logger.log(`[RESEND-SM] retry msg role=${message.role} id=${message.id} hasActiveModel=${p.hasActiveModel} conv=${p.activeConversationId} totalMsgs=${msgs.length}`);
-  if (!p.activeConversationId || !p.hasActiveModel) { logger.log('[RESEND-SM] retry BAIL: no conv or no active model'); return; }
+  // No model loaded (e.g. user ejected all models): tell them, don't silently
+  // no-op. Mirrors the send path's "No Model Selected" alert (handleSendFn).
+  if (!p.hasActiveModel) { logger.log('[RESEND-SM] retry BAIL: no active model'); genDeps.setAlertState(showAlert('No Model Selected', 'Please select a model first.')); return; }
+  if (!p.activeConversationId) { logger.log('[RESEND-SM] retry BAIL: no conv'); return; }
   // Stop any in-flight TTS before deleting messages (no-op without pro audio)
   callHook(HOOKS.audioStop);
   if (message.role === 'user') {
@@ -62,7 +65,9 @@ type EditParams = {
 };
 
 export async function handleEditMessageFn(genDeps: GenerationDeps, p: EditParams): Promise<void> {
-  if (!p.activeConversationId || !p.hasActiveModel) return;
+  // Same as retry: no model loaded → alert instead of a silent no-op.
+  if (!p.hasActiveModel) { genDeps.setAlertState(showAlert('No Model Selected', 'Please select a model first.')); return; }
+  if (!p.activeConversationId) return;
   p.updateMessageContent(p.activeConversationId, p.message.id, p.newContent);
   p.deleteMessagesAfter(p.activeConversationId, p.message.id);
   await regenerateResponseFn(genDeps, { setDebugInfo: p.setDebugInfo, userMessage: { ...p.message, content: p.newContent } });


### PR DESCRIPTION
## Problem

Eject all models (no active text model), open an existing chat, tap **Resend** / **Retry** on a message — nothing happens. No new message, no error, no feedback. The tap appears dead and the user is left confused. Edit-and-resend has the same silent failure.

## Root cause

The resend/edit handlers guard with a single combined condition that returns with no user-facing feedback:

- `handleRetryMessageFn` — `if (!p.activeConversationId || !p.hasActiveModel) { ...; return; }` (silent)
- `handleEditMessageFn` — `if (!p.activeConversationId || !p.hasActiveModel) return;` (silent)

The **normal send path already handles this** — `handleSendFn` shows a `No Model Selected` alert when `!hasActiveModel`. So send tells the user to pick a model, but resend/edit stay silent. Inconsistent.

## Fix

Split the guard in both handlers so the **no-model case shows the same alert as the send path**, while the no-conversation case (genuinely nothing to resend) still bails quietly.

`genDeps.setAlertState` is already part of `GenerationDeps`, so this is fully contained to `useChatMessageHandlers.ts` — **no call-site wiring in `useChatScreen.ts` changes**. Reuses the exact existing copy (`No Model Selected` / `Please select a model first.`), so nothing new to run through the brand voice guide.

## Tests

Adds `__tests__/unit/hooks/useChatMessageHandlers.test.ts` (no test file existed for this module). Regression tests that fail on the old code and pass after:

- Retry with no model → alerts `No Model Selected`, does **not** call `regenerateResponseFn`.
- Retry with a model but no conversation → does **not** alert, does **not** regenerate (quiet bail preserved).
- Edit-and-resend with no model → alerts, does **not** regenerate.

## Quality gates

- `npx tsc --noEmit` — clean
- `eslint` on changed files — clean
- `jest` — 83 pass (3 new + 80 adjacent `useChatGenerationActions` suite, unchanged)

## Scope

- **In scope:** the silent-no-op-with-no-model bug for Resend/Retry and edit-and-resend.
- **Out of scope (separate PRs):** the larger audit findings — resend re-routing to the *currently selected* backend with no per-message provenance, and the local/remote selection desync between the UI `isRemote` and `generationService.isUsingRemoteProvider()`.

## Stacking

Based on `fix/llm-stability-and-perf` (#425), not `main`.