### PR TITLE
fix(rag): roll back + surface a document that fails to embed (no silent dead KB entries)

### DIFF
--- a/__tests__/unit/services/rag/index.test.ts
+++ b/__tests__/unit/services/rag/index.test.ts
@@ -113,10 +113,37 @@ describe('RagService', () => {
         .rejects.toThrow('already in the knowledge base');
     });
 
-    it('continues without embeddings if embedding fails', async () => {
+    // HONESTY: a doc with no embeddings is not searchable, so it must NOT be left in
+    // the KB looking "added". On any embedding failure, indexDocument rolls back the
+    // inserted doc + chunks and throws, so the KB add flow surfaces the real error
+    // (instead of a silent dead entry). backfillEmbeddings has no auto-trigger, so the
+    // old "continue without embeddings" swallow stranded the doc permanently.
+    it('rolls back the inserted document and throws when embedding LOAD fails', async () => {
       mockEmbedding.load.mockRejectedValueOnce(new Error('model not found'));
-      const docId = await ragService.indexDocument({ projectId: 'proj1', filePath: '/p', fileName: 'test.txt', fileSize: 100 });
-      expect(docId).toBe(1); // Still returns docId
+      await expect(
+        ragService.indexDocument({ projectId: 'proj1', filePath: '/p', fileName: 'test.txt', fileSize: 100 }),
+      ).rejects.toThrow(/Could not index "test.txt".*embeddings failed/);
+      expect(mockDb.deleteDocument).toHaveBeenCalledWith(1); // the just-inserted docId
+      expect(mockDb.insertEmbeddingsBatch).not.toHaveBeenCalled();
+    });
+
+    it('rolls back the inserted document and throws when embedBatch fails (e.g. OOM)', async () => {
+      mockEmbedding.embedBatch.mockRejectedValueOnce(new Error('Embedding failed (native error). OOM'));
+      await expect(
+        ragService.indexDocument({ projectId: 'proj1', filePath: '/p', fileName: 'test.txt', fileSize: 100 }),
+      ).rejects.toThrow(/embeddings failed to generate/);
+      expect(mockDb.deleteDocument).toHaveBeenCalledWith(1);
+      expect(mockDb.insertEmbeddingsBatch).not.toHaveBeenCalled();
+    });
+
+    it('rolls back and throws when embedBatch returns fewer embeddings than chunks', async () => {
+      // insertChunks mock returns [1,2] (2 chunks); return only 1 embedding → mismatch.
+      mockEmbedding.embedBatch.mockResolvedValueOnce([[0.1, 0.2]]);
+      await expect(
+        ragService.indexDocument({ projectId: 'proj1', filePath: '/p', fileName: 'test.txt', fileSize: 100 }),
+      ).rejects.toThrow(/embeddings failed to generate/);
+      expect(mockDb.deleteDocument).toHaveBeenCalledWith(1);
+      expect(mockDb.insertEmbeddingsBatch).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/rag/index.ts
+++ b/src/services/rag/index.ts
@@ -63,6 +63,9 @@ class RagService {
       await embeddingService.load();
       const texts = chunks.map(c => c.content);
       const embeddings = await embeddingService.embedBatch(texts);
+      if (embeddings.length !== rowIds.length) {
+        throw new Error(`embedding count ${embeddings.length} does not match ${rowIds.length} chunks`);
+      }
       const entries = rowIds.map((rowId, i) => ({
         chunkRowid: rowId,
         docId,
@@ -71,7 +74,15 @@ class RagService {
       ragDatabase.insertEmbeddingsBatch(entries);
       logger.log(`[RAG] Generated ${embeddings.length} embeddings for ${fileName}`);
     } catch (err) {
-      logger.error('[RAG] Embedding generation failed (non-fatal):', err);
+      // A document with no embeddings is NOT searchable — semantic search skips it —
+      // yet the KB would show it as "added". That is the "looks indexed but doesn't
+      // work" lie. backfillEmbeddings has no auto-trigger, so a swallowed failure
+      // strands the doc permanently. Roll back the just-inserted doc + chunks and
+      // surface the failure so the user sees the real error (KnowledgeBaseScreen
+      // already alerts on an index throw) and can retry — never a silent dead entry.
+      ragDatabase.deleteDocument(docId);
+      logger.error('[RAG] Embedding generation failed — rolled back document:', err);
+      throw new Error(`Could not index "${fileName}": embeddings failed to generate. ${err instanceof Error ? err.message : String(err)}`);
     }
 
     onProgress?.({ stage: 'done', message: 'Done' });


### PR DESCRIPTION
## Problem
`indexDocument` caught embedding failure **non-fatally** and still returned success. A document with **zero embeddings** then showed as "added" in the Knowledge Base but was **not searchable** (semantic search skips it) — the "looks indexed but doesn't actually work" lie. `backfillEmbeddings` has no auto-trigger, so the swallowed failure stranded the doc **permanently**.

## Fix
On any embedding failure (load throw, `embedBatch` throw/OOM, or an embedding-count vs chunk-count mismatch), **roll back the just-inserted document + chunks and throw**. `KnowledgeBaseScreen` already alerts on an index throw, so the user sees the real error and can retry — never a silent non-functional entry.

## Tests (jest, fails-before / passes-after)
Replaced the old `continues without embeddings if embedding fails` test (which encoded the lie) with three cases: load failure, `embedBatch` failure (OOM), and embedding-count mismatch — each asserts `indexDocument` **throws** and **rolls back** (`deleteDocument` called), with `insertEmbeddingsBatch` never called.

## Provit (on-device E2E)
Pending — a KB round-trip journey (index a real doc → confirm searchable; feed a doc that fails to embed → confirm the error surfaces, no silent dead entry). jest mocks the sqlite/native boundary, so the true round-trip proof is on-device. Self-audit comment below.

## Scope
Fixes the "not actually working" half of the KB honesty issue. The truncation-honesty half (>500KB silently cut) is a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document indexing reliability by rolling back failed indexing attempts instead of leaving partially indexed documents.
  * Prevented documents from appearing indexed when required search embeddings were not created.
  * Added validation to ensure the number of generated embeddings matches the number of content chunks before saving them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->