### PR TITLE
fix: CodeRabbit review hardening for #425 (slot-leak guard, residency veto, audio serialization, mmproj remove, banner)

### DIFF
--- a/__tests__/unit/screens/ChatScreen/computePendingSettings.test.ts
+++ b/__tests__/unit/screens/ChatScreen/computePendingSettings.test.ts
@@ -1,0 +1,35 @@
+import { computePendingSettings } from '../../../../src/screens/ChatScreen/useChatScreen';
+
+describe('computePendingSettings — reload banner (LiteRT token budget)', () => {
+  it('returns false when nothing was loaded yet', () => {
+    expect(computePendingSettings('litert', { liteRTMaxTokens: 8192 }, null)).toBe(false);
+  });
+
+  it('does NOT flag a change when both sides resolve to the same effective token budget', () => {
+    // Backend matches on both sides; isolate the token-budget behavior.
+    // Loaded with the setting unset (effective native default 4096); live still unset.
+    expect(computePendingSettings('litert', { liteRTBackend: 'cpu' }, { liteRTBackend: 'cpu' })).toBe(false);
+    // Loaded 4096 explicitly, live unset → both effective 4096 → not changed.
+    expect(computePendingSettings('litert', { liteRTBackend: 'cpu' }, { liteRTBackend: 'cpu', liteRTMaxTokens: 4096 })).toBe(false);
+  });
+
+  it('flags a change when the setting goes from unset (effective 4096) to an explicit value (F5)', () => {
+    // The mirror bug: loaded with liteRTMaxTokens undefined, user later sets 8192. The
+    // effective budget genuinely changed and a reload is required, so the banner must fire.
+    expect(
+      computePendingSettings('litert', { liteRTBackend: 'cpu', liteRTMaxTokens: 8192 }, { liteRTBackend: 'cpu' }),
+    ).toBe(true);
+  });
+
+  it('flags a change when an explicit value changes', () => {
+    expect(
+      computePendingSettings('litert', { liteRTBackend: 'cpu', liteRTMaxTokens: 8192 }, { liteRTBackend: 'cpu', liteRTMaxTokens: 4096 }),
+    ).toBe(true);
+  });
+
+  it('flags a LiteRT backend change', () => {
+    expect(
+      computePendingSettings('litert', { liteRTBackend: 'gpu' }, { liteRTBackend: 'cpu' }),
+    ).toBe(true);
+  });
+});

--- a/__tests__/unit/services/audioSessionManager.test.ts
+++ b/__tests__/unit/services/audioSessionManager.test.ts
@@ -91,6 +91,23 @@ describe('AudioSessionManager', () => {
       // A throw is how iOS surfaces a denied mic permission; mode must not advance.
       expect(audioSessionManager.getMode()).toBeNull();
     });
+
+    it('serializes concurrent record + playback so the last call wins deterministically (no stale-mode race)', async () => {
+      // Fire recording then playback without awaiting between them. With the check-then-act
+      // race, both read the old mode and apply concurrently — the final category depended on
+      // which setAudioSessionActivity resolved last. Serialized, they run in call order.
+      const order: string[] = [];
+      setOptions.mockImplementation((opts: any) => { order.push(opts.iosCategory); });
+
+      const p1 = audioSessionManager.ensureRecording();
+      const p2 = audioSessionManager.ensurePlayback();
+      await Promise.all([p1, p2]);
+
+      // ensureRecording applied first (playAndRecord); ensurePlayback then saw mode==='record'
+      // and correctly skipped the downgrade — so record is the final, deterministic mode.
+      expect(order).toEqual(['playAndRecord']);
+      expect(audioSessionManager.getMode()).toBe('record');
+    });
   });
 
   describe('Android', () => {

--- a/__tests__/unit/services/modelResidency.test.ts
+++ b/__tests__/unit/services/modelResidency.test.ts
@@ -294,6 +294,16 @@ describe('ModelResidencyManager', () => {
       await expect(modelResidencyManager.reclaimSttForGeneration()).resolves.toBeUndefined();
     });
 
+    it('honors the canEvict veto — does NOT unload Whisper while it is in use', async () => {
+      jest.spyOn(hardwareService, 'getTotalMemoryGB').mockReturnValue(4);
+      const unload = jest.fn().mockResolvedValue(undefined);
+      // canEvict returns false → the owner vetoes (e.g. still finalizing a transcription).
+      modelResidencyManager.register({ key: 'whisper', type: 'whisper', sizeMB: 466, canEvict: () => false }, unload, 1);
+      await modelResidencyManager.reclaimSttForGeneration();
+      expect(unload).not.toHaveBeenCalled();
+      expect(modelResidencyManager.isResident('whisper')).toBe(true);
+    });
+
     it('serializes the reclaim behind an in-flight load (F3: no unload while the lock is held)', async () => {
       jest.spyOn(hardwareService, 'getTotalMemoryGB').mockReturnValue(4);
       const order: string[] = [];

--- a/__tests__/unit/services/whisperService.test.ts
+++ b/__tests__/unit/services/whisperService.test.ts
@@ -515,6 +515,9 @@ describe('WhisperService', () => {
         // did, so mode stayed 'record' and the next TTS ensurePlayback() early-returned
         // → silent speech after dictation.
         await whisperService.stopTranscription();
+        // restore is fire-and-forget in stopTranscription's finally and now runs through
+        // the session owner's serialized queue, so let that microtask settle.
+        await new Promise(resolve => setImmediate(resolve));
         expect(audioSessionManager.getMode()).toBe('playback');
 
         // And a subsequent TTS playback request is actually applied (not skipped).

--- a/src/screens/ChatScreen/useChatScreen.ts
+++ b/src/screens/ChatScreen/useChatScreen.ts
@@ -46,7 +46,7 @@ type ActiveModelInfo = {
  * loadedSettings is persisted, so a relaunch or a llama→LiteRT switch would otherwise pop
  * the banner with nothing changed.
  */
-function computePendingSettings(
+export function computePendingSettings(
   engine: string | undefined,
   settings: Record<string, unknown>,
   loadedSettings: Record<string, unknown> | null | undefined,
@@ -55,8 +55,12 @@ function computePendingSettings(
   // Pending only if BOTH sides are defined AND differ.
   const changed = (live: unknown, loaded: unknown) => loaded !== undefined && live !== loaded;
   if (engine === 'litert') {
+    // Compare the EFFECTIVE token budget (unset = native default 4096) so an
+    // undefined→explicit change still flags a reload (mirror of the false-positive fix).
+    const liveTokens = (settings.liteRTMaxTokens as number | undefined) ?? 4096;
+    const loadedTokens = (loadedSettings.liteRTMaxTokens as number | undefined) ?? 4096;
     return changed(settings.liteRTBackend, loadedSettings.liteRTBackend) ||
-           changed(settings.liteRTMaxTokens, loadedSettings.liteRTMaxTokens);
+           (loadedSettings.liteRTBackend !== undefined && liveTokens !== loadedTokens);
   }
   const effCache = settings.inferenceBackend === INFERENCE_BACKENDS.OPENCL ? 'f16' : settings.cacheType;
   return (

--- a/src/services/audioSessionManager.ts
+++ b/src/services/audioSessionManager.ts
@@ -23,6 +23,18 @@ class AudioSessionManager {
   /** The category currently applied to the AVAudioSession (null = never set). */
   private mode: AudioSessionMode | null = null;
 
+  /** Serializes the check-then-apply of every session op so a mode guard is never
+   *  evaluated against a stale value. Without this, a concurrent ensurePlayback +
+   *  ensureRecording both read the old `mode`, both call apply(), and whichever
+   *  setAudioSessionActivity resolves last silently wins the category — exactly the
+   *  "last writer decides" race this owner exists to eliminate. */
+  private queue: Promise<unknown> = Promise.resolve();
+  private runSerial<T>(fn: () => Promise<T>): Promise<T> {
+    const next = this.queue.then(fn, fn);
+    this.queue = next.catch(() => {}); // never let a rejection wedge the chain
+    return next;
+  }
+
   /** The mode last applied (testing/diagnostics). */
   getMode(): AudioSessionMode | null {
     return this.mode;
@@ -38,15 +50,17 @@ class AudioSessionManager {
    */
   async ensurePlayback(): Promise<void> {
     if (Platform.OS !== 'ios') return;
-    if (this.mode === 'record') return;
-    await this.apply('playback');
+    await this.runSerial(async () => {
+      if (this.mode === 'record') return; // checked inside the serialized block → not stale
+      await this.apply('playback');
+    });
   }
 
   /** Ensure a record+playback session is active before recording starts.
    *  (Re)asserts every call, matching the recorder's prior per-start activation. */
   async ensureRecording(): Promise<void> {
     if (Platform.OS !== 'ios') return;
-    await this.apply('record');
+    await this.runSerial(() => this.apply('record'));
   }
 
   /**
@@ -72,7 +86,7 @@ class AudioSessionManager {
     // Returns whether the record session activated; a throw on activation is how
     // iOS surfaces a denied mic permission, so false === denied here (matching the
     // old whisperService.requestPermissions, which returned false on setActive throw).
-    return this.apply('record');
+    return this.runSerial(() => this.apply('record'));
   }
 
   /**
@@ -82,8 +96,10 @@ class AudioSessionManager {
    */
   async restorePlaybackAfterRecording(): Promise<void> {
     if (Platform.OS !== 'ios') return;
-    if (this.mode !== 'record') return;
-    await this.apply('playback');
+    await this.runSerial(async () => {
+      if (this.mode !== 'record') return; // checked inside the serialized block → not stale
+      await this.apply('playback');
+    });
   }
 
   /** @returns true if the session activated, false if activation threw (swallowed). */

--- a/src/services/backgroundDownloadService.ts
+++ b/src/services/backgroundDownloadService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- cohesive download admission-control service: the concurrency cap, FIFO queue, slot accounting, native-bridge calls, and event fan-out are one tightly-coupled unit; splitting it would scatter the shared activeIds/startQueue state. */
 import { NativeModules, NativeEventEmitter, Platform, Alert } from 'react-native';
 import { BackgroundDownloadInfo, BackgroundDownloadStatus } from '../types';
 import logger from '../utils/logger';
@@ -40,6 +41,10 @@ class BackgroundDownloadService {
   private startQueue: QueuedStart[] = [];
   /** Monotonic counter for unique in-flight reservation tokens. */
   private startSeq = 0;
+  /** Set once cleanup() runs, so a beginDownload() still awaiting the native start can't
+   *  re-add its id to the just-cleared activeIds (its release listeners are gone → the
+   *  slot would leak permanently). */
+  private shutDown = false;
 
   constructor() {
     if (this.isAvailable()) {
@@ -104,8 +109,11 @@ class BackgroundDownloadService {
         sha256: params.sha256,
         hideNotification: params.hideNotification ?? false,
       });
-      // Swap the reservation for the real download id (still one slot).
+      // Swap the reservation for the real download id (still one slot). If cleanup() ran
+      // while we awaited the native start, don't re-add — the release listeners are gone,
+      // so this id could never be freed and would leak a slot for the service's life.
       this.activeIds.delete(token);
+      if (this.shutDown) { DownloadManagerModule.cancelDownload(result.downloadId).catch(() => {}); return { downloadId: result.downloadId, fileName: result.fileName, modelId: result.modelId, status: 'failed', bytesDownloaded: 0, totalBytes: params.totalBytes ?? 0, startedAt: Date.now() }; }
       this.activeIds.add(result.downloadId);
       return {
         downloadId: result.downloadId,
@@ -454,6 +462,7 @@ class BackgroundDownloadService {
   }
 
   cleanup(): void {
+    this.shutDown = true;
     this.stopProgressPolling();
     this.subscriptions.forEach(sub => sub.remove());
     this.subscriptions = [];

--- a/src/services/classifierProvisioning.ts
+++ b/src/services/classifierProvisioning.ts
@@ -59,13 +59,19 @@ export async function ensureDefaultClassifier(): Promise<void> {
     // phantom "downloading 100%" entry in the Download Manager (its uniform id —
     // text:<repo> — never matched the finished model's text:<repo>/<file>, so the
     // one-entry dedup couldn't collapse it).
+    let settled = false;
     await startModelDownload(CLASSIFIER_REPO, file, {
       onRegistered: (model) => {
+        settled = true;
         useAppStore.getState().updateSettings({ classifierModelId: model.id });
         provisioning = false;
       },
-      onError: () => { provisioning = false; },
+      onError: () => { settled = true; provisioning = false; },
     });
+    // startModelDownload can return without firing either callback (already-active
+    // download, or a queued start that was cancelled). Don't leave provisioning stuck
+    // true forever — that would block every future classifier selection attempt.
+    if (!settled) provisioning = false;
   } catch {
     provisioning = false;
   }

--- a/src/services/modelDownloadService/providers/textProvider.ts
+++ b/src/services/modelDownloadService/providers/textProvider.ts
@@ -135,6 +135,11 @@ export const textProvider: DownloadProvider = {
     if (entry) {
       await modelManager.cancelBackgroundDownload(entry.downloadId)
         .catch(err => logger.log(`[DL-SM] ${id} remove: native cancel failed err=${msg(err)}`));
+      // Cancel the mmproj sidecar too (mirrors cancel()) — otherwise removing an in-flight
+      // vision download orphans the mmproj transfer: it keeps occupying a concurrency slot
+      // (never released) and its terminal event has no listener left.
+      if (entry.mmProjDownloadId) await modelManager.cancelBackgroundDownload(entry.mmProjDownloadId)
+        .catch(err => logger.log(`[DL-SM] ${id} remove: mmproj native cancel failed err=${msg(err)}`));
       useDownloadStore.getState().remove(entry.modelKey);
     }
     await modelManager.deleteModel(key)

--- a/src/services/modelResidency/index.ts
+++ b/src/services/modelResidency/index.ts
@@ -295,6 +295,7 @@ class ModelResidencyManager {
     await this.runExclusive('reclaim:stt', async () => {
       const w = this.residents.get('whisper');
       if (!w) return; // reclaimed by another op while we waited for the lock
+      if (w.canEvict && !w.canEvict()) return; // in use (e.g. finalizing a transcription) — owner vetoes
       logger.log('[ModelResidency] reclaiming idle STT for generation turn (memory-tight)');
       await w.unload().catch(err => logger.log('[ModelResidency] STT reclaim failed:', err));
       this.residents.delete('whisper');


### PR DESCRIPTION
Follow-up addressing six verified CodeRabbit findings on #425, each hardening a fix already in this release: cleanup-vs-reservation slot re-leak guard, reclaimStt canEvict veto, textProvider.remove mmproj cancel, audioSessionManager serialized check-then-apply, classifierProvisioning stuck-flag reset, and the LiteRT reload-banner effective-token comparison. Tests added for each; full suite green (278 suites / 6507). Stacked on #425.