### PR TITLE
fix(tools): validate cached tool-embedding dimension (stale-dim after model swap poisons routing)

### DIFF
--- a/__tests__/unit/services/toolEmbeddingRouter.test.ts
+++ b/__tests__/unit/services/toolEmbeddingRouter.test.ts
@@ -82,6 +82,30 @@ describe('toolEmbeddingRouter (F6 — persistent embedding cache)', () => {
     expect(mockEmbed).toHaveBeenCalledTimes(2);
   });
 
+  it('re-embeds a cached entry whose dimension no longer matches the model (stale-dim after a model swap)', async () => {
+    await selectToolsByEmbedding('find my page', TOOLS, 4);
+    await new Promise(r => setTimeout(r, 1100)); // let the debounced persist fire
+
+    // Simulate an embedding-model swap: ONE persisted vector was produced by the OLD
+    // model and has a DIFFERENT dimension (4) than the current model (mock returns 3).
+    // The content hash keys on the tool text, not the model, so it still "matches" —
+    // without a dimension guard, embedTool returns the stale 4-dim vector and
+    // cosineSimilarity compares across dimensions, silently poisoning routing.
+    const stored = JSON.parse((await AsyncStorage.getItem('tool-embedding-cache-v1'))!);
+    const staleName = Object.keys(stored)[0];
+    stored[staleName] = { ...stored[staleName], v: [0.1, 0.2, 0.3, 0.4] }; // 4-dim; model is 3-dim
+    await AsyncStorage.setItem('tool-embedding-cache-v1', JSON.stringify(stored));
+
+    _resetToolEmbeddingCache();
+    mockEmbed.mockClear();
+    const selected = await selectToolsByEmbedding('find my page', TOOLS, 4);
+    // FAILS before the fix: the stale-dim vector is returned from cache (hash matches),
+    // so only the query is embedded (1). AFTER: the dim mismatch forces a re-embed, so
+    // query (1) + the one stale tool (1) = 2, and the other 11 valid cached entries are reused.
+    expect(mockEmbed).toHaveBeenCalledTimes(2);
+    expect(selected).toHaveLength(4); // routing still produces a sane top-K, no NaN wipeout
+  });
+
   it('returns all tools without embedding when count <= topK', async () => {
     const names = await selectToolsByEmbedding('x', TOOLS.slice(0, 3), 4);
     expect(names).toHaveLength(3);

--- a/src/services/toolEmbeddingRouter.ts
+++ b/src/services/toolEmbeddingRouter.ts
@@ -82,6 +82,11 @@ function firstLine(desc: string | undefined, max = 200): string {
 }
 
 function cosineSimilarity(a: number[], b: number[]): number {
+  // Mismatched dimensions are not comparable — comparing across dims (e.g. a stale
+  // 384-dim cached vector vs a fresh query from a 256-dim model) reads garbage from the
+  // shorter vector and yields a meaningless score. Treat as no-match so a dimension
+  // change can never silently poison routing.
+  if (a.length !== b.length) return 0;
   let dot = 0;
   let normA = 0;
   let normB = 0;
@@ -140,11 +145,15 @@ function discoveryBoost(tool: RoutableTool): number {
   return DISCOVERY_VERBS.some(v => name.includes(v)) ? 0.15 : 0;
 }
 
-async function embedTool(tool: RoutableTool): Promise<number[]> {
+async function embedTool(tool: RoutableTool, expectedDim: number): Promise<number[]> {
   const text = `${tool.function.name}: ${firstLine(tool.function.description)}`;
   const hash = hashText(text);
   const cached = toolEmbeddingCache.get(tool.function.name);
-  if (cached && cached.h === hash) return cached.v;
+  // The content hash keys on the tool TEXT, not the embedding model — so a model whose
+  // output dimension changed (e.g. a different MiniLM variant) keeps the same hash and
+  // would return a stale-dimension vector. Require the cached vector to match the
+  // current model's dimension (that of the live query embedding); otherwise re-embed.
+  if (cached && cached.h === hash && cached.v.length === expectedDim) return cached.v;
   const vec = await embeddingService.embed(text);
   toolEmbeddingCache.set(tool.function.name, { h: hash, v: vec });
   schedulePersist();
@@ -170,7 +179,7 @@ export async function selectToolsByEmbedding(
   const tokens = queryTokens(query);
   const scored: Array<{ name: string; score: number }> = [];
   for (const tool of tools) {
-    const vec = await embedTool(tool);
+    const vec = await embedTool(tool, queryVec.length);
     // Hybrid: semantic similarity + lexical (provider/verb word) + discovery boost.
     const score = cosineSimilarity(queryVec, vec) + lexicalBoost(tokens, tool) + discoveryBoost(tool);
     scored.push({ name: tool.function.name, score });


### PR DESCRIPTION
## Problem
The tool-routing embedding cache (`toolEmbeddingRouter.ts`) keys entries on the tool **text** (content hash), not the embedding model. If the embedding model's output dimension changes, the hash still matches and `embedTool` returns a **stale-dimension** vector. `cosineSimilarity` then loops on the query's length and reads garbage from the shorter vector — **silently poisoning tool routing** after a model swap. (Audit finding A12; the test fails on `main`.)

## Fix
- `embedTool` requires a cached vector to match the **current model's dimension** (the live query embedding's length) or re-embeds it.
- `cosineSimilarity` returns 0 on a dimension mismatch (defense-in-depth).
- Self-consistent: uses the live query-embedding dimension, no reliance on a separate `getDimension()`.

## Test (jest, fails-before / passes-after)
A persisted 4-dim vector against a 3-dim model is re-embedded (not served stale), and routing still yields a sane top-K. Fails on `main` (stale vector served, only query embedded), passes here.

## Provit
Pending — this is exercised by the tools/MCP routing journeys (KUF: Remote/Tools); will run on-device once the vision oracle is back up. Self-audit below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool selection reliability when embedding model dimensions change, ensuring cached results are refreshed instead of causing inaccurate routing.
  * Prevented mismatched vector sizes from affecting similarity scoring, helping keep top results stable.

* **Tests**
  * Added coverage for cache invalidation and re-embedding behavior when stored embeddings are outdated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->