### PR TITLE
fix: release stability & performance hardening (downloads, memory, chat, audio, Pro, test integrity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Check out pro submodule (private; skipped on open-core forks)
+        # When the PRO_SUBMODULE_PAT secret is present (this org's CI), pull the private
+        # pro/ submodule so the pro-dependent suites (TTS/MCP/audio) run against the REAL
+        # package — a green run then actually exercises pro, not a stub. Forks without the
+        # secret skip this: proExists=false and jest runs the open-core suite instead.
+        if: ${{ secrets.PRO_SUBMODULE_PAT != '' }}
+        env:
+          PRO_PAT: ${{ secrets.PRO_SUBMODULE_PAT }}
+        run: |
+          git config --global url."https://x-access-token:${PRO_PAT}@github.com/".insteadOf "https://github.com/"
+          git submodule update --init --recursive pro
+          git config --global --unset url."https://x-access-token:${PRO_PAT}@github.com/".insteadOf || true
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/__tests__/integration/audio/streamingStateMachine.test.ts
+++ b/__tests__/integration/audio/streamingStateMachine.test.ts
@@ -151,9 +151,16 @@ describe('streaming state machine — engine errors never wedge', () => {
     expect(names()).toContain('stream segment FAILED');
     expect(names()).toContain('stream drain ABORT: engine wedged → release for fresh remount');
     expect(mockEngine.release).toHaveBeenCalled();
-    // Lock released: a brand-new stream can engage afterwards.
+    // Lock released. A brand-new stream can engage afterwards — but only after the
+    // wedged stream's state is cleared, which in the real app is what the next
+    // generation turn does (resetStreamingSpeech on new-turn/stop). Without it the
+    // aborted stream's stale active/ended flags block re-engagement. (This test never
+    // ran in CI and had rotted to a bare one-flush assertion that skipped the reset.)
     speakMode = 'resolve';
-    feedStreamingText('Recovered.');
+    resetStreamingSpeech();
+    await flush();
+    feedStreamingText('Recovered. ');
+    finishStreamingText('Recovered.', 'm2');
     await flush();
     expect((mockEngine.speak.mock.calls as unknown as string[][]).map((c) => c[0])).toContain('Recovered.');
   });

--- a/__tests__/integration/models/activeModelService.test.ts
+++ b/__tests__/integration/models/activeModelService.test.ts
@@ -104,6 +104,26 @@ describe('ActiveModelService Integration', () => {
       expect(getAppState().activeModelId).toBe('test-model-1');
     });
 
+    it('budgets a LiteRT text model as dirty memory and a GGUF as clean (F9)', async () => {
+      const spy = jest.spyOn(modelResidencyManager, 'makeRoomFor');
+      mockLlmService.isModelLoaded.mockReturnValue(true);
+
+      // LiteRT weights + KV are dirty/accelerator memory -> must budget against REAL
+      // free RAM (dirtyMemory:true), or the native engine can OOM on a "fits" verdict.
+      const litert = createDownloadedModel({ id: 'litert-1', engine: 'litert' as any, fileName: 'm.litertlm', filePath: '/m.litertlm' });
+      useAppStore.setState({ downloadedModels: [litert] });
+      await activeModelService.loadTextModel('litert-1').catch(() => {});
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ key: 'text', dirtyMemory: true }));
+
+      // GGUF/llama is clean mmap -> physical-cap budgeting unchanged (dirtyMemory:false).
+      spy.mockClear();
+      const gguf = createDownloadedModel({ id: 'gguf-1', engine: 'llama' as any });
+      useAppStore.setState({ downloadedModels: [gguf] });
+      await activeModelService.loadTextModel('gguf-1').catch(() => {});
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ key: 'text', dirtyMemory: false }));
+      spy.mockRestore();
+    });
+
     it('should save loadedSettings when model is loaded', async () => {
       const model = createDownloadedModel({ id: 'test-model-1' });
       useAppStore.setState({

--- a/__tests__/rntl/components/ModelSelectorModal.test.tsx
+++ b/__tests__/rntl/components/ModelSelectorModal.test.tsx
@@ -534,6 +534,23 @@ describe('ModelSelectorModal', () => {
   // Image Tab
   // ============================================================================
   describe('image tab', () => {
+    it('opens directly on the image tab when initialTab="image" (F-SHEET)', () => {
+      // Tapping the "Image" row in the models manager must open the selector focused on
+      // Image, not default to Text. The modal honors initialTab; the manager now passes it.
+      mockUseAppStore.mockReturnValue({
+        downloadedModels: [],
+        downloadedImageModels: [],
+        activeImageModelId: null,
+      });
+
+      const { getByText } = render(
+        <ModelSelectorModal {...defaultProps} initialTab="image" />
+      );
+
+      // No tab press needed — image content is shown immediately.
+      expect(getByText('No Image Models')).toBeTruthy();
+    });
+
     it('switches to image tab when Image is pressed', () => {
       mockUseAppStore.mockReturnValue({
         downloadedModels: [],

--- a/__tests__/unit/components/settings/sectionRegistry.test.ts
+++ b/__tests__/unit/components/settings/sectionRegistry.test.ts
@@ -1,6 +1,10 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, act } from '@testing-library/react-native';
 import {
   registerSettingsSection,
   getSettingsSections,
+  useSettingsSections,
   _clearSectionsForTesting,
 } from '../../../../src/components/settings/sectionRegistry';
 
@@ -29,5 +33,24 @@ describe('settings section registry', () => {
     expect(sections).toHaveLength(2);
     expect(sections[0]).toBe(FakeSection);
     expect(sections[1]).toBe(AnotherSection);
+  });
+
+  it('re-renders a mounted consumer when a section registers afterwards (F6 reactivity)', () => {
+    // The Pro-activation flow registers a Settings section AFTER SettingsScreen mounted;
+    // without reactivity the screen showed nothing until an app restart. useSettingsSections
+    // must push the update to an already-mounted consumer.
+    const Consumer = () => {
+      const sections = useSettingsSections();
+      return React.createElement(Text, { testID: 'count' }, `sections:${sections.length}`);
+    };
+    const { getByTestId } = render(React.createElement(Consumer));
+    expect(getByTestId('count').props.children).toBe('sections:0');
+
+    act(() => { registerSettingsSection(FakeSection); });
+    expect(getByTestId('count').props.children).toBe('sections:1');
+
+    // A no-op re-register (dev Fast Refresh) must not spuriously bump the count.
+    act(() => { registerSettingsSection(FakeSection); });
+    expect(getByTestId('count').props.children).toBe('sections:1');
   });
 });

--- a/__tests__/unit/engine/kokoroEngine.test.ts
+++ b/__tests__/unit/engine/kokoroEngine.test.ts
@@ -24,6 +24,7 @@ import { KokoroEngine, type KokoroBridgeHandle } from '../../../pro/audio/engine
 const listDownloadedFiles =
   BareResourceFetcher.listDownloadedFiles as jest.Mock;
 const deleteResources = BareResourceFetcher.deleteResources as jest.Mock;
+const fetchResources = (BareResourceFetcher as any).fetch as jest.Mock;
 
 // The two shared core .pte models.
 const KOKORO_CORE_FILES = ['duration_predictor.pte', 'synthesizer.pte'];
@@ -48,7 +49,38 @@ describe('KokoroEngine install status', () => {
   beforeEach(() => {
     listDownloadedFiles.mockReset();
     deleteResources.mockReset().mockResolvedValue(undefined);
+    fetchResources?.mockReset().mockResolvedValue(undefined);
     listDownloadedFiles.mockResolvedValue([]);
+  });
+
+  it('REGRESSION: a benign "already downloading" collision does not leave the voice stuck at downloading (F23)', async () => {
+    // Two overlapping downloadAssets() for the same shared sources: executorch throws
+    // "already downloading" on the losing one. That fetch drives progress on ITS own
+    // instance, not this one, so returning early here would strand this instance at
+    // phase 'downloading' forever (the stuck Voice-row bug). We reconcile from disk.
+    const engine = new KokoroEngine();
+    // The concurrent (winning) fetch has completed the files on disk by the time our
+    // benign catch runs its reconcile scan.
+    listDownloadedFiles.mockResolvedValue(allOnDisk());
+    fetchResources.mockRejectedValueOnce(new Error('Resource is already downloading'));
+
+    await engine.downloadAssets(); // must not throw
+
+    // Settled from disk truth, not stuck at 'downloading'.
+    expect(engine.getPhase()).not.toBe('downloading');
+    expect(engine.getPhase()).toBe('idle'); // downloaded on disk, no bridge yet
+    expect(engine.isFullyDownloaded()).toBe(true);
+  });
+
+  it('REGRESSION: a benign collision with assets NOT yet on disk settles to idle, not stuck downloading (F23)', async () => {
+    const engine = new KokoroEngine();
+    listDownloadedFiles.mockResolvedValue([]); // concurrent fetch hasn't finished either
+    fetchResources.mockRejectedValueOnce(new Error('already downloading'));
+
+    await engine.downloadAssets();
+
+    expect(engine.getPhase()).toBe('idle'); // not 'downloading'
+    expect(engine.isFullyDownloaded()).toBe(false);
   });
 
   it('reports not-downloaded when disk is empty and nothing has loaded', async () => {

--- a/__tests__/unit/hooks/useChatGenerationActions.test.ts
+++ b/__tests__/unit/hooks/useChatGenerationActions.test.ts
@@ -258,10 +258,16 @@ describe('shouldRouteToImageGenerationFn', () => {
     expect(mockClassifyIntent).not.toHaveBeenCalled();
   });
 
-  it('returns false when no image model is selected (nothing to load on demand)', async () => {
+  it('returns false when no image model is selected WITHOUT running the classifier or setting a status (F12)', async () => {
+    // Auto mode + no image model: there is nothing to route to, so the classifier must
+    // not run (it only adds latency on the send hot path) and no "Analyzing…" status
+    // should be set. Regression guard for the removed early-out.
     const deps = makeGenerationDeps({ activeImageModel: null });
     const result = await shouldRouteToImageGenerationFn(deps, 'draw a cat');
     expect(result).toBe(false);
+    expect(mockClassifyIntent).not.toHaveBeenCalled();
+    expect(deps.setIsClassifying).not.toHaveBeenCalledWith(true);
+    expect(deps.setAppImageGenerationStatus).not.toHaveBeenCalled();
   });
 
   it('routes an image request even when the image model is NOT resident (loads on demand — the voice-mode fix)', async () => {

--- a/__tests__/unit/hooks/useChatModelActions.test.ts
+++ b/__tests__/unit/hooks/useChatModelActions.test.ts
@@ -152,6 +152,50 @@ describe('initiateModelLoad', () => {
       expect.objectContaining({ title: 'Error' }),
     );
   });
+
+  it('resumes the pending turn after "Load Anyway" on insufficient memory (F16)', async () => {
+    jest.useFakeTimers();
+    const { InteractionManager } = require('react-native');
+    const iaSpy = jest.spyOn(InteractionManager, 'runAfterInteractions')
+      .mockImplementation((cb: any) => { cb?.(); return { then: () => {}, done: () => {}, cancel: () => {} } as any; });
+    mockCheckMemoryForModel.mockResolvedValueOnce({ canLoad: false, message: 'Not enough RAM', severity: 'critical' });
+    mockLoadTextModel.mockResolvedValue(undefined);
+    mockIsModelLoaded.mockReturnValue(true);
+    const onResume = jest.fn();
+    const deps = makeDeps();
+
+    await initiateModelLoad(deps, false, onResume);
+    const alert = deps.setAlertState.mock.calls.find((c: any) => c[0].title === 'Insufficient Memory')[0];
+    const loadAnyway = alert.buttons.find((b: any) => b.text === 'Load Anyway');
+
+    loadAnyway.onPress();
+    await jest.advanceTimersByTimeAsync(400); // flush waitForRenderFrame -> doLoadTextModel -> resume
+
+    expect(mockLoadTextModel).toHaveBeenCalledWith('model-1');
+    expect(onResume).toHaveBeenCalledTimes(1); // the message is NOT dropped
+    iaSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('does NOT resume a turn for "Load Anyway" when no resume was requested (model-select/reload)', async () => {
+    jest.useFakeTimers();
+    const { InteractionManager } = require('react-native');
+    const iaSpy = jest.spyOn(InteractionManager, 'runAfterInteractions')
+      .mockImplementation((cb: any) => { cb?.(); return { then: () => {}, done: () => {}, cancel: () => {} } as any; });
+    mockCheckMemoryForModel.mockResolvedValueOnce({ canLoad: false, message: 'Not enough RAM', severity: 'critical' });
+    mockLoadTextModel.mockResolvedValue(undefined);
+    mockIsModelLoaded.mockReturnValue(true);
+    const deps = makeDeps();
+
+    await initiateModelLoad(deps, false); // no onLoadedResume
+    const alert = deps.setAlertState.mock.calls.find((c: any) => c[0].title === 'Insufficient Memory')[0];
+    alert.buttons.find((b: any) => b.text === 'Load Anyway').onPress();
+    await jest.advanceTimersByTimeAsync(400);
+
+    expect(mockLoadTextModel).toHaveBeenCalledWith('model-1'); // still loads
+    iaSpy.mockRestore();
+    jest.useRealTimers();
+  });
 });
 
 // ─────────────────────────────────────────────

--- a/__tests__/unit/screens/DownloadManagerScreen/useDownloadManager.branches.test.ts
+++ b/__tests__/unit/screens/DownloadManagerScreen/useDownloadManager.branches.test.ts
@@ -27,7 +27,8 @@ const mockModelManager = {
 };
 const mockHardwareService = { getModelTotalSize: jest.fn(() => 1000) };
 const mockHuggingFaceService = { getModelFiles: jest.fn() };
-const mockBackgroundDownloadService = { cancelDownload: jest.fn(), getActiveDownloads: jest.fn(), getQueuedItems: jest.fn(() => []) };
+const mockBackgroundDownloadService = { cancelDownload: jest.fn(), getActiveDownloads: jest.fn(), getQueuedItems: jest.fn(() => []), reconcileActiveIds: jest.fn().mockResolvedValue(undefined) };
+const mockSubscribe = jest.fn((_fn?: any) => () => {});
 
 const mockMDS = {
   retry: jest.fn(async (_id: string) => {}),
@@ -57,7 +58,7 @@ jest.mock('../../../../src/services', () => ({
   get backgroundDownloadService() { return mockBackgroundDownloadService; },
 }));
 jest.mock('../../../../src/services/modelDownloadService', () => ({
-  get modelDownloadService() { return { retry: (id: string) => mockMDS.retry(id), cancel: (id: string) => mockMDS.cancel(id), remove: (id: string) => mockMDS.remove(id), subscribe: () => () => {} }; },
+  get modelDownloadService() { return { retry: (id: string) => mockMDS.retry(id), cancel: (id: string) => mockMDS.cancel(id), remove: (id: string) => mockMDS.remove(id), subscribe: (fn: any) => mockSubscribe(fn) }; },
 }));
 jest.mock('../../../../src/services/modelDownloadService/providers/imageProvider', () => ({
   setImageDownloadOps: (...a: any[]) => mockSetImageDownloadOps(...a),
@@ -309,5 +310,23 @@ describe('activeItems mapping', () => {
     const { result } = renderHook(() => useDownloadManager());
     expect(result.current.isRepairingVision('org/repo/m.gguf')).toBe(true);
     expect(result.current.isRepairingVision('other')).toBe(false);
+  });
+});
+
+describe('queued-items subscription (F14 churn)', () => {
+  it('subscribes to the download service once and does NOT re-subscribe when downloads change each tick', () => {
+    const { rerender } = renderHook(() => useDownloadManager());
+    expect(mockSubscribe).toHaveBeenCalledTimes(1);
+
+    // Simulate progress ticks handing the selector a brand-new downloads object each
+    // render. Under the old [downloads] dep this tore down + rebuilt the subscription
+    // (and the 1s interval) every tick; with [] it must stay a single subscription.
+    const entry = (progress: number) => ({ 'a/x/f.gguf': { modelId: 'a/x', modelKey: 'a/x/f.gguf', fileName: 'f.gguf', modelType: 'text', status: 'running', progress, bytesDownloaded: 1, totalBytes: 100, quantization: 'Q4' } });
+    act(() => { downloads = entry(0.1); configureStores(); });
+    rerender({});
+    act(() => { downloads = entry(0.2); configureStores(); });
+    rerender({});
+
+    expect(mockSubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/unit/screens/ModelsScreen/useModelsScreen.test.ts
+++ b/__tests__/unit/screens/ModelsScreen/useModelsScreen.test.ts
@@ -589,6 +589,31 @@ describe('useModelsScreen', () => {
 
       expect(mockHandleDownload).toHaveBeenCalledWith(mockModel, mockFile);
     });
+
+    it('starts a download even when 2+ are already active (no "Starting more can affect performance" gate)', () => {
+      // The concurrency cap + FIFO queue in backgroundDownloadService owns this now,
+      // so a 3rd+ start just queues. The old caller-side alert must be gone.
+      const { useTextModels } = require('../../../../src/screens/ModelsScreen/useTextModels');
+      const { showAlert } = require('../../../../src/components/CustomAlert');
+      const mockHandleDownload = jest.fn();
+      mockDownloads['a/x/a.gguf'] = { status: 'running' };
+      mockDownloads['b/y/b.gguf'] = { status: 'running' };
+      useTextModels.mockReturnValue({
+        downloadedModels: [], setIsRefreshing: jest.fn(),
+        loadDownloadedModels: jest.fn().mockResolvedValue(undefined),
+        hasSearched: false, searchQuery: '', handleSearch: jest.fn(),
+        handleDownload: mockHandleDownload, downloadProgress: {},
+        setFilterState: jest.fn(), setTextFiltersVisible: jest.fn(),
+      });
+
+      const { result } = renderHook(() => useModelsScreen());
+      const mockModel: any = { id: 'model-id', name: 'Test', author: 'Test', files: [] };
+      const mockFile: any = { name: 'url', size: 100, quantization: 'Q4', downloadUrl: 'http://test' };
+      act(() => { result.current.handleDownload(mockModel, mockFile); });
+
+      expect(mockHandleDownload).toHaveBeenCalledWith(mockModel, mockFile);
+      expect(showAlert).not.toHaveBeenCalledWith('Downloads Already Active', expect.anything(), expect.anything());
+    });
   });
 
   describe('handleDownloadImageModel callback', () => {

--- a/__tests__/unit/services/backgroundDownloadService.test.ts
+++ b/__tests__/unit/services/backgroundDownloadService.test.ts
@@ -1395,5 +1395,38 @@ describe('BackgroundDownloadService', () => {
       await flush();
       expect(mockDownloadManagerModule.startDownload).toHaveBeenCalledTimes(1);
     });
+
+    it('reconcileActiveIds reclaims leaked slots (e.g. folded mmproj sidecars) and pumps the queue', async () => {
+      // 3 downloads hold the slots, a 4th is queued.
+      ['a', 'b', 'c', 'd'].forEach((id) => service.startDownload(params(id)));
+      await flush();
+      expect(mockDownloadManagerModule.startDownload).toHaveBeenCalledTimes(3);
+      expect(service.getQueuedCount()).toBe(1);
+
+      // Native truth: only '1' is still transferring — '2' and '3' leaked (their tasks
+      // were folded into a main download, so they never emitted DownloadComplete and
+      // release() was never called). Without reconcile, pump() sees the cap as full
+      // forever and 'd' is wedged — the "1 downloading, N queued" collapse.
+      mockDownloadManagerModule.getActiveDownloads.mockResolvedValue([{ downloadId: '1' }]);
+      await service.reconcileActiveIds();
+      await flush();
+
+      // The two phantom slots are reclaimed, so the queued 'd' starts.
+      expect(mockDownloadManagerModule.startDownload).toHaveBeenCalledTimes(4);
+      expect(service.getQueuedCount()).toBe(0);
+    });
+
+    it('reconcileActiveIds does NOT drop slots the native layer still reports active', async () => {
+      ['a', 'b', 'c', 'd'].forEach((id) => service.startDownload(params(id)));
+      await flush();
+      // All three are genuinely still downloading — reconcile must not free anything.
+      mockDownloadManagerModule.getActiveDownloads.mockResolvedValue([
+        { downloadId: '1' }, { downloadId: '2' }, { downloadId: '3' },
+      ]);
+      await service.reconcileActiveIds();
+      await flush();
+      expect(mockDownloadManagerModule.startDownload).toHaveBeenCalledTimes(3);
+      expect(service.getQueuedCount()).toBe(1);
+    });
   });
 });

--- a/__tests__/unit/services/backgroundDownloadService.test.ts
+++ b/__tests__/unit/services/backgroundDownloadService.test.ts
@@ -1439,6 +1439,24 @@ describe('BackgroundDownloadService', () => {
       expect(service.getQueuedCount()).toBe(0);
     });
 
+    it('purgeNativeRecord drops the record and frees the slot WITHOUT dispatching an error', async () => {
+      mockDownloadManagerModule.cancelDownload.mockResolvedValue(undefined);
+      const onErr = jest.fn();
+      service.onAnyError(onErr);
+      service.startDownload(params('a')); // id '1' occupies a slot
+      await flush();
+
+      await service.purgeNativeRecord('1');
+
+      // Native record dropped and slot freed, but (unlike cancelDownload) NO synthetic
+      // DownloadError — a just-finalized model must not flash "failed".
+      expect(mockDownloadManagerModule.cancelDownload).toHaveBeenCalledWith('1');
+      expect(onErr).not.toHaveBeenCalled();
+      // Slot was freed: three fresh starts all begin, none queued.
+      ['b', 'c', 'd'].forEach((id) => service.startDownload(params(id)));
+      expect(service.getQueuedCount()).toBe(0);
+    });
+
     it('reconcileActiveIds does NOT drop slots the native layer still reports active', async () => {
       ['a', 'b', 'c', 'd'].forEach((id) => service.startDownload(params(id)));
       await flush();

--- a/__tests__/unit/services/backgroundDownloadService.test.ts
+++ b/__tests__/unit/services/backgroundDownloadService.test.ts
@@ -17,6 +17,7 @@ const originalOS = Platform.OS;
 const mockDownloadManagerModule = {
   startDownload: jest.fn(),
   cancelDownload: jest.fn(),
+  retryDownload: jest.fn(),
   getActiveDownloads: jest.fn(),
   getDownloadProgress: jest.fn(),
   moveCompletedDownload: jest.fn(),
@@ -1413,6 +1414,28 @@ describe('BackgroundDownloadService', () => {
 
       // The two phantom slots are reclaimed, so the queued 'd' starts.
       expect(mockDownloadManagerModule.startDownload).toHaveBeenCalledTimes(4);
+      expect(service.getQueuedCount()).toBe(0);
+    });
+
+    it('retryDownload re-reserves the slot so a retried download counts against the cap', async () => {
+      mockDownloadManagerModule.retryDownload.mockResolvedValue(undefined);
+      ['a', 'b', 'c'].forEach((id) => service.startDownload(params(id))); // ids 1,2,3
+      await flush();
+      // 'a' (id '1') fails -> its slot is released.
+      eventHandlers.DownloadError({ downloadId: '1', reason: 'boom' });
+      await flush();
+
+      // Retry it. Before the fix this restarted the native transfer without re-reserving,
+      // so the cap was silently bypassed and its completion couldn't pump the queue.
+      await service.retryDownload('1');
+
+      // At the cap again -> a fresh start must queue.
+      service.startDownload(params('d'));
+      expect(service.getQueuedCount()).toBe(1);
+
+      // The retried '1' completing frees its slot and promotes the queued 'd'.
+      eventHandlers.DownloadComplete({ downloadId: '1' });
+      await flush();
       expect(service.getQueuedCount()).toBe(0);
     });
 

--- a/__tests__/unit/services/litert.test.ts
+++ b/__tests__/unit/services/litert.test.ts
@@ -94,6 +94,59 @@ describe('LiteRTService', () => {
       await liteRTService.sendMessage('test', { onToken: jest.fn(), onReasoning: jest.fn(), onComplete: jest.fn(), onError });
       expect(onError).toHaveBeenCalled();
     });
+
+    it('adopts the native-clamped maxNumTokens from the load result (F20)', async () => {
+      const isolatedLiteRTModule = {
+        // Requested 4096, but native clamped the context to 1024 to fit free RAM.
+        loadModel: jest.fn().mockResolvedValue({ backend: 'cpu', maxNumTokens: 1024 }),
+        resetConversation: jest.fn(), sendMessage: jest.fn(), stopGeneration: jest.fn(),
+        unloadModel: jest.fn(), getMemoryInfo: jest.fn(),
+      };
+      const isolatedEmitter = { addListener: jest.fn(() => ({ remove: jest.fn() })) };
+      jest.resetModules();
+      jest.doMock('react-native', () => ({
+        NativeModules: { LiteRTModule: isolatedLiteRTModule },
+        NativeEventEmitter: jest.fn(() => isolatedEmitter),
+        Platform: { OS: 'android', select: (s: Record<string, any>) => s.android ?? s.default ?? null },
+      }));
+      jest.doMock('../../../src/utils/logger', () => {
+        const log = jest.fn();
+        return { __esModule: true, default: { log, error: log, warn: log } };
+      });
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { liteRTService: svc } = require('../../../src/services/litert');
+
+      await svc.loadModel('/m.litertlm', 'cpu', { maxNumTokens: 4096 });
+
+      // The context-usage budget reflects the CLAMPED value, not the requested 4096 —
+      // so compaction + the usage bar are accurate.
+      expect(svc.getContextUsage().max).toBe(1024);
+    });
+
+    it('tolerates a bare-string load result from an older native build (backward-compatible)', async () => {
+      const isolatedLiteRTModule = {
+        loadModel: jest.fn().mockResolvedValue('gpu'), // old contract: backend string only
+        resetConversation: jest.fn(), sendMessage: jest.fn(), stopGeneration: jest.fn(),
+        unloadModel: jest.fn(), getMemoryInfo: jest.fn(),
+      };
+      const isolatedEmitter = { addListener: jest.fn(() => ({ remove: jest.fn() })) };
+      jest.resetModules();
+      jest.doMock('react-native', () => ({
+        NativeModules: { LiteRTModule: isolatedLiteRTModule },
+        NativeEventEmitter: jest.fn(() => isolatedEmitter),
+        Platform: { OS: 'android', select: (s: Record<string, any>) => s.android ?? s.default ?? null },
+      }));
+      jest.doMock('../../../src/utils/logger', () => {
+        const log = jest.fn();
+        return { __esModule: true, default: { log, error: log, warn: log } };
+      });
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { liteRTService: svc } = require('../../../src/services/litert');
+
+      await svc.loadModel('/m.litertlm', 'gpu', { maxNumTokens: 2048 });
+      expect(svc.getActiveBackend()).toBe('gpu');
+      expect(svc.getContextUsage().max).toBe(2048); // keeps the requested value
+    });
   });
 
   describe('sendMessage', () => {

--- a/__tests__/unit/services/modelDownloadService.test.ts
+++ b/__tests__/unit/services/modelDownloadService.test.ts
@@ -119,28 +119,41 @@ describe('ModelDownloadService', () => {
     await expect(modelDownloadService.retry('image:zzz')).resolves.toBeUndefined();
   });
 
-  it('cancels a queued (not-yet-started) download that no provider lists, matched by uniform id', async () => {
-    // 'text:m/a' isn't in any provider list (it's still waiting for a slot), so it
-    // lives only in the queue owner keyed by its platform modelKey.
+  it('cancels a queued text download using the SAME id the View dispatches (text:<modelKey>, not text:<repo>)', async () => {
+    // A queued text start carries modelId=<repo> but modelKey=<repo/file>. Its started-row
+    // id is text:<modelKey> (textProvider.list keys on modelKey), so the View dispatches
+    // text:m/a/a.gguf — NOT text:m/a. cancelQueuedStart must match on the modelKey-derived
+    // id via queuedUniformId, or cancelling a Queued text row silently no-ops and it
+    // downloads anyway. (Before the fix cancelQueuedStart derived text:m/a and missed.)
     mockBg.getQueuedItems.mockReturnValue([
-      { modelKey: 'm/a::a.gguf', modelId: 'm/a', fileName: 'a.gguf', modelType: 'text', totalBytes: 100 },
+      { modelKey: 'm/a/a.gguf', modelId: 'm/a', fileName: 'a.gguf', modelType: 'text', totalBytes: 100 },
     ]);
     mockBg.cancelQueued.mockReturnValue(true);
     modelDownloadService.register(makeProvider('text', [dl('text:other', 'text')]));
 
-    await modelDownloadService.cancel('text:m/a');
+    await modelDownloadService.cancel('text:m/a/a.gguf');
 
     // Routed to the queue owner by the SAME uniform id, using the queued item's modelKey.
-    expect(mockBg.cancelQueued).toHaveBeenCalledWith('m/a::a.gguf');
+    expect(mockBg.cancelQueued).toHaveBeenCalledWith('m/a/a.gguf');
     const lines = (logger.log as jest.Mock).mock.calls.map(c => c[0]);
-    expect(lines.some((l: string) => l.includes('cancel text:m/a → cancelled queued start'))).toBe(true);
+    expect(lines.some((l: string) => l.includes('cancel text:m/a/a.gguf → cancelled queued start'))).toBe(true);
+  });
+
+  it('does NOT match a queued text download by its bare-repo id (text:<repo>)', async () => {
+    // The bare-repo id is never what the View dispatches; matching it would be the old bug.
+    mockBg.getQueuedItems.mockReturnValue([
+      { modelKey: 'm/a/a.gguf', modelId: 'm/a', fileName: 'a.gguf', modelType: 'text', totalBytes: 100 },
+    ]);
+    mockBg.cancelQueued.mockReturnValue(true);
+    await modelDownloadService.cancel('text:m/a');
+    expect(mockBg.cancelQueued).not.toHaveBeenCalled();
   });
 
   it('does NOT route retry to the queue (a not-yet-started item cannot be retried)', async () => {
     mockBg.getQueuedItems.mockReturnValue([
-      { modelKey: 'm/a::a.gguf', modelId: 'm/a', fileName: 'a.gguf', modelType: 'text', totalBytes: 100 },
+      { modelKey: 'm/a/a.gguf', modelId: 'm/a', fileName: 'a.gguf', modelType: 'text', totalBytes: 100 },
     ]);
-    await modelDownloadService.retry('text:m/a');
+    await modelDownloadService.retry('text:m/a/a.gguf');
     expect(mockBg.cancelQueued).not.toHaveBeenCalled();
   });
 

--- a/__tests__/unit/services/modelResidency.test.ts
+++ b/__tests__/unit/services/modelResidency.test.ts
@@ -293,6 +293,31 @@ describe('ModelResidencyManager', () => {
       jest.spyOn(hardwareService, 'getTotalMemoryGB').mockReturnValue(4);
       await expect(modelResidencyManager.reclaimSttForGeneration()).resolves.toBeUndefined();
     });
+
+    it('serializes the reclaim behind an in-flight load (F3: no unload while the lock is held)', async () => {
+      jest.spyOn(hardwareService, 'getTotalMemoryGB').mockReturnValue(4);
+      const order: string[] = [];
+      const unload = jest.fn().mockImplementation(async () => { order.push('reclaim:unload'); });
+      modelResidencyManager.register({ key: 'whisper', type: 'whisper', sizeMB: 466 }, unload, 1);
+
+      // A load holds the global lock.
+      let releaseLoad: () => void = () => {};
+      const load = modelResidencyManager.runExclusive('load:text', async () => {
+        order.push('load:start');
+        await new Promise<void>(r => { releaseLoad = r; });
+        order.push('load:end');
+      });
+      // Fire the reclaim while the load is still holding the lock.
+      const reclaim = modelResidencyManager.reclaimSttForGeneration();
+      await new Promise(r => setImmediate(r));
+      // The reclaim's native unload must NOT run mid-load — that's the race the lock closes.
+      expect(order).toEqual(['load:start']);
+
+      releaseLoad();
+      await Promise.all([load, reclaim]);
+      expect(order).toEqual(['load:start', 'load:end', 'reclaim:unload']);
+      expect(modelResidencyManager.isResident('whisper')).toBe(false);
+    });
   });
 
   describe('makeRoomFor (predictive — credits evictable residents)', () => {

--- a/__tests__/unit/services/parallelMmproj.test.ts
+++ b/__tests__/unit/services/parallelMmproj.test.ts
@@ -38,6 +38,7 @@ jest.mock('../../../src/services/backgroundDownloadService', () => ({
     isAvailable: jest.fn(() => true),
     startDownload: jest.fn(),
     cancelDownload: jest.fn(() => Promise.resolve()),
+    purgeNativeRecord: jest.fn(() => Promise.resolve()),
     adoptActive: jest.fn(),
     getActiveDownloads: jest.fn(() => Promise.resolve([])),
     moveCompletedDownload: jest.fn(),
@@ -575,7 +576,7 @@ describe('Parallel mmproj download', () => {
       const onError = jest.fn();
       mockService.moveCompletedDownload.mockRejectedValue(new Error('Download 42 not completed yet'));
       mockedRNFS.exists.mockResolvedValue(true); // the final file IS on disk
-      mockService.cancelDownload.mockResolvedValue(undefined);
+      mockService.purgeNativeRecord.mockResolvedValue(undefined);
 
       watchBackgroundDownload({
         downloadId: '42',
@@ -591,7 +592,10 @@ describe('Parallel mmproj download', () => {
 
       expect(onComplete).toHaveBeenCalledTimes(1); // finalized from disk, not an error
       expect(onError).not.toHaveBeenCalled();
-      expect(mockService.cancelDownload).toHaveBeenCalledWith('42'); // stale record purged
+      // Purged via the listener-free path (NOT the finalize-path cancelDownload, which
+      // would synthesize a spurious DownloadError and flash the just-finalized model as
+      // failed — see F2). cancelDownload may still be called by the re-adopt path above.
+      expect(mockService.purgeNativeRecord).toHaveBeenCalledWith('42');
     });
 
     it('fails (not loops) when the native move rejects AND the file is genuinely absent', async () => {

--- a/__tests__/unit/services/whisperService.test.ts
+++ b/__tests__/unit/services/whisperService.test.ts
@@ -505,6 +505,25 @@ describe('WhisperService', () => {
 
         expect(requestSpy).not.toHaveBeenCalled();
       });
+
+      it('restores playback after stopTranscription so TTS is not silenced (F4)', async () => {
+        // Dictation sets the owner to record mode.
+        await whisperService.requestPermissions();
+        expect(audioSessionManager.getMode()).toBe('record');
+
+        // Stopping dictation must hand the session back to the owner. Previously nothing
+        // did, so mode stayed 'record' and the next TTS ensurePlayback() early-returned
+        // → silent speech after dictation.
+        await whisperService.stopTranscription();
+        expect(audioSessionManager.getMode()).toBe('playback');
+
+        // And a subsequent TTS playback request is actually applied (not skipped).
+        mockSetAudioSessionOptions.mockClear();
+        await audioSessionManager.ensurePlayback();
+        expect(mockSetAudioSessionOptions).toHaveBeenCalledWith(
+          expect.objectContaining({ iosCategory: 'playback' }),
+        );
+      });
     });
   });
 

--- a/__tests__/unit/stores/remoteServerStore.test.ts
+++ b/__tests__/unit/stores/remoteServerStore.test.ts
@@ -598,6 +598,38 @@ describe('remoteServerStore', () => {
       expect(useRemoteServerStore.getState().discoveredModels[serverId]).toHaveLength(1);
     });
 
+    it('trusts the gateway kind:"vision" for supportsVision even when name/probe detection would miss it (F7)', async () => {
+      // A gateway vision model whose id matches no name heuristic; probes return no
+      // capability. Without trusting kind, supportsVision would be false and the image
+      // would be dropped client-side so the model behaved text-only.
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          object: 'list',
+          data: [
+            { id: 'gemma-4-e4b-it-Q8_0.gguf', kind: 'vision', owned_by: 'offgrid' },
+            { id: 'plain-chat.gguf', kind: 'chat', owned_by: 'offgrid' },
+          ],
+        }),
+      });
+      (global as any).fetch = mockFetch;
+
+      let serverId = '';
+      actStoreUpdate(() => {
+        serverId = useRemoteServerStore.getState().addServer({
+          name: 'Gateway', endpoint: 'http://mac:7878', providerType: 'openai-compatible',
+        });
+      });
+      let modelsPromise: any;
+      act(() => { modelsPromise = useRemoteServerStore.getState().discoverModels(serverId); });
+      const models = await modelsPromise;
+
+      const vision = models.find((m: any) => m.id === 'gemma-4-e4b-it-Q8_0.gguf');
+      const chat = models.find((m: any) => m.id === 'plain-chat.gguf');
+      expect(vision?.capabilities.supportsVision).toBe(true);
+      expect(chat?.capabilities.supportsVision).toBe(false);
+    });
+
     it('should handle fetch failure and return empty array', async () => {
       // Mock fetch to fail
       const mockFetch = jest.fn().mockRejectedValue(new Error('Network error'));

--- a/__tests__/unit/utils/downloadStatusIcon.test.ts
+++ b/__tests__/unit/utils/downloadStatusIcon.test.ts
@@ -1,0 +1,21 @@
+import { downloadStatusIcon, QUEUED_ICON } from '../../../src/utils/downloadStatusIcon';
+
+describe('downloadStatusIcon (single status->icon source of truth)', () => {
+  it('maps a queued (pending) download to the clock icon', () => {
+    // Queued was previously text-only with no icon; it must now be icon-coded like
+    // every other state so the Download Manager row and ModelCard agree.
+    expect(downloadStatusIcon('pending')).toBe('clock');
+    expect(QUEUED_ICON).toBe('clock');
+  });
+
+  it('maps the other non-running states to their icons', () => {
+    expect(downloadStatusIcon('failed')).toBe('alert-circle');
+    expect(downloadStatusIcon('retrying')).toBe('refresh-cw');
+    expect(downloadStatusIcon('waiting_for_network')).toBe('wifi-off');
+  });
+
+  it('returns null for running/completed (no status glyph)', () => {
+    expect(downloadStatusIcon('running')).toBeNull();
+    expect(downloadStatusIcon('completed')).toBeNull();
+  });
+});

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -84,5 +84,12 @@
               <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />
           </intent-filter>
       </receiver>
+
+      <!-- WorkManager's foreground-service host needs the dataSync type declared, or
+           setForeground() throws on Android 14+ (the model-download FGS, see WorkerDownload). -->
+      <service
+          android:name="androidx.work.impl.foreground.SystemForegroundService"
+          android:foregroundServiceType="dataSync"
+          tools:node="merge" />
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,13 @@
 <!-- To check and request battery optimization exemption for uninterrupted downloads -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <!-- Run large model downloads as a foreground service so they keep progressing when
+         the app is backgrounded / the screen is off (WorkManager foreground worker). -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <!-- Android 13+ needs this to SHOW the ongoing download notification (requested at runtime). -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <!-- For reading and creating calendar events -->
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -1,9 +1,13 @@
 package ai.offgridmobile.download
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import android.os.Environment
 import android.os.PowerManager
 import android.provider.Settings
@@ -321,6 +325,20 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     fun stopProgressPolling() {
         workObservers.keys.toList().forEach { removeWorkObserver(it) }
         workObservers.clear()
+    }
+
+    /** Ask for POST_NOTIFICATIONS (Android 13+) so the foreground-service download
+     *  notification is visible. The download still runs as an FGS if denied; this only
+     *  affects notification visibility. Best-effort, no-op when unavailable/granted. */
+    @ReactMethod
+    fun requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        val activity = reactApplicationContext.currentActivity ?: return
+        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.POST_NOTIFICATIONS)
+            == PackageManager.PERMISSION_GRANTED) return
+        try {
+            ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.POST_NOTIFICATIONS), 8123)
+        } catch (_: Exception) { /* activity gone or already prompting */ }
     }
 
     @ReactMethod

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -1,15 +1,23 @@
 package ai.offgridmobile.download
 
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.util.Log
 import android.os.Environment
 import android.os.StatFs
+import androidx.core.app.NotificationCompat
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.WorkRequest
 import androidx.work.WorkerParameters
@@ -39,6 +47,15 @@ class WorkerDownload(
         val progressInterval = inputData.getLong(KEY_PROGRESS_INTERVAL, DEFAULT_PROGRESS_INTERVAL)
         val download = downloadDao.getDownload(downloadId) ?: return Result.failure()
 
+        // Run as a foreground service so a multi-GB download keeps progressing when the
+        // app is backgrounded or the screen is off. A plain CoroutineWorker gets WorkManager's
+        // ~10-min window + Doze throttling, so large downloads stalled/retry-looped (the
+        // Android-only "downloads never finish in background" bug). Best-effort: on Android
+        // 12+ setForeground can be refused if the app can't start an FGS right now; the
+        // worker still runs (just without the promotion), so never fail the download on it.
+        runCatching { setForeground(createForegroundInfo(download.fileName)) }
+            .onFailure { Log.w(TAG, "setForeground refused; continuing as background worker: ${it.message}") }
+
         if (isStopped) return handleStoppedState(downloadId, download, 0L)
 
         val targetFile = File(download.destination)
@@ -65,6 +82,12 @@ class WorkerDownload(
             cancelHandle?.dispose()
         }
     }
+
+    /** Required by expedited work as the pre-Android-12 foreground fallback. */
+    override suspend fun getForegroundInfo(): ForegroundInfo = buildForegroundInfo(applicationContext, null)
+
+    private fun createForegroundInfo(fileName: String?): ForegroundInfo =
+        buildForegroundInfo(applicationContext, fileName)
 
     private suspend fun checkDiskSpace(downloadId: String, download: DownloadEntity, targetFile: File, existingBytes: Long): Result? {
         if (download.totalBytes <= 0L) return null
@@ -271,6 +294,8 @@ class WorkerDownload(
             .build()
 
         const val DEFAULT_PROGRESS_INTERVAL = 1500L
+        private const val DOWNLOAD_CHANNEL_ID = "model_downloads"
+        private const val DOWNLOAD_NOTIFICATION_ID = 4711
         const val KEY_DOWNLOAD_ID = "download_id"
         const val KEY_PROGRESS = "progress"
         const val KEY_TOTAL = "total"
@@ -295,6 +320,37 @@ class WorkerDownload(
                 200 -> if (contentLength > 0L) contentLength else existingTotal
                 else -> maxOf(existingTotal, contentLength)
             }
+        }
+
+        /** Build the ongoing progress notification that promotes the worker to a
+         *  foreground service (dataSync type). Extracted here so it's testable with a
+         *  Robolectric Context without constructing the worker. */
+        internal fun buildForegroundInfo(ctx: Context, fileName: String?): ForegroundInfo {
+            ensureNotificationChannel(ctx)
+            val notification: Notification = NotificationCompat.Builder(ctx, DOWNLOAD_CHANNEL_ID)
+                .setContentTitle("Downloading model")
+                .setContentText(fileName ?: "Preparing download")
+                .setSmallIcon(android.R.drawable.stat_sys_download)
+                .setOngoing(true)
+                .setOnlyAlertOnce(true)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .build()
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ForegroundInfo(DOWNLOAD_NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+            } else {
+                ForegroundInfo(DOWNLOAD_NOTIFICATION_ID, notification)
+            }
+        }
+
+        internal fun ensureNotificationChannel(ctx: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+            val mgr = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            if (mgr.getNotificationChannel(DOWNLOAD_CHANNEL_ID) != null) return
+            mgr.createNotificationChannel(
+                NotificationChannel(DOWNLOAD_CHANNEL_ID, "Model downloads", NotificationManager.IMPORTANCE_LOW).apply {
+                    description = "Keeps large model downloads running in the background"
+                }
+            )
         }
 
         internal fun computeFileSha256(file: File): String {
@@ -338,6 +394,10 @@ class WorkerDownload(
                     WorkRequest.MIN_BACKOFF_MILLIS,
                     TimeUnit.MILLISECONDS,
                 )
+                // Start expedited when the OS allows it; fall back to a normal (still
+                // foreground-promoted via setForeground) run otherwise, so we never
+                // fail to enqueue when the expedited quota is exhausted.
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .setInputData(
                     workDataOf(
                         KEY_DOWNLOAD_ID to downloadId,

--- a/android/app/src/main/java/ai/offgridmobile/litert/LiteRTModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/litert/LiteRTModule.kt
@@ -136,8 +136,16 @@ class LiteRTModule(private val reactContext: ReactApplicationContext) :
                 supportsVision = visionEnabled
                 supportsAudio = audioEnabled
 
-                Log.i(TAG, "loadModel — success on backend=$activeBackend vision=$supportsVision audio=$supportsAudio")
-                safe.resolve(activeBackend)
+                Log.i(TAG, "loadModel — success on backend=$activeBackend vision=$supportsVision audio=$supportsAudio maxNumTokens=$configuredMaxTokens")
+                // Resolve what we ACTUALLY configured, not just the backend: resolveSafeMaxTokens
+                // may have clamped the context below the requested budget to fit free RAM. JS
+                // adopts the effective value so compaction thresholds + the context-usage bar
+                // reflect reality (they were stale at the requested figure otherwise).
+                val result = com.facebook.react.bridge.Arguments.createMap().apply {
+                    putString("backend", activeBackend)
+                    putInt("maxNumTokens", configuredMaxTokens)
+                }
+                safe.resolve(result)
             } catch (e: Exception) {
                 Log.e(TAG, "loadModel — all backends failed: ${e.message}", e)
                 safe.reject("LITERT_LOAD_ERROR", "Failed to load model: ${e.message}", e)

--- a/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
+++ b/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
@@ -3,6 +3,7 @@ package ai.offgridmobile.download
 import android.app.Application
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -280,5 +281,27 @@ class DownloadManagerModuleTest {
         assertEquals(seeded, total)
     }
 
+    // ── Foreground-service download notification (F8) ─────────────────────────
+
+    @Test
+    fun buildForegroundInfoUsesDataSyncServiceType() {
+        val ctx = org.robolectric.RuntimeEnvironment.getApplication()
+        val info = WorkerDownload.buildForegroundInfo(ctx, "gemma-4-Q8_0.gguf")
+        // On SDK 33 the FGS type MUST be dataSync, or startForeground throws on Android 14+.
+        assertEquals(
+            android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            info.foregroundServiceType,
+        )
+        assertNotNull(info.notification)
+    }
+
+    @Test
+    fun ensureNotificationChannelCreatesTheDownloadChannel() {
+        val ctx = org.robolectric.RuntimeEnvironment.getApplication()
+        WorkerDownload.ensureNotificationChannel(ctx)
+        val mgr = ctx.getSystemService(android.content.Context.NOTIFICATION_SERVICE)
+            as android.app.NotificationManager
+        assertNotNull(mgr.getNotificationChannel("model_downloads"))
+    }
 }
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,41 +1,60 @@
+const path = require('node:path');
+const fs = require('node:fs');
+
+// pro/ is a git submodule: the directory exists even when not checked out, so detect a
+// real file inside it (package.json). Mirrors metro.config.js's proExists. When pro IS
+// checked out (store builds + the pro repo's PAT in CI), we run the pro-dependent suites
+// against the REAL pro package instead of stubbing it — so a green public-CI run that
+// pulled the submodule actually exercises TTS/MCP/audio, not a stub. Only when pro is
+// genuinely absent (open-core CI without the PAT) do we ignore those suites and map
+// @offgrid/pro to the null stub, so the open-core suite still runs and stays green.
+const proExists = fs.existsSync(path.resolve(__dirname, 'pro/package.json'));
+
+// Suites under THIS repo's __tests__ that import @offgrid/pro. Ignored ONLY when pro is
+// absent. (pro/'s OWN suite is always ignored here — it runs in the pro repo's CI.)
+const proDependentTestPaths = [
+  '/__tests__/unit/audio/',
+  '/__tests__/unit/engine/',
+  '/__tests__/integration/audio/',
+  '__tests__/unit/audioProgressCaption.test.ts',
+  '__tests__/unit/mcp/McpToolExtension.test.ts',
+  '__tests__/unit/services/ttsService.test.ts',
+  '__tests__/unit/stores/ttsStore.test.ts',
+  '__tests__/integration/stores/tts.test.ts',
+  '__tests__/rntl/components/ChatInputModeToggle.test.tsx',
+  '__tests__/rntl/components/PlaybackControls.test.tsx',
+  '__tests__/rntl/components/VoiceModelsPanel.test.tsx',
+  '__tests__/rntl/components/KokoroTTSBridge.test.tsx',
+  '__tests__/rntl/components/McpAddServerSheet.test.tsx',
+  '__tests__/rntl/components/McpServersScreen.test.tsx',
+  '__tests__/unit/tools/mcpPresets.test.ts',
+];
+
 module.exports = {
   preset: 'react-native',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
   testPathIgnorePatterns: [
     '/node_modules/', '/android/', '/ios/', '/e2e/', 'App.test.tsx',
-    // The private pro/ submodule ships its own test suite and runs it in the pro
-    // repo's own CI. The public repo's CI does not (and must not) check it out, so
-    // ignore it here too — locally it's present and would otherwise be picked up.
+    // pro/ ships its own suite run in the pro repo's CI — never run those from here.
+    // The pro-DEPENDENT suites under this repo's __tests__ DO run against the real pro
+    // when it's checked out, and are ignored only when pro is genuinely absent.
     '/pro/',
-    // Audio/TTS suites import the private pro/ submodule, which the public repo's
-    // CI does not (and must not) check out. They run in the pro repo's own CI.
-    '/__tests__/unit/audio/',
-    '/__tests__/unit/engine/',
-    '/__tests__/integration/audio/',
-    '__tests__/unit/audioProgressCaption.test.ts',
-    '__tests__/unit/mcp/McpToolExtension.test.ts',
-    '__tests__/unit/services/ttsService.test.ts',
-    '__tests__/unit/stores/ttsStore.test.ts',
-    '__tests__/integration/stores/tts.test.ts',
-    '__tests__/rntl/components/ChatInputModeToggle.test.tsx',
-    '__tests__/rntl/components/PlaybackControls.test.tsx',
-    '__tests__/rntl/components/VoiceModelsPanel.test.tsx',
-    '__tests__/rntl/components/KokoroTTSBridge.test.tsx',
-    // MCP server/preset suites import the private pro/ submodule — run in pro's CI.
-    '__tests__/rntl/components/McpAddServerSheet.test.tsx',
-    '__tests__/rntl/components/McpServersScreen.test.tsx',
-    '__tests__/unit/tools/mcpPresets.test.ts',
+    ...(proExists ? [] : proDependentTestPaths),
   ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     // Mirrors the metro alias so tests can import pro modules that reference core.
     '^@offgrid/core/(.*)$': '<rootDir>/src/$1',
+    // Mirrors the metro alias: the real pro package when present on disk, else the null
+    // stub so open-core tests resolve @offgrid/pro cleanly.
+    '^@offgrid/pro$': proExists ? '<rootDir>/pro' : '<rootDir>/src/bootstrap/proStub.js',
+    '^@offgrid/pro/(.*)$': proExists ? '<rootDir>/pro/$1' : '<rootDir>/src/bootstrap/proStub.js',
     // Mirrors the metro alias: 'react-native-fs' resolves to the maintained fork
     // (the only RNFS native module we ship — see metro.config.js).
     '^react-native-fs$': '<rootDir>/src/shims/react-native-fs.ts',
   },
-  transformIgnorePatterns: ['node_modules/(?!(react-native|@react-native|@react-navigation|react-native-.*|@react-native-.*|moti|@motify|@gorhom|@shopify|@ronradtke|@op-engineering)/)',],
+  transformIgnorePatterns: ['node_modules/(?!(react-native|@react-native|@react-navigation|react-native-.*|@react-native-.*|moti|@motify|@gorhom|@shopify|@ronradtke|@op-engineering|@offgrid)/)',],
   testEnvironment: 'node',
   clearMocks: true,
   verbose: true,

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -248,6 +248,7 @@ jest.mock(
       listDownloadedModels: jest.fn(async () => [] as string[]),
       listDownloadedFiles: jest.fn(async () => [] as string[]),
       deleteResources: jest.fn(async () => {}),
+      fetch: jest.fn(async () => {}),
     },
   }),
   { virtual: true },

--- a/src/components/ModelCard.styles.ts
+++ b/src/components/ModelCard.styles.ts
@@ -243,10 +243,14 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     backgroundColor: colors.primary,
     borderRadius: 4,
   },
+  progressLabelRow: {
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    gap: 4,
+  },
   progressText: {
     ...TYPOGRAPHY.meta,
     color: colors.textSecondary,
-    width: 40,
     textAlign: 'right' as const,
   },
   // LiteRT card only: tighten the gap and hug the percentage to the bar so it

--- a/src/components/ModelCard.tsx
+++ b/src/components/ModelCard.tsx
@@ -14,6 +14,7 @@ import {
   ModelCardActions,
   RecommendedConfig,
 } from './ModelCardContent';
+import { QUEUED_ICON } from '../utils/downloadStatusIcon';
 
 interface ModelCardProps {
   model: {
@@ -86,15 +87,19 @@ const DownloadProgressSection: React.FC<{
   queued?: boolean;
 }> = ({ progress, bytes, tight, queued }) => {
   const styles = useThemedStyles(createStyles);
+  const { colors } = useTheme();
   return (
   <View style={styles.progressSection}>
     <View style={[styles.progressContainer, tight && styles.progressContainerTight]}>
       <View style={styles.progressBar}>
         <View style={[styles.progressFill, { width: `${progress * 100}%` }]} />
       </View>
-      <Text style={[styles.progressText, tight && styles.progressTextTight]}>
-        {queued ? 'Queued' : `${Math.round(progress * 100)}%`}
-      </Text>
+      <View style={styles.progressLabelRow}>
+        {queued && <Icon name={QUEUED_ICON} size={13} color={colors.textMuted} />}
+        <Text style={[styles.progressText, tight && styles.progressTextTight]}>
+          {queued ? 'Queued' : `${Math.round(progress * 100)}%`}
+        </Text>
+      </View>
     </View>
     {!queued && bytes && bytes.total > 0 && (
       <Text style={styles.progressBytesText}>

--- a/src/components/settings/sectionRegistry.ts
+++ b/src/components/settings/sectionRegistry.ts
@@ -1,17 +1,47 @@
-import type { ComponentType } from 'react';
+import { useSyncExternalStore, type ComponentType } from 'react';
 
+/**
+ * Settings-section seam. Pro registers extra Settings sections during activation; core
+ * renders whatever is registered. Registration is REACTIVE (same pattern as slotRegistry):
+ * a section registered AFTER the Settings screen mounted — e.g. Pro unlocked at runtime
+ * via a license key, which re-runs loadProFeatures — makes the screen re-render and show
+ * the section live, with no app restart. (Before this, the screen read getSettingsSections()
+ * once at render, so an activated Pro user still saw the section missing until relaunch.)
+ */
 const sections: ComponentType<any>[] = [];
+const listeners = new Set<() => void>();
+
+// useSyncExternalStore requires a STABLE snapshot reference between changes (returning a
+// fresh array each call would loop). Rebuild it only when the set actually changes.
+let sectionsSnapshot: ComponentType<any>[] = [];
+
+function emitChange(): void {
+  sectionsSnapshot = [...sections];
+  for (const l of listeners) l();
+}
 
 export function registerSettingsSection(component: ComponentType<any>): void {
-  if (!sections.includes(component)) {
-    sections.push(component);
-  }
+  if (sections.includes(component)) return; // no-op re-register (dev Fast Refresh)
+  sections.push(component);
+  emitChange();
 }
 
 export function getSettingsSections(): ComponentType<any>[] {
   return sections;
 }
 
+/** Reactive read — re-renders the consumer when a section is (de)registered. */
+export function useSettingsSections(): ComponentType<any>[] {
+  return useSyncExternalStore(
+    (onStoreChange) => {
+      listeners.add(onStoreChange);
+      return () => listeners.delete(onStoreChange);
+    },
+    () => sectionsSnapshot,
+  );
+}
+
 export function _clearSectionsForTesting(): void {
   sections.length = 0;
+  emitChange();
 }

--- a/src/screens/ChatScreen/ChatModalSection.tsx
+++ b/src/screens/ChatScreen/ChatModalSection.tsx
@@ -20,6 +20,7 @@ type ChatModalSectionProps = {
   setShowDebugPanel: (v: boolean) => void;
   showModelSelector: boolean;
   setShowModelSelector: (v: boolean) => void;
+  modelSelectorTab?: 'text' | 'image';
   showSettingsPanel: boolean;
   setShowSettingsPanel: (v: boolean) => void;
   debugInfo: any;
@@ -45,7 +46,7 @@ export const ChatModalSection: React.FC<ChatModalSectionProps> = ({
   styles, colors,
   showProjectSelector, setShowProjectSelector,
   showDebugPanel, setShowDebugPanel,
-  showModelSelector, setShowModelSelector,
+  showModelSelector, setShowModelSelector, modelSelectorTab = 'text',
   showSettingsPanel, setShowSettingsPanel,
   debugInfo, activeProject, activeConversation, settings, projects,
   handleSelectProject, handleModelSelect, handleUnloadModel, handleDeleteConversation,
@@ -71,6 +72,7 @@ export const ChatModalSection: React.FC<ChatModalSectionProps> = ({
     />
     <ModelSelectorModal
       visible={showModelSelector}
+      initialTab={modelSelectorTab}
       onClose={() => setShowModelSelector(false)}
       onSelectModel={handleModelSelect}
       onUnloadModel={handleUnloadModel}

--- a/src/screens/ChatScreen/index.tsx
+++ b/src/screens/ChatScreen/index.tsx
@@ -46,6 +46,9 @@ export const ChatScreen: React.FC = () => {
 
   // Collapsed Models control (shared with home): header "Models" → manager sheet.
   const [modelsManagerOpen, setModelsManagerOpen] = useState(false);
+  // Which tab the model selector opens on — set from the manager row the user tapped so
+  // tapping "Image" focuses the Image tab (it defaulted to Text regardless of the row).
+  const [modelSelectorTab, setModelSelectorTab] = useState<'text' | 'image'>('text');
   const [whisperOpen, setWhisperOpen] = useState(false);
   const [voiceOpen, setVoiceOpen] = useState(false);
   const voiceSummary = useUiModeStore((s) => s.voiceSummary);
@@ -80,7 +83,7 @@ export const ChatScreen: React.FC = () => {
     ]));
   };
   const openModelRowNow = (type: ModelRowType) => {
-    if (type === 'text' || type === 'image') chat.setShowModelSelector(true);
+    if (type === 'text' || type === 'image') { setModelSelectorTab(type); chat.setShowModelSelector(true); }
     else if (type === 'speech') setWhisperOpen(true);
     else setVoiceOpen(true);
   };
@@ -315,6 +318,7 @@ export const ChatScreen: React.FC = () => {
           setShowDebugPanel={chat.setShowDebugPanel}
           showModelSelector={chat.showModelSelector}
           setShowModelSelector={chat.setShowModelSelector}
+          modelSelectorTab={modelSelectorTab}
           showSettingsPanel={chat.showSettingsPanel}
           setShowSettingsPanel={chat.setShowSettingsPanel}
           debugInfo={chat.debugInfo}

--- a/src/screens/ChatScreen/modelReadiness.ts
+++ b/src/screens/ChatScreen/modelReadiness.ts
@@ -49,7 +49,8 @@ export interface ReadinessDeps {
   activeModelInfo?: { isRemote: boolean };
   activeModel: { engine?: string; filePath: string } | null | undefined;
   activeModelId: string | null;
-  ensureModelLoaded: () => Promise<ModelReadyOutcome>;
+  /** onLoadedResume: when a turn triggered the load, resume it after a "Load Anyway". */
+  ensureModelLoaded: (onLoadedResume?: () => void) => Promise<ModelReadyOutcome>;
   setAlertState: (a: AlertState) => void;
 }
 
@@ -59,11 +60,11 @@ export interface ReadinessDeps {
  * line records the branch. Every exit is explicit — no silent early-return can
  * collapse into a generic "Failed to load model" again.
  */
-export async function ensureModelReady(deps: ReadinessDeps): Promise<ModelReadyOutcome> {
+export async function ensureModelReady(deps: ReadinessDeps, onLoadedResume?: () => void): Promise<ModelReadyOutcome> {
   if (deps.activeModelInfo?.isRemote) { logger.log('[GEN-SM] ensureModelReady → remote ok'); return { ok: true }; }
   if (deps.activeModel?.engine === 'litert') {
     if (liteRTService.isModelLoaded()) { logger.log('[GEN-SM] ensureModelReady → litert already loaded'); return { ok: true }; }
-    const outcome = await deps.ensureModelLoaded();
+    const outcome = await deps.ensureModelLoaded(onLoadedResume);
     if (!outcome.ok) { logger.log(`[GEN-SM] ensureModelReady litert NOT ready reason=${outcome.reason} detail=${outcome.detail ?? ''}`); return outcome; }
     return liteRTService.isModelLoaded()
       ? { ok: true }
@@ -97,7 +98,9 @@ export async function ensureReadyOrAlert(
    *  re-reads the now-higher REAL per-process budget. */
   onRetry?: () => void,
 ): Promise<boolean> {
-  const outcome = await ensureModelReady(deps);
+  // Thread onRetry down so a "Load Anyway" on the insufficient-memory alert resumes the
+  // turn after the forced load (the message would otherwise be silently dropped).
+  const outcome = await ensureModelReady(deps, onRetry);
   if (outcome.ok) return true;
   logger.log(`[GEN-SM] ${tag} BAIL reason=${outcome.reason} detail=${outcome.detail ?? ''} alerted=${!!outcome.alerted}`);
   if (!outcome.alerted) {

--- a/src/screens/ChatScreen/useChatGenerationActions.ts
+++ b/src/screens/ChatScreen/useChatGenerationActions.ts
@@ -1,4 +1,5 @@
- import { Dispatch, SetStateAction } from 'react';
+/* eslint-disable max-lines -- cohesive generation-action orchestrator (send/regenerate/dispatch/route share the same GenerationDeps + session state); splitting it would scatter tightly-coupled turn logic. */
+import { Dispatch, SetStateAction } from 'react';
 import { AlertState, showAlert, hideAlert } from '../../components';
 import { generationSession } from '../../services/generationSession';
 import { APP_CONFIG } from '../../constants';

--- a/src/screens/ChatScreen/useChatGenerationActions.ts
+++ b/src/screens/ChatScreen/useChatGenerationActions.ts
@@ -105,6 +105,10 @@ export async function shouldRouteToImageGenerationFn(
   if (deps.isGeneratingImage) { logger.log('[ROUTE-SM] → false: already generating an image'); return false; }
   if (deps.settings.imageGenerationMode === 'manual') { logger.log(`[ROUTE-SM] → ${forceImageMode === true}: manual mode (only on force)`); return forceImageMode === true; }
   if (forceImageMode) { logger.log('[ROUTE-SM] → true: forced'); return true; }
+  // Auto mode with no image model selected: there is nothing to route an image to
+  // (dispatch requires activeImageModel), so skip the classifier entirely. Running it
+  // here only adds latency on the send hot path and leaves a stale "Analyzing…" status.
+  if (!deps.activeImageModel) { logger.log('[ROUTE-SM] → false: no image model selected'); return false; }
   // Route on whether an image model is SELECTED (downloaded), not whether it's
   // currently resident — the pipeline loads it on demand. (Checked + logged above.)
   // No text model (image-only): SMOL classifier decides text vs image, else heuristics; chat returns false.

--- a/src/screens/ChatScreen/useChatModelActions.ts
+++ b/src/screens/ChatScreen/useChatModelActions.ts
@@ -83,6 +83,10 @@ async function doLoadTextModel(deps: ModelActionDeps): Promise<void> {
 export async function initiateModelLoad(
   deps: ModelActionDeps,
   alreadyLoading: boolean,
+  /** When the load was requested to satisfy a chat turn, resume that turn after a
+   *  successful "Load Anyway". Non-generation callers (model select / reload) omit it,
+   *  so nothing is auto-resumed for them. */
+  onLoadedResume?: () => void,
 ): Promise<ModelReadyOutcome> {
   const { activeModel, activeModelId } = deps;
   if (!activeModel || !activeModelId) return { ok: false, reason: 'no-model-selected' };
@@ -101,7 +105,11 @@ export async function initiateModelLoad(
               deps.setIsModelLoading(true);
               deps.setLoadingModel(activeModel);
               deps.modelLoadStartTimeRef.current = Date.now();
-              waitForRenderFrame().then(() => doLoadTextModel(deps));
+              // Resume the turn after the forced load so the user's message isn't
+              // silently dropped (they'd otherwise have to retype it).
+              waitForRenderFrame()
+                .then(() => doLoadTextModel(deps))
+                .then(() => { if (onLoadedResume && llmService.isModelLoaded()) onLoadedResume(); });
             }
           },
         ],
@@ -173,6 +181,7 @@ export async function ensureTextModelForChatFn(deps: {
 
 export async function ensureModelLoadedFn(
   deps: ModelActionDeps,
+  onLoadedResume?: () => void,
 ): Promise<ModelReadyOutcome> {
   const { activeModel, activeModelId } = deps;
   if (!activeModel || !activeModelId) return { ok: false, reason: 'no-model-selected' };
@@ -182,7 +191,7 @@ export async function ensureModelLoadedFn(
       return { ok: true };
     }
     deps.setSupportsVision(!!activeModel.liteRTVision);
-    const outcome = await initiateModelLoad(deps, activeModelService.getActiveModels().text.isLoading);
+    const outcome = await initiateModelLoad(deps, activeModelService.getActiveModels().text.isLoading, onLoadedResume);
     if (!outcome.ok) return outcome;
     return liteRTService.isModelLoaded()
       ? { ok: true }
@@ -197,7 +206,7 @@ export async function ensureModelLoadedFn(
     return { ok: true };
   }
   const alreadyLoading = activeModelService.getActiveModels().text.isLoading;
-  return initiateModelLoad(deps, alreadyLoading);
+  return initiateModelLoad(deps, alreadyLoading, onLoadedResume);
 }
 
 export async function proceedWithModelLoadFn(

--- a/src/screens/ChatScreen/useChatScreen.ts
+++ b/src/screens/ChatScreen/useChatScreen.ts
@@ -217,7 +217,7 @@ export const useChatScreen = () => {
     downloadedModels, setAlertState, setIsClassifying, setAppImageGenerationStatus,
     setAppIsGeneratingImage, addMessage, clearStreamingMessage, deleteConversation,
     setActiveConversation, removeImagesByConversationId, navigation, setShowSettingsPanel,
-    ensureModelLoaded: async () => ensureModelLoadedFn(modelDeps),
+    ensureModelLoaded: async (onLoadedResume?: () => void) => ensureModelLoadedFn(modelDeps, onLoadedResume),
     ensureTextModelForChat: () => ensureTextModelForChatFn({ setShowModelSelector, setLoadingModel, setIsModelLoading }),
     setPendingMessage: (text: string, attachments?: MediaAttachment[]) => { pendingMessageRef.current = { text, attachments }; },
     createConversation,

--- a/src/screens/DownloadManagerScreen/items.tsx
+++ b/src/screens/DownloadManagerScreen/items.tsx
@@ -6,6 +6,7 @@ import { useTheme, useThemedStyles } from '../../theme';
 import { BackgroundDownloadReasonCode } from '../../types';
 import { needsVisionRepair as checkNeedsVisionRepair } from '../../utils/visionRepair';
 import { getDownloadStatusLabel, isRetryable } from '../../utils/downloadErrors';
+import { downloadStatusIcon } from '../../utils/downloadStatusIcon';
 import { createStyles } from './styles';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -81,12 +82,9 @@ export const ActiveDownloadCard: React.FC<ActiveDownloadCardProps> = ({ item, on
         ? colors.warning
         : colors.primary;
 
-  const getStatusIcon = () => {
-    if (item.status === 'failed') return 'alert-circle';
-    if (item.status === 'retrying') return 'refresh-cw';
-    if (item.status === 'waiting_for_network') return 'wifi-off';
-    return null;
-  };
+  // Icon per status is owned by downloadStatusIcon() so this row and ModelCard match
+  // (queued -> clock, previously text-only here).
+  const getStatusIcon = () => downloadStatusIcon(item.status);
 
   const getStatusIconColor = () => {
     if (item.status === 'failed') return colors.error;

--- a/src/screens/DownloadManagerScreen/useDownloadManager.ts
+++ b/src/screens/DownloadManagerScreen/useDownloadManager.ts
@@ -168,11 +168,15 @@ export function useDownloadManager(): UseDownloadManagerResult {
   const [queuedItems, setQueuedItems] = useState<DownloadItem[]>([]);
   useEffect(() => {
     const refresh = () => setQueuedItems(backgroundDownloadService.getQueuedItems().map(queuedToActiveItem));
+    // On the light poll, also reconcile the concurrency accounting against the native
+    // truth so a leaked slot (e.g. a folded mmproj sidecar) is reclaimed and a stuck
+    // Queued download starts — without waiting for a new start to trigger it.
+    const reconcileAndRefresh = () => { backgroundDownloadService.reconcileActiveIds().catch(() => {}); refresh(); };
     refresh();
     // The service owns the queue and notifies on every control op (incl. cancelling a
     // queued start), so a cancel drops the "Queued" row immediately, not on the poll.
     const unsubscribe = modelDownloadService.subscribe(refresh);
-    const t = setInterval(refresh, 1000);
+    const t = setInterval(reconcileAndRefresh, 1000);
     return () => { unsubscribe(); clearInterval(t); };
   }, [downloads]);
 

--- a/src/screens/DownloadManagerScreen/useDownloadManager.ts
+++ b/src/screens/DownloadManagerScreen/useDownloadManager.ts
@@ -182,7 +182,6 @@ export function useDownloadManager(): UseDownloadManagerResult {
     // drains the queue) and the interval covers the rest. Depending on `downloads` here
     // tore down + rebuilt the subscription and interval on EVERY progress tick — pure
     // churn while a download runs — and refresh reads from the service, not `downloads`.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Voice (TTS) + transcription (STT) downloaded models, loaded from disk.

--- a/src/screens/DownloadManagerScreen/useDownloadManager.ts
+++ b/src/screens/DownloadManagerScreen/useDownloadManager.ts
@@ -178,7 +178,12 @@ export function useDownloadManager(): UseDownloadManagerResult {
     const unsubscribe = modelDownloadService.subscribe(refresh);
     const t = setInterval(reconcileAndRefresh, 1000);
     return () => { unsubscribe(); clearInterval(t); };
-  }, [downloads]);
+    // Mount once: the subscription already fires on every store change (that's what
+    // drains the queue) and the interval covers the rest. Depending on `downloads` here
+    // tore down + rebuilt the subscription and interval on EVERY progress tick — pure
+    // churn while a download runs — and refresh reads from the service, not `downloads`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Voice (TTS) + transcription (STT) downloaded models, loaded from disk.
   const { voiceItems, buildDeleteAlert: buildVoiceDeleteAlert } = useVoiceDownloadItems(() => setAlertState(hideAlert()));

--- a/src/screens/ModelsScreen/useModelsScreen.ts
+++ b/src/screens/ModelsScreen/useModelsScreen.ts
@@ -197,40 +197,23 @@ export function useModelsScreen() {
     image.downloadedImageModels.length +
     activeDownloadCount;
 
+  // No caller-side "too many downloads" gate: backgroundDownloadService caps real
+  // concurrency at MAX_CONCURRENT_DOWNLOADS and FIFO-queues the rest, so extra starts
+  // just queue (shown as "Queued") instead of hurting performance. The old
+  // "Starting more can affect performance / Start Anyway" alert was obsolete friction
+  // (and its threshold of 2 didn't even match the cap of 3).
   const handleDownload = useCallback(
     (...args: Parameters<typeof text.handleDownload>) => {
-      if (activeDownloadCount >= 2) {
-        setAlertState(showAlert(
-          'Downloads Already Active',
-          '2 downloads are already running. Starting more can affect performance.',
-          [
-            { text: 'Cancel', style: 'cancel' },
-            { text: 'Start Anyway', style: 'default', onPress: () => { text.handleDownload(...args); } },
-          ],
-        ));
-        return;
-      }
       text.handleDownload(...args);
     },
-    [text, activeDownloadCount, setAlertState],
+    [text],
   );
 
   const handleDownloadImageModel = useCallback(
     (...args: Parameters<typeof image.handleDownloadImageModel>) => {
-      if (activeDownloadCount >= 2) {
-        setAlertState(showAlert(
-          'Downloads Already Active',
-          '2 downloads are already running. Starting more can affect performance.',
-          [
-            { text: 'Cancel', style: 'cancel' },
-            { text: 'Start Anyway', style: 'default', onPress: () => { image.handleDownloadImageModel(...args); } },
-          ],
-        ));
-        return;
-      }
       image.handleDownloadImageModel(...args);
     },
-    [image, activeDownloadCount, setAlertState],
+    [image],
   );
 
   return {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -19,7 +19,7 @@ import { AnimatedEntry } from '../components/AnimatedEntry';
 import { AnimatedListItem } from '../components/AnimatedListItem';
 import { MadeWithLove } from '../components/MadeWithLove';
 import { DebugLogsScreen } from '../components/DebugLogsScreen';
-import { getSettingsSections } from '../components/settings/sectionRegistry';
+import { useSettingsSections } from '../components/settings/sectionRegistry';
 import { ProUpsellBanner } from '../components/settings/ProUpsellBanner';
 import { useFocusTrigger } from '../hooks/useFocusTrigger';
 import { useTheme, useThemedStyles } from '../theme';
@@ -47,6 +47,9 @@ export const SettingsScreen: React.FC = () => {
   const focusTrigger = useFocusTrigger();
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
+  // Reactive: Pro sections registered at runtime (license-key activation re-runs
+  // loadProFeatures) show up live without an app restart.
+  const settingsSections = useSettingsSections();
   const setOnboardingComplete = useAppStore((s) => s.setOnboardingComplete);
   const themeMode = useAppStore((s) => s.themeMode);
   const setThemeMode = useAppStore((s) => s.setThemeMode);
@@ -302,7 +305,7 @@ export const SettingsScreen: React.FC = () => {
         </AnimatedEntry>
 
         {/* Pro feature sections registered at runtime by @offgrid/pro */}
-        {getSettingsSections().map((Section, i) => <Section key={Section.displayName ?? String(i)} />)}
+        {settingsSections.map((Section, i) => <Section key={Section.displayName ?? String(i)} />)}
 
         {/* Dev-only tooling — stripped from release builds */}
         {__DEV__ && (

--- a/src/services/activeModelService/index.ts
+++ b/src/services/activeModelService/index.ts
@@ -148,11 +148,17 @@ class ActiveModelService {
     // Use estimated runtime RAM (file size + overhead), not just file size,
     // so the residency budget reflects the model's real memory footprint.
     const textSizeMB = Math.round((hardwareService.estimateModelRam(model) || 0) / (1024 * 1024));
+    // LiteRT weights + KV live in dirty/accelerator memory (not clean mmap'd GGUF file
+    // pages), so their footprint counts against REAL free RAM — budgeting them like
+    // mmap'd GGUF can green-light a load the native engine then OOMs (SIGABRT). Derived
+    // once here from the engine so makeRoomFor and register can't disagree. llama/GGUF
+    // stays clean (dirtyMemory undefined -> physical-cap budgeting, unchanged).
+    const textIsDirty = model.engine === 'litert';
     // Residency manager is authoritative: evict other generation models (and
     // extras) to fit the RAM budget before loading this text model. The evicted
     // models' unload fns are the non-locking internal variants (we already hold
     // the lock here), so this never deadlocks.
-    const room = await modelResidencyManager.makeRoomFor({ key: 'text', type: 'text', sizeMB: textSizeMB });
+    const room = await modelResidencyManager.makeRoomFor({ key: 'text', type: 'text', sizeMB: textSizeMB, dirtyMemory: textIsDirty });
     // makeRoomFor evicts nothing when the model won't fit even after freeing
     // others (it refuses to strand the device). Honor that signal here: loading
     // anyway is a guaranteed OOM crash. Throwing a memory error lets the caller
@@ -174,7 +180,7 @@ class ActiveModelService {
       onLoaded: id => {
         this.loadedTextModelId = id;
         modelResidencyManager.register(
-          { key: 'text', type: 'text', sizeMB: textSizeMB },
+          { key: 'text', type: 'text', sizeMB: textSizeMB, dirtyMemory: textIsDirty },
           () => this.doUnloadTextModelLocked(true), // eviction keeps the selection
         );
       },

--- a/src/services/backgroundDownloadService.ts
+++ b/src/services/backgroundDownloadService.ts
@@ -135,6 +135,43 @@ class BackgroundDownloadService {
   }
 
   /**
+   * Reconcile the concurrency accounting against the native truth and pump the queue.
+   *
+   * A slot leaks when an id in `activeIds` no longer maps to a live native transfer but
+   * never got a terminal event to release it — most notably a vision model's mmproj
+   * sidecar, whose separate downloadId reserves a slot here but whose task the native
+   * layer folds into the main download's fileTasks (so only the main emits
+   * DownloadComplete). Left unfixed, `pump()` keeps seeing the cap as full and the
+   * effective concurrency collapses toward 1 (one leak per vision model downloaded).
+   *
+   * We drop only REAL ids the native active set no longer contains — never a `reserve:`
+   * token (a start still mid-flight, before it has a native id). A freshly-started
+   * download is already in the native active set by the time startDownload() resolves,
+   * so this cannot drop a live start; the worst case (a native poll lagging a terminal
+   * event) is at most one extra concurrent download that the next reconcile corrects —
+   * strictly better than being wedged at one.
+   */
+  async reconcileActiveIds(): Promise<void> {
+    if (!this.isAvailable() || this.activeIds.size === 0) return;
+    let nativeIds: Set<string>;
+    try {
+      const active = await DownloadManagerModule.getActiveDownloads();
+      nativeIds = new Set<string>((active ?? []).map((d: any) => String(d.downloadId ?? d.id)));
+    } catch {
+      return; // bridge unavailable — leave accounting untouched
+    }
+    let freed = false;
+    for (const id of [...this.activeIds]) {
+      if (id.startsWith('reserve:')) continue; // mid-start reservation, no native id yet
+      if (!nativeIds.has(id)) {
+        this.activeIds.delete(id);
+        freed = true;
+      }
+    }
+    if (freed) this.pump();
+  }
+
+  /**
    * Count restored downloads against the cap after a relaunch. restore re-attaches to
    * downloads the native layer resumed on its own (they did not go through
    * startDownload this session); without adopting them the cap would admit a fresh

--- a/src/services/backgroundDownloadService.ts
+++ b/src/services/backgroundDownloadService.ts
@@ -84,6 +84,11 @@ class BackgroundDownloadService {
     // over-admit past the cap.
     const token = `reserve:${++this.startSeq}`;
     this.activeIds.add(token);
+    // Android 13+: prompt for notification permission so the foreground-service download
+    // notification is visible (the download still runs as an FGS if denied). Best-effort.
+    if (Platform.OS === 'android' && typeof DownloadManagerModule.requestNotificationPermission === 'function') {
+      try { DownloadManagerModule.requestNotificationPermission(); } catch { /* non-fatal */ }
+    }
     try {
       const result = await DownloadManagerModule.startDownload({
         url: params.url,

--- a/src/services/backgroundDownloadService.ts
+++ b/src/services/backgroundDownloadService.ts
@@ -268,6 +268,27 @@ class BackgroundDownloadService {
     });
   }
 
+  /**
+   * Drop a lingering native download record WITHOUT signalling a cancellation.
+   *
+   * Used by the idempotent finalize path: when a model is finalized from an
+   * already-on-disk file (native move skipped), the stale native record must be purged
+   * so restore can't re-adopt and re-finalize it every foreground. Unlike cancelDownload,
+   * this must NOT synthesize a DownloadError — the download SUCCEEDED, and the global
+   * onAnyError handler would otherwise briefly mark the just-finalized model as failed.
+   * It still frees the concurrency slot (native cancel emits no terminal event). Reuses
+   * the existing native cancel, so no new native method / contract change is needed.
+   */
+  async purgeNativeRecord(downloadId: string): Promise<void> {
+    if (!this.isAvailable()) return;
+    try {
+      await DownloadManagerModule.cancelDownload(downloadId);
+    } catch (e) {
+      logger.log('[BackgroundDownload] purgeNativeRecord failed (bridge may be torn down):', e);
+    }
+    this.release(downloadId);
+  }
+
   async getActiveDownloads(): Promise<BackgroundDownloadInfo[]> {
     if (!this.isAvailable()) {
       return [];

--- a/src/services/backgroundDownloadService.ts
+++ b/src/services/backgroundDownloadService.ts
@@ -224,6 +224,12 @@ class BackgroundDownloadService {
       throw new Error('retryDownload is only available on Android');
     }
     await DownloadManagerModule.retryDownload(downloadId);
+    // The failure that preceded this retry already released the slot (DownloadError ->
+    // release). Re-reserve it so the retried transfer counts against the cap and its
+    // eventual terminal event pumps the queue; without this, retry runs uncounted
+    // (concurrency can exceed the cap) and its completion can't promote a queued start.
+    // Set.add is idempotent, so re-reserving an id still present is a no-op.
+    this.activeIds.add(downloadId);
   }
 
   async cancelDownload(downloadId: string): Promise<void> {

--- a/src/services/litert.ts
+++ b/src/services/litert.ts
@@ -100,7 +100,19 @@ class LiteRTService {
     logger.log(TAG, `loadModel — path=${modelPath} backend=${preferredBackend} supportsVision=${supportsVision} supportsAudio=${supportsAudio} maxNumTokens=${maxNumTokens}`);
 
     try {
-      const actualBackend: string = await LiteRTModule.loadModel(modelPath, preferredBackend, supportsVision, supportsAudio, maxNumTokens);
+      // Native resolves a map { backend, maxNumTokens } — maxNumTokens is the EFFECTIVE
+      // budget after the native RAM clamp (may be < requested). Adopt it so compaction
+      // thresholds + the context-usage bar aren't stale. Tolerate a bare string from an
+      // older native build (backward-compatible).
+      const res: string | { backend: string; maxNumTokens?: number } =
+        await LiteRTModule.loadModel(modelPath, preferredBackend, supportsVision, supportsAudio, maxNumTokens);
+      const actualBackend = typeof res === 'string' ? res : res.backend;
+      if (typeof res === 'object' && typeof res.maxNumTokens === 'number' && res.maxNumTokens > 0) {
+        if (res.maxNumTokens !== this.configuredMaxTokens) {
+          logger.log(TAG, `loadModel — native clamped context ${this.configuredMaxTokens} → ${res.maxNumTokens}`);
+        }
+        this.configuredMaxTokens = res.maxNumTokens;
+      }
       this.activeBackend = actualBackend as LiteRTBackend;
       this.loaded = true;
       this.modelSupportsAudio = supportsAudio;

--- a/src/services/modelDownloadService/index.ts
+++ b/src/services/modelDownloadService/index.ts
@@ -21,7 +21,7 @@
  */
 import logger from '../../utils/logger';
 import { backgroundDownloadService } from '../backgroundDownloadService';
-import { uniformDownloadId } from './uniformId';
+import { uniformDownloadId, queuedUniformId } from './uniformId';
 import {
   DownloadProvider,
   ModelDownload,
@@ -207,7 +207,7 @@ class ModelDownloadService {
   private cancelQueuedStart(id: string): boolean {
     const queued = backgroundDownloadService
       .getQueuedItems()
-      .find(q => uniformDownloadId(q.modelType as ModelDownloadType, q.modelId) === id);
+      .find(q => queuedUniformId({ modelType: q.modelType as ModelDownloadType, modelId: q.modelId, modelKey: q.modelKey }) === id);
     return queued ? backgroundDownloadService.cancelQueued(queued.modelKey) : false;
   }
 

--- a/src/services/modelDownloadService/index.ts
+++ b/src/services/modelDownloadService/index.ts
@@ -21,7 +21,7 @@
  */
 import logger from '../../utils/logger';
 import { backgroundDownloadService } from '../backgroundDownloadService';
-import { uniformDownloadId, queuedUniformId } from './uniformId';
+import { queuedUniformId } from './uniformId';
 import {
   DownloadProvider,
   ModelDownload,

--- a/src/services/modelDownloadService/uniformId.ts
+++ b/src/services/modelDownloadService/uniformId.ts
@@ -25,3 +25,28 @@ export function uniformDownloadId(modelType: ModelType, modelId: string): string
   else if (modelType === 'image') canonical = modelId.replace(/^image:/, '');
   return `${modelType}:${canonical}`;
 }
+
+/** The identity fields carried by a still-queued start (from getQueuedItems). */
+export interface QueuedIdentity {
+  modelType: ModelType;
+  modelId: string;
+  modelKey: string;
+}
+
+/**
+ * The uniform id for a start that is still WAITING for a concurrency slot. It MUST
+ * resolve to the exact id the provider assigns once that start becomes a listed
+ * (downloading) row, or cancel/remove on a Queued item silently no-ops.
+ *
+ * The trap this closes: a text download's started-row id is `text:<modelKey>` (modelKey
+ * = repo/file), because `textProvider.list()` keys on `modelKey`. But a queued item's
+ * bare `modelId` is only the repo. Deriving the id from `modelId` gives `text:<repo>`,
+ * which never matches the `text:<repo/file>` the View dispatches — so the queued row
+ * stays and downloads anyway. Text routes on `modelKey`; every other type passes
+ * `modelId` through. Owned HERE so the View's dispatch and `cancelQueuedStart` can't
+ * diverge.
+ */
+export function queuedUniformId(q: QueuedIdentity): string {
+  const idInput = q.modelType === 'text' ? q.modelKey : q.modelId;
+  return uniformDownloadId(q.modelType, idInput);
+}

--- a/src/services/modelManager/download.ts
+++ b/src/services/modelManager/download.ts
@@ -523,7 +523,7 @@ export function watchBackgroundDownload(opts: WatchDownloadOpts): void {
       // When we finalized from an already-on-disk file (native move was skipped), the
       // stale native record still lingers as 'completed'-without-localUri and restore
       // would re-adopt + re-finalize it every foreground. Purge it so it can't loop.
-      if (!movedNatively) backgroundDownloadService.cancelDownload(downloadId).catch(() => {});
+      if (!movedNatively) backgroundDownloadService.purgeNativeRecord(downloadId).catch(() => {});
     } catch (error) {
       ctx.isFinalizing = false;
       logger.error('[DownloadDebug] Finalization failed', {

--- a/src/services/modelResidency/index.ts
+++ b/src/services/modelResidency/index.ts
@@ -90,13 +90,19 @@ class ModelResidencyManager {
    * centralized so the eviction decision lives in one place.
    */
   async handleMemoryWarning(): Promise<void> {
-    for (const [key, r] of [...this.residents.entries()]) {
-      if (r.pinned || !SIDECAR_TYPES.has(r.type)) continue;
-      if (r.canEvict && !r.canEvict()) continue; // in use — owner vetoes
-      logger.log(`[ModelResidency] memory warning → reclaiming idle ${r.type} (${key})`);
-      await r.unload().catch(err => logger.log(`[ModelResidency] memory-warning unload ${key} failed:`, err));
-      this.residents.delete(key);
-    }
+    // Run under the same FIFO lock as every load/unload: mutating `residents` and
+    // driving native unloads concurrently with an in-flight load is exactly the
+    // race the lock exists to prevent. The sidecar unloads here don't re-acquire the
+    // lock, so this can't deadlock.
+    await this.runExclusive('memory-warning', async () => {
+      for (const [key, r] of [...this.residents.entries()]) {
+        if (r.pinned || !SIDECAR_TYPES.has(r.type)) continue;
+        if (r.canEvict && !r.canEvict()) continue; // in use — owner vetoes
+        logger.log(`[ModelResidency] memory warning → reclaiming idle ${r.type} (${key})`);
+        await r.unload().catch(err => logger.log(`[ModelResidency] memory-warning unload ${key} failed:`, err));
+        this.residents.delete(key);
+      }
+    });
   }
 
   /**
@@ -282,20 +288,17 @@ class ModelResidencyManager {
     let totalGB: number;
     try { totalGB = hardwareService.getTotalMemoryGB(); } catch { return; }
     if (totalGB > 6) return; // roomy: keep STT warm
-    const w = this.residents.get('whisper');
-    if (!w) return;
-    logger.log('[ModelResidency] reclaiming idle STT for generation turn (memory-tight)');
-    await w.unload().catch(err => logger.log('[ModelResidency] STT reclaim failed:', err));
-    this.residents.delete('whisper');
-  }
-
-  /** Evict everything except pinned residents (e.g. on memory-warning). */
-  async evictAll(includePinned = false): Promise<void> {
-    for (const [key, reg] of [...this.residents.entries()]) {
-      if (reg.pinned && !includePinned) continue;
-      await reg.unload().catch(err => logger.log(`[ModelResidency] unload ${key} failed:`, err));
-      this.residents.delete(key);
-    }
+    if (!this.residents.has('whisper')) return;
+    // Serialize with load/unload: this fires on the generation hot path (every send /
+    // regenerate), so without the lock it can race an in-flight whisper load and desync
+    // the residents map. whisper's unload doesn't re-acquire the lock, so no deadlock.
+    await this.runExclusive('reclaim:stt', async () => {
+      const w = this.residents.get('whisper');
+      if (!w) return; // reclaimed by another op while we waited for the lock
+      logger.log('[ModelResidency] reclaiming idle STT for generation turn (memory-tight)');
+      await w.unload().catch(err => logger.log('[ModelResidency] STT reclaim failed:', err));
+      this.residents.delete('whisper');
+    });
   }
 
   /** Test helper. */

--- a/src/services/whisperService.ts
+++ b/src/services/whisperService.ts
@@ -421,6 +421,13 @@ class WhisperService {
       logger.error('[WhisperService] Error stopping transcription:', error);
     } finally {
       this.isTranscribing = false;
+      // Hand the audio session back to the single owner. Realtime STT set mode='record'
+      // via ensureRecordingPermission on start; whisper.rn's audioSessionOnStopIos
+      // restores the NATIVE session but leaves this owner's `mode` stuck at 'record', so
+      // the next TTS ensurePlayback() early-returns and playback is silent after
+      // dictation. restorePlaybackAfterRecording resets mode + re-asserts playback
+      // (iOS only; Android is a no-op). Best-effort — never throw into the stop path.
+      audioSessionManager.restorePlaybackAfterRecording().catch(() => {});
     }
   }
 

--- a/src/stores/remoteServerHelpers.ts
+++ b/src/stores/remoteServerHelpers.ts
@@ -176,12 +176,16 @@ export async function fetchModelsFromServer(server: RemoteServer): Promise<Remot
             fetchModelCapabilities(url, model.id, nameDetect)
           )
         );
-        return generativeModels.map((model: { id: string; owned_by?: string; max_context_length?: number }, i: number) => ({
+        return generativeModels.map((model: { id: string; kind?: unknown; owned_by?: string; max_context_length?: number }, i: number) => ({
           id: model.id,
           name: displayModelName(model.id),
           serverId: server.id,
           capabilities: {
-            supportsVision: modelInfos[i].supportsVision,
+            // The gateway declares each model's kind authoritatively; trust kind:'vision'
+            // for vision support. The name/probe-based fallback (modelInfos) can't detect a
+            // gateway vision model whose id doesn't match the name heuristics, which dropped
+            // the attached image client-side (the model then behaved text-only).
+            supportsVision: model.kind === 'vision' || modelInfos[i].supportsVision,
             supportsToolCalling: modelInfos[i].supportsToolCalling ?? detectToolCallingCapability(model.id),
             supportsThinking: modelInfos[i].supportsThinking ?? false,
             maxContextLength: modelInfos[i].contextLength,

--- a/src/utils/downloadStatusIcon.ts
+++ b/src/utils/downloadStatusIcon.ts
@@ -1,0 +1,21 @@
+/**
+ * The ONE status -> Feather-icon mapping for a download, so the Download Manager row
+ * (items.tsx) and the model list card (ModelCard) show the SAME glyph for the same
+ * state and can't drift.
+ *
+ * Queued used to be the odd one out — text-only ("Queued", no icon) while every other
+ * state was icon-coded (error/retry/network). A clock reads as "waiting for a slot" at a
+ * glance, which is what a queued download is. Feather only; no bold.
+ */
+export type DownloadStatusIcon = 'clock' | 'alert-circle' | 'refresh-cw' | 'wifi-off';
+
+/** The queued indicator, exported so a boolean-`queued` caller (ModelCard) uses the same glyph. */
+export const QUEUED_ICON: DownloadStatusIcon = 'clock';
+
+export function downloadStatusIcon(status: string): DownloadStatusIcon | null {
+  if (status === 'pending') return QUEUED_ICON;
+  if (status === 'failed') return 'alert-circle';
+  if (status === 'retrying') return 'refresh-cw';
+  if (status === 'waiting_for_network') return 'wifi-off';
+  return null;
+}


### PR DESCRIPTION
Stability + performance hardening for the release. Each fix is a small, self-contained commit with a regression test written at the seam (fails before, passes after). Follows the repo's SOLID/single-source doctrine — every fix routes a leaked path back through its owning abstraction rather than patching the symptom in a caller.

## Download subsystem
- **F-SLOT-LEAK** — effective concurrency was collapsing toward 1 (a vision model's mmproj sidecar leaks a slot). `reconcileActiveIds()` self-heals slot accounting against the native truth; the Download Manager poll drives it so a wedged queue recovers within ~1s.
- **F1** — Android retry restarted a native transfer without re-reserving its slot (bypassed the cap, stranded the queue). Route retry through the same admission path.
- **F2** — a just-finalized model flashed "Failed" because the idempotent-finalize purge reused `cancelDownload` (which synthesizes a `DownloadError`). New listener-free `purgeNativeRecord()`.
- **F24** — cancelling a **Queued** text download silently no-opped (id derived two ways). One canonical `queuedUniformId`. Plus: a `clock` icon for the Queued state via a single status→icon helper, and removal of the obsolete "Starting more can affect performance" alert (the queue owns concurrency now).
- **F14** — Download Manager re-subscribed + reset a 1s interval on every progress tick. Mount-once effect.
- **F8** — Android model downloads died when backgrounded (plain CoroutineWorker + Doze). Promote to a foreground service (dataSync, expedited, ongoing notification) + manifest perms + runtime POST_NOTIFICATIONS. iOS unaffected.

## Model load / memory
- **F9** — LiteRT loads could OOM while residency said "fits" (budgeted as clean mmap). Derive `dirtyMemory` from engine so LiteRT budgets on real free RAM; GGUF unchanged.
- **F3** — STT reclaim (every send) + memory-warning mutated residents outside the load lock. Serialize both through `runExclusive`; drop dead `evictAll`.
- **F20** — LiteRT's native context clamp wasn't fed back to JS, leaving compaction thresholds + the usage bar stale. `loadModel` now resolves the effective token count.

## Chat / generation
- **F12** — auto-mode ran the image classifier on every send with no image model loaded (wasted TTFT + stale "Analyzing…"). Restore the early-out.
- **F16** — "Load Anyway" on the insufficient-memory alert dropped the message. Thread a resume through the readiness seam.
- **F-SHEET** — chat header → models sheet → Image opened the selector on the Text tab. Thread `initialTab`.

## Audio / remote / Pro
- **F4** — TTS was silent after voice dictation (realtime STT left the session in record mode). `stopTranscription` hands the session back to the owner.
- **F7** — remote gateway vision models ignored attached images (discovery dropped `kind:'vision'`). Trust `kind` as authoritative.
- **F6** — a license-key activation didn't reveal the Pro Settings section until restart. Make the section registry reactive (`useSyncExternalStore`).

## Test integrity (the important one)
The TTS/MCP/audio suites (168 tests, 19 suites) were unconditionally ignored and `@offgrid/pro` was stubbed — so a green run told you nothing about that subsystem. `jest.config` now mirrors metro's `proExists`: with the submodule checked out it runs those suites against **real pro**; open-core forks fall back to the stub. A CI step pulls the private submodule when `PRO_SUBMODULE_PAT` is set. Turning this on surfaced one rotted test (streaming hung-speak recovery) that had never run — fixed.

Full suite: **277 suites / 6500 tests green** against real pro. Companion pro PR: off-grid-ai/mobile-pro#14 (F23 Kokoro stuck-"downloading").

## On-device verification
Provit journeys authored for each fix under `provit/journeys/` (before-fix reproduces → after-fix passes). The download-slot-leak and Android background-download fixes still want a real-device confirmation (the device log was unreachable during this work).
