### PR TITLE
test(hardening): additive coverage — abort guard, license trim, memory severity (no prod change)

### DIFF
--- a/__tests__/hardening/batch1-onboarding-checklist.test.tsx
+++ b/__tests__/hardening/batch1-onboarding-checklist.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * BATCH 1 (Onboarding & First Launch) — hardening coverage for the onboarding
+ * checklist step-completion state machine.
+ *
+ * The REAL logic under test is `useOnboardingSteps` (src/components/checklist/
+ * useOnboardingSteps.ts): a hook that derives each checklist step's `completed`
+ * and `disabled` flags + the `completedCount` from FOUR real reactive stores
+ * (appStore, chatStore, projectStore, remoteServerStore). This is the single
+ * source of truth for "which step is active/complete" that the home checklist
+ * (useHomeScreen) renders — Provit cases 6, 18, 20, 26, 36, 38.
+ *
+ * These tests drive the REAL stores and the REAL hook (via renderHook). Nothing
+ * that is asserted is mocked — deleting the hook body or a store action would
+ * fail these. Existing tests (checklistComponents.test.tsx) cover the individual
+ * happy-path step flags; this file adds the gaps:
+ *   - the FULL sequential progression (0→…→6) that mirrors the checklist advancing
+ *     its active step, and the exact completedCount at each stage (cases 6/18/20/26/36)
+ *   - the flag-driven steps (exploredSettings, triedImageGen) reflected THROUGH the
+ *     hook's `completed` field (not just the raw store flag)
+ *   - the triedImageGen disabled→enabled transition when a text model loads
+ *   - the remote-server / remote-active-model ALTERNATE completion paths for
+ *     downloadedModel + loadedModel (the hook's `|| remoteServers.length` / `||
+ *     activeRemoteTextModelId` branches, which no existing test exercises)
+ *   - completed steps surviving a persist rehydrate — the checklist does not reset
+ *     across a cold relaunch (case 38)
+ */
+
+import { renderHook, act } from '@testing-library/react-native';
+import { useAppStore } from '../../src/stores/appStore';
+import { useChatStore } from '../../src/stores/chatStore';
+import { useProjectStore } from '../../src/stores/projectStore';
+import { useRemoteServerStore } from '../../src/stores/remoteServerStore';
+import { useOnboardingSteps } from '../../src/components/checklist/useOnboardingSteps';
+import { resetStores, getAppState } from '../utils/testHelpers';
+import { createDownloadedModel, createONNXImageModel } from '../utils/factories';
+
+const stepById = (steps: any[], id: string) => steps.find((s) => s.id === id);
+
+describe('BATCH1 onboarding checklist — useOnboardingSteps (real hook + real stores)', () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  // ── case 6: after onboarding, step 1 (Download a Model) is the active/first
+  //    incomplete step and NOTHING is complete. ─────────────────────────────
+  it('case6: fresh state has 0 complete; downloadedModel is the first incomplete step', () => {
+    const { result } = renderHook(() => useOnboardingSteps());
+    expect(result.current.completedCount).toBe(0);
+    // The "active" step the checklist highlights is the first not-yet-completed one.
+    const firstIncomplete = result.current.steps.find((s: any) => !s.completed);
+    expect(firstIncomplete!.id).toBe('downloadedModel');
+    // No step should be complete on a fresh install.
+    expect(result.current.steps.every((s: any) => !s.completed)).toBe(true);
+  });
+
+  // ── cases 6→18→20→26→36: the full sequential progression. Each completion moves
+  //    the "first incomplete" (active) step forward and bumps completedCount. ──
+  it('cases6-36: completing steps in order advances the active step and completedCount', () => {
+    const { result, rerender } = renderHook(() => useOnboardingSteps());
+
+    // Step 1: Download a Model → active step becomes "loadedModel" (case 18).
+    act(() => { useAppStore.getState().addDownloadedModel(createDownloadedModel()); });
+    rerender({});
+    expect(stepById(result.current.steps, 'downloadedModel').completed).toBe(true);
+    expect(result.current.completedCount).toBe(1);
+    expect(result.current.steps.find((s: any) => !s.completed)!.id).toBe('loadedModel');
+
+    // Step 2: Load a Model → active step becomes "sentMessage" (case 20).
+    act(() => { useAppStore.getState().setActiveModelId('m-1'); });
+    rerender({});
+    expect(stepById(result.current.steps, 'loadedModel').completed).toBe(true);
+    expect(result.current.completedCount).toBe(2);
+    expect(result.current.steps.find((s: any) => !s.completed)!.id).toBe('sentMessage');
+
+    // Step 3: Send first message (case 26).
+    act(() => {
+      const id = useChatStore.getState().createConversation('m-1', 'Chat');
+      useChatStore.getState().addMessage(id, { role: 'user', content: 'hi' });
+    });
+    rerender({});
+    expect(stepById(result.current.steps, 'sentMessage').completed).toBe(true);
+    expect(result.current.completedCount).toBe(3);
+
+    // Step 5: Explore Settings — flag driven (case 36).
+    act(() => { useAppStore.getState().completeChecklistStep('exploredSettings'); });
+    rerender({});
+    expect(stepById(result.current.steps, 'exploredSettings').completed).toBe(true);
+    expect(result.current.completedCount).toBe(4);
+  });
+
+  // ── case 36 isolated: exploredSettings is a FLAG the hook surfaces as `completed`.
+  //    Drives the real completeChecklistStep action and reads it back THROUGH the hook. ──
+  it('case36: exploredSettings flag flows through the hook completed field', () => {
+    const { result, rerender } = renderHook(() => useOnboardingSteps());
+    expect(stepById(result.current.steps, 'exploredSettings').completed).toBe(false);
+    act(() => { useAppStore.getState().completeChecklistStep('exploredSettings'); });
+    rerender({});
+    expect(stepById(result.current.steps, 'exploredSettings').completed).toBe(true);
+  });
+
+  // ── triedImageGen: disabled while no text model loaded, enabled once one is,
+  //    completed only via the flag (NOT by merely downloading an image model). ──
+  it('triedImageGen: disabled→enabled on model load, completed only via flag', () => {
+    const { result, rerender } = renderHook(() => useOnboardingSteps());
+
+    // No model loaded → disabled, not completed.
+    expect(stepById(result.current.steps, 'triedImageGen').disabled).toBe(true);
+    expect(stepById(result.current.steps, 'triedImageGen').completed).toBe(false);
+
+    // Downloading an image model must NOT complete it (guards a false-complete).
+    act(() => { useAppStore.getState().addDownloadedImageModel(createONNXImageModel()); });
+    rerender({});
+    expect(stepById(result.current.steps, 'triedImageGen').completed).toBe(false);
+
+    // Loading a TEXT model enables the step (disabled is keyed off activeModelId).
+    act(() => { useAppStore.getState().setActiveModelId('m-1'); });
+    rerender({});
+    expect(stepById(result.current.steps, 'triedImageGen').disabled).toBe(false);
+    expect(stepById(result.current.steps, 'triedImageGen').completed).toBe(false);
+
+    // Only the explicit flag (set by imageGenerationService after a real gen) completes it.
+    act(() => { useAppStore.getState().completeChecklistStep('triedImageGen'); });
+    rerender({});
+    expect(stepById(result.current.steps, 'triedImageGen').completed).toBe(true);
+  });
+
+  // ── createdProject completes only at projects.length > 4 (the 4 seeded defaults
+  //    are NOT enough — this is the exact >4 boundary the hook uses). ──────────
+  it('createdProject: not complete at 4 projects, complete at 5 (>4 boundary)', () => {
+    // Start from exactly 4 projects (the seeded defaults are 4).
+    act(() => {
+      useProjectStore.setState({
+        projects: Array.from({ length: 4 }, (_, i) => ({
+          id: `p-${i}`, name: `P${i}`, description: '', systemPrompt: '',
+          createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+        })),
+      });
+    });
+    const { result, rerender } = renderHook(() => useOnboardingSteps());
+    expect(useProjectStore.getState().projects.length).toBe(4);
+    expect(stepById(result.current.steps, 'createdProject').completed).toBe(false);
+
+    act(() => {
+      useProjectStore.getState().createProject({ name: 'fifth', description: '', systemPrompt: '' });
+    });
+    rerender({});
+    expect(useProjectStore.getState().projects.length).toBe(5);
+    expect(stepById(result.current.steps, 'createdProject').completed).toBe(true);
+  });
+
+  // ── ALTERNATE completion path: a configured remote server satisfies "Download a
+  //    Model", and an active remote text model satisfies "Load a Model" — no local
+  //    download/activeModelId required. These are the hook's `|| remoteServers` and
+  //    `|| activeRemoteTextModelId` branches. ─────────────────────────────────
+  it('downloadedModel/loadedModel also complete via remote server + remote active model', () => {
+    const { result, rerender } = renderHook(() => useOnboardingSteps());
+    expect(stepById(result.current.steps, 'downloadedModel').completed).toBe(false);
+    expect(stepById(result.current.steps, 'loadedModel').completed).toBe(false);
+
+    // A remote server counts as "has any model" even with zero local downloads.
+    act(() => {
+      useRemoteServerStore.getState().addServer({
+        name: 'LAN box', endpoint: 'http://192.168.1.9:8080', providerType: 'openai-compatible',
+      });
+    });
+    rerender({});
+    expect(getAppState().downloadedModels.length).toBe(0);
+    expect(stepById(result.current.steps, 'downloadedModel').completed).toBe(true);
+
+    // An active remote text model counts as "has active model" with no local activeModelId.
+    act(() => { useRemoteServerStore.getState().setActiveRemoteTextModelId('remote/qwen'); });
+    rerender({});
+    expect(getAppState().activeModelId).toBeNull();
+    expect(stepById(result.current.steps, 'loadedModel').completed).toBe(true);
+  });
+
+  // ── case 38: completed steps survive a cold relaunch. Persist the onboarding
+  //    flags to AsyncStorage, reset the in-memory store, rehydrate, and confirm the
+  //    hook still reports them complete — the checklist did NOT reset. ──────────
+  it('case38: completed checklist steps survive a persist rehydrate (no reset)', async () => {
+    const AsyncStorage = require('@react-native-async-storage/async-storage');
+
+    // Wipe in-memory flags FIRST — before writing the payload — so the persist
+    // middleware's auto-save on this setState can't clobber the payload below.
+    act(() => {
+      useAppStore.setState({
+        hasCompletedOnboarding: false,
+        onboardingChecklist: {
+          downloadedModel: false, loadedModel: false, sentMessage: false,
+          triedImageGen: false, exploredSettings: false, createdProject: false,
+        },
+      });
+    });
+
+    // A returning user who has completed onboarding + several checklist steps.
+    const persistedPayload = JSON.stringify({
+      state: {
+        hasCompletedOnboarding: true,
+        onboardingChecklist: {
+          downloadedModel: true, loadedModel: true, sentMessage: true,
+          triedImageGen: false, exploredSettings: true, createdProject: false,
+        },
+        checklistDismissed: false,
+        activeModelId: 'm-1',
+      },
+      version: 0,
+    });
+    await AsyncStorage.setItem('local-llm-app-storage', persistedPayload);
+
+    await act(async () => {
+      await (useAppStore as any).persist.rehydrate();
+    });
+
+    const state = getAppState();
+    expect(state.hasCompletedOnboarding).toBe(true);
+    // Flags 1, 2, 3, 5 stayed done across the relaunch (the exact case-38 assertion).
+    expect(state.onboardingChecklist.downloadedModel).toBe(true);
+    expect(state.onboardingChecklist.loadedModel).toBe(true);
+    expect(state.onboardingChecklist.sentMessage).toBe(true);
+    expect(state.onboardingChecklist.exploredSettings).toBe(true);
+    // And the flag-driven steps the hook reads surface as completed post-rehydrate.
+    const { result } = renderHook(() => useOnboardingSteps());
+    expect(stepById(result.current.steps, 'exploredSettings').completed).toBe(true);
+
+    await AsyncStorage.removeItem('local-llm-app-storage');
+  });
+
+  // ── The migration guard: if the checklist was dismissed but is NOT fully complete,
+  //    rehydration un-dismisses it so remaining steps stay visible (real merge rule
+  //    that keeps the checklist from vanishing after a partial-then-relaunch). ──
+  it('case38 guard: a dismissed-but-incomplete checklist is un-dismissed on rehydrate', () => {
+    const merge = (useAppStore as any).persist.getOptions().merge as (p: any, c: any) => any;
+    const merged = merge(
+      {
+        checklistDismissed: true,
+        onboardingChecklist: {
+          downloadedModel: true, loadedModel: false, sentMessage: false,
+          triedImageGen: false, exploredSettings: false, createdProject: false,
+        },
+      },
+      useAppStore.getState(),
+    );
+    // Not every step is done → the dismiss must be reverted so the checklist re-appears.
+    expect(merged.checklistDismissed).toBe(false);
+  });
+});

--- a/__tests__/hardening/batch2-chatslist.test.tsx
+++ b/__tests__/hardening/batch2-chatslist.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Batch 2 hardening — Chats list (sort, timestamp formatting, delete, empty state)
+ *
+ * Renders the REAL ChatsListScreen so the REAL inline formatDate() + the REAL sort
+ * comparator + the REAL chatStore.deleteConversation run. The existing RNTL suite
+ * (__tests__/rntl/screens/ChatsListScreen.test.tsx) only asserts that the row title
+ * renders for each date bucket — it does NOT assert the actual formatted string, nor
+ * the actual row order. These tests close that false-green gap by asserting:
+ *
+ *   25/30 — most-recently-active conversation floats to position 1 (real sort order).
+ *   26    — a conversation from TODAY shows a clock time (HH:MM), not a date.
+ *   27    — a conversation from a prior day shows a weekday / month-day, not a clock.
+ *   31    — deleting a conversation removes exactly that row (real store delete).
+ *   32    — deleting all conversations shows the empty state ("No Chats Yet").
+ *
+ * Boundaries mocked: navigation, animation wrappers, Swipeable, CustomAlert, the
+ * services barrel, and vector icons — none of which is the logic under test.
+ */
+
+import React from 'react';
+import { render, fireEvent, within } from '@testing-library/react-native';
+import { useAppStore } from '../../src/stores/appStore';
+import { useChatStore } from '../../src/stores/chatStore';
+import { resetStores } from '../utils/testHelpers';
+import { createConversation, createDownloadedModel } from '../utils/factories';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+      goBack: jest.fn(),
+      setOptions: jest.fn(),
+      addListener: jest.fn(() => jest.fn()),
+    }),
+    useRoute: () => ({ params: {} }),
+    useFocusEffect: jest.fn(),
+    useIsFocused: () => true,
+  };
+});
+
+jest.mock('../../src/hooks/useFocusTrigger', () => ({ useFocusTrigger: () => 0 }));
+jest.mock('../../src/components/AnimatedEntry', () => ({ AnimatedEntry: ({ children }: any) => children }));
+jest.mock('../../src/components/AnimatedListItem', () => ({
+  AnimatedListItem: ({ children, onPress, style, testID }: any) => {
+    const { TouchableOpacity } = require('react-native');
+    return (
+      <TouchableOpacity style={style} onPress={onPress} testID={testID}>
+        {children}
+      </TouchableOpacity>
+    );
+  },
+}));
+
+const mockShowAlert = jest.fn((_t: string, _m: string, _b?: any[]) => ({
+  visible: true,
+  title: _t,
+  message: _m,
+  buttons: _b || [{ text: 'OK', style: 'default' }],
+}));
+
+jest.mock('../../src/components/CustomAlert', () => ({
+  CustomAlert: ({ visible, title, buttons }: any) => {
+    if (!visible) return null;
+    const { View, Text, TouchableOpacity: TO } = require('react-native');
+    return (
+      <View testID="custom-alert">
+        <Text testID="alert-title">{title}</Text>
+        {buttons && buttons.map((btn: any, i: number) => (
+          <TO key={i} testID={`alert-button-${btn.text}`} onPress={btn.onPress}>
+            <Text>{btn.text}</Text>
+          </TO>
+        ))}
+      </View>
+    );
+  },
+  showAlert: (...args: any[]) => (mockShowAlert as any)(...args),
+  hideAlert: jest.fn(() => ({ visible: false, title: '', message: '', buttons: [] })),
+  initialAlertState: { visible: false, title: '', message: '', buttons: [] },
+}));
+
+jest.mock('../../src/services', () => ({
+  onnxImageGeneratorService: { deleteGeneratedImage: jest.fn(() => Promise.resolve()) },
+  activeModelService: {
+    loadTextModel: jest.fn(() => Promise.resolve()),
+    loadImageModel: jest.fn(() => Promise.resolve()),
+    unloadTextModel: jest.fn(() => Promise.resolve()),
+    unloadImageModel: jest.fn(() => Promise.resolve()),
+  },
+  llmService: { getLoadedModelPath: jest.fn(() => null), isModelLoaded: jest.fn(() => false) },
+  remoteServerManager: { clearActiveRemoteModel: jest.fn() },
+}));
+
+jest.mock('../../src/components', () => ({
+  ModelSelectorModal: ({ visible }: any) => {
+    if (!visible) return null;
+    const { View, Text } = require('react-native');
+    return (<View testID="model-selector-modal"><Text>Select Model</Text></View>);
+  },
+}));
+
+// Render Swipeable's right actions so the delete button is reachable.
+jest.mock('react-native-gesture-handler/Swipeable', () => {
+  return ({ children, renderRightActions }: any) => {
+    const { View } = require('react-native');
+    return (<View>{children}{renderRightActions && renderRightActions()}</View>);
+  };
+});
+
+import { ChatsListScreen } from '../../src/screens/ChatsListScreen';
+
+describe('batch2 ChatsListScreen — sort, timestamp format, delete, empty', () => {
+  beforeEach(() => {
+    resetStores();
+    jest.clearAllMocks();
+    // a downloaded model so the empty-state uses the "with models" copy (doesn't matter here)
+    const model = createDownloadedModel();
+    useAppStore.setState({ downloadedModels: [model], activeModelId: model.id });
+  });
+
+  // Case 26: today's conversation shows a clock time, NOT a date.
+  it('case26: shows a clock time (HH:MM) for a conversation from today', () => {
+    const now = new Date();
+    const conv = createConversation({ title: 'Today Chat', updatedAt: now.toISOString() });
+    useChatStore.setState({ conversations: [conv] });
+
+    const { getByText } = render(<ChatsListScreen />);
+    const expectedClock = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    expect(getByText(expectedClock)).toBeTruthy();
+    // it is NOT a weekday or month/day string
+    expect(expectedClock).toMatch(/\d/);
+  });
+
+  // Case 27: a prior-day conversation shows a weekday (within a week) — not a clock.
+  it('case27: shows a weekday name for a conversation 3 days ago (not a clock time)', () => {
+    const threeDaysAgo = new Date();
+    threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+    const conv = createConversation({ title: 'Recent Chat', updatedAt: threeDaysAgo.toISOString() });
+    useChatStore.setState({ conversations: [conv] });
+
+    const { getByText } = render(<ChatsListScreen />);
+    const expectedWeekday = threeDaysAgo.toLocaleDateString([], { weekday: 'short' });
+    expect(getByText(expectedWeekday)).toBeTruthy();
+    // guard: a weekday short name is not a HH:MM clock
+    expect(expectedWeekday).not.toMatch(/^\d{1,2}:\d{2}/);
+  });
+
+  // Case 27 (older bucket): a >1-week-old conversation shows month/day.
+  it('case27: shows month/day for a conversation 14 days ago', () => {
+    const twoWeeksAgo = new Date();
+    twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
+    const conv = createConversation({ title: 'Old Chat', updatedAt: twoWeeksAgo.toISOString() });
+    useChatStore.setState({ conversations: [conv] });
+
+    const { getByText } = render(<ChatsListScreen />);
+    const expectedMonthDay = twoWeeksAgo.toLocaleDateString([], { month: 'short', day: 'numeric' });
+    expect(getByText(expectedMonthDay)).toBeTruthy();
+  });
+
+  // Cases 25/30: most-recently-active conversation is at position 1 (row index 0).
+  it('case25/30: most-recently-updated conversation sorts to the top row', () => {
+    const older = createConversation({ title: 'Older Chat', updatedAt: new Date('2024-01-01T10:00:00Z').toISOString() });
+    const newer = createConversation({ title: 'Newer Chat', updatedAt: new Date('2024-06-01T10:00:00Z').toISOString() });
+    // insert oldest-first so ONLY the real comparator can produce the correct order
+    useChatStore.setState({ conversations: [older, newer] });
+
+    const { getByTestId } = render(<ChatsListScreen />);
+    const row0 = getByTestId('conversation-item-0');
+    const row1 = getByTestId('conversation-item-1');
+    expect(within(row0).getByText('Newer Chat')).toBeTruthy();
+    expect(within(row1).getByText('Older Chat')).toBeTruthy();
+  });
+
+  // Case 31 (through the UI): the swipe-delete action opens a confirm alert whose
+  // Delete button removes exactly that conversation from the real store, leaving the
+  // rest intact.
+  it('case31: confirming the swipe-delete alert removes exactly that conversation', () => {
+    const a = createConversation({ title: 'Alpha', updatedAt: new Date('2024-06-02T10:00:00Z').toISOString() });
+    const b = createConversation({ title: 'Bravo', updatedAt: new Date('2024-06-01T10:00:00Z').toISOString() });
+    useChatStore.setState({ conversations: [a, b] });
+
+    const { UNSAFE_getAllByType } = render(<ChatsListScreen />);
+    const { TouchableOpacity } = require('react-native');
+    const touchables = UNSAFE_getAllByType(TouchableOpacity);
+
+    // Press each touchable until one raises the "Delete Chat" confirm alert (the
+    // swipe-delete action). Row 0 is the newest ("Alpha").
+    for (const t of touchables) {
+      fireEvent.press(t);
+      if (mockShowAlert.mock.calls.some(c => c[0] === 'Delete Chat')) break;
+    }
+
+    expect(mockShowAlert).toHaveBeenCalledWith(
+      'Delete Chat',
+      expect.any(String),
+      expect.any(Array),
+    );
+
+    // Invoke the confirm handler the screen passed to the alert -> real store delete.
+    const call = mockShowAlert.mock.calls.find(c => c[0] === 'Delete Chat')!;
+    const buttons = call[2] as any[];
+    const del = buttons.find(btn => btn.text === 'Delete')!;
+    del.onPress();
+
+    const remaining = useChatStore.getState().conversations;
+    expect(remaining).toHaveLength(1);
+    // exactly one conversation was removed; the other survives
+    expect(remaining.map(c => c.title)).toEqual(['Bravo']);
+  });
+
+  // Case 32: deleting all conversations shows the empty state.
+  it('case32: empty conversation list renders the "No Chats Yet" empty state', () => {
+    useChatStore.setState({ conversations: [] });
+    const { getByText, queryByTestId } = render(<ChatsListScreen />);
+    expect(getByText('No Chats Yet')).toBeTruthy();
+    expect(queryByTestId('conversation-list')).toBeNull();
+  });
+});

--- a/__tests__/hardening/batch2-getDisplayMessages-transitions.test.ts
+++ b/__tests__/hardening/batch2-getDisplayMessages-transitions.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Batch 2 hardening — Core Chat / Text Generation
+ *
+ * Cases 6, 7, 8: the thinking -> streaming -> done display transitions.
+ *
+ * Drives the REAL getDisplayMessages projection (src/screens/ChatScreen/types.ts) —
+ * the single source of truth the chat screen renders from. No mocks: this is a pure
+ * function over (messages, streamingState). Deleting the branch logic in the impl
+ * would fail these assertions.
+ *
+ * Already covered elsewhere (NOT duplicated here): the model-loading bubble isolation
+ * (`Loading <model>...`) lives in __tests__/unit/screens/getDisplayMessages.test.ts.
+ */
+
+import {
+  getDisplayMessages,
+  StreamingState,
+} from '../../src/screens/ChatScreen/types';
+import { createMessage } from '../utils/factories';
+
+const baseStreaming: StreamingState = {
+  isThinking: false,
+  streamingMessage: '',
+  streamingReasoningContent: '',
+  isStreamingForThisConversation: false,
+  isModelLoading: false,
+  loadingModelName: undefined,
+  isGeneratingForThisConversation: false,
+};
+
+describe('batch2 getDisplayMessages — thinking -> streaming -> done transitions', () => {
+  const userMsg = createMessage({ role: 'user', content: 'What is the capital of France?' });
+
+  // Case 6: a "Thinking" bubble is shown before any token arrives.
+  it('case6: appends a thinking bubble (empty content, isThinking) before the first token', () => {
+    const out = getDisplayMessages([userMsg], {
+      ...baseStreaming,
+      isThinking: true,
+      isStreamingForThisConversation: true,
+    });
+
+    expect(out).toHaveLength(2);
+    const bubble = out[1] as any;
+    expect(bubble.id).toBe('thinking');
+    expect(bubble.isThinking).toBe(true);
+    expect(bubble.content).toBe(''); // no generated text yet
+    expect(bubble.isStreaming).toBeUndefined();
+    // the real user message is preserved and ordered first
+    expect((out[0] as any).id).toBe(userMsg.id);
+  });
+
+  // Case 7: the moment the first token arrives, the thinking bubble is replaced by a
+  // streaming bubble carrying the partial content.
+  it('case7: replaces thinking with a streaming bubble the moment content exists', () => {
+    const out = getDisplayMessages([userMsg], {
+      ...baseStreaming,
+      isThinking: false,
+      streamingMessage: 'Paris',
+      isStreamingForThisConversation: true,
+    });
+
+    expect(out).toHaveLength(2);
+    const bubble = out[1] as any;
+    expect(bubble.id).toBe('streaming');
+    expect(bubble.isStreaming).toBe(true);
+    expect(bubble.content).toBe('Paris');
+    // the "thinking" bubble is gone — no thinking id present
+    expect(out.some(m => (m as any).id === 'thinking')).toBe(false);
+  });
+
+  it('case7: streaming bubble grows as more tokens accumulate', () => {
+    const first = getDisplayMessages([userMsg], {
+      ...baseStreaming,
+      streamingMessage: 'Paris',
+      isStreamingForThisConversation: true,
+    });
+    const later = getDisplayMessages([userMsg], {
+      ...baseStreaming,
+      streamingMessage: 'Paris is the capital',
+      isStreamingForThisConversation: true,
+    });
+
+    expect((first[1] as any).content).toBe('Paris');
+    expect((later[1] as any).content).toBe('Paris is the capital');
+  });
+
+  it('case7: reasoning-only content also produces a streaming bubble', () => {
+    const out = getDisplayMessages([userMsg], {
+      ...baseStreaming,
+      streamingReasoningContent: 'Let me think...',
+      isStreamingForThisConversation: true,
+    });
+    const bubble = out[1] as any;
+    expect(bubble.id).toBe('streaming');
+    expect(bubble.reasoningContent).toBe('Let me think...');
+  });
+
+  // Case 8: when generation finishes, the finalized assistant message is a REAL stored
+  // message and there is no synthetic thinking/streaming bubble left over.
+  it('case8: done state shows only the real messages, no synthetic bubble', () => {
+    const assistantMsg = createMessage({ role: 'assistant', content: 'Paris is the capital of France.' });
+    const out = getDisplayMessages([userMsg, assistantMsg], {
+      ...baseStreaming,
+      // generation over: not thinking, no live streaming content
+      isThinking: false,
+      streamingMessage: '',
+      isStreamingForThisConversation: false,
+    });
+
+    expect(out).toHaveLength(2);
+    expect(out.some(m => (m as any).id === 'thinking')).toBe(false);
+    expect(out.some(m => (m as any).id === 'streaming')).toBe(false);
+    expect((out[1] as any).id).toBe(assistantMsg.id);
+    expect((out[1] as any).content).toBe('Paris is the capital of France.');
+  });
+
+  // Isolation: a generation happening in ANOTHER conversation must not leak a bubble
+  // into this one (isStreamingForThisConversation === false).
+  it('does not append any bubble when the stream is for a different conversation', () => {
+    const thinkingElsewhere = getDisplayMessages([userMsg], {
+      ...baseStreaming,
+      isThinking: true,
+      isStreamingForThisConversation: false,
+    });
+    expect(thinkingElsewhere).toHaveLength(1);
+
+    const streamingElsewhere = getDisplayMessages([userMsg], {
+      ...baseStreaming,
+      streamingMessage: 'hello from another chat',
+      isStreamingForThisConversation: false,
+    });
+    expect(streamingElsewhere).toHaveLength(1);
+  });
+
+  // The full lifecycle in one sequence — the exact user-visible arc of a single turn.
+  it('cases 6->7->8: full thinking -> streaming -> done sequence for one turn', () => {
+    // 6. thinking
+    const thinking = getDisplayMessages([userMsg], {
+      ...baseStreaming, isThinking: true, isStreamingForThisConversation: true,
+    });
+    expect((thinking[1] as any).id).toBe('thinking');
+
+    // 7. first token -> streaming
+    const streaming = getDisplayMessages([userMsg], {
+      ...baseStreaming, streamingMessage: 'Par', isStreamingForThisConversation: true,
+    });
+    expect((streaming[1] as any).id).toBe('streaming');
+    expect((streaming[1] as any).content).toBe('Par');
+
+    // 8. finalized -> only real messages
+    const done = getDisplayMessages(
+      [userMsg, createMessage({ role: 'assistant', content: 'Paris.' })],
+      { ...baseStreaming },
+    );
+    expect(done).toHaveLength(2);
+    expect(done.some(m => (m as any).id === 'streaming' || (m as any).id === 'thinking')).toBe(false);
+  });
+});

--- a/__tests__/hardening/batch2-retry.test.ts
+++ b/__tests__/hardening/batch2-retry.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Batch 2 hardening — Core Chat / Text Generation (retry path)
+ *
+ * Drives the REAL handleRetryMessageFn (src/screens/ChatScreen/useChatMessageHandlers.ts)
+ * against the REAL chatStore. Boundaries mocked:
+ *   - modelResidency / hardware        (native memory diagnostics)
+ *   - regenerateResponseFn             (kicks off the native LLM decode — spied, like the
+ *                                       existing no-model test does)
+ *   - hookRegistry.callHook            (audio-stop hook; pro side-effect boundary)
+ *
+ * The REAL, asserted behavior is the retry ORCHESTRATION in handleRetryMessageFn:
+ *   16/17 — retry on a completed ASSISTANT message finds the preceding USER message,
+ *           trims everything after it, and regenerates for that user prompt.
+ *   17    — retry on a USER message trims trailing messages and regenerates.
+ *   19    — retry is NOT locked out after a previous (stopped) retry: a second retry
+ *           regenerates again.
+ *   20    — retry with no model loaded alerts and does not regenerate (guard).
+ *
+ * Deleting the prev-user lookup or the deleteMessagesAfter call in handleRetryMessageFn
+ * would fail these tests.
+ */
+
+jest.mock('../../src/services/modelResidency', () => ({
+  modelResidencyManager: { getResidents: jest.fn(() => []), reclaimSttForGeneration: jest.fn() },
+}));
+jest.mock('../../src/services/hardware', () => ({
+  hardwareService: { getAvailableMemoryGB: jest.fn(() => 4), getTotalMemoryGB: jest.fn(() => 8) },
+}));
+jest.mock('../../src/bootstrap/hookRegistry', () => ({
+  HOOKS: { audioStop: 'audio.stop' },
+  callHook: jest.fn(),
+}));
+
+import { handleRetryMessageFn } from '../../src/screens/ChatScreen/useChatMessageHandlers';
+import * as generationActions from '../../src/screens/ChatScreen/useChatGenerationActions';
+import { useChatStore } from '../../src/stores/chatStore';
+import { resetStores } from '../utils/testHelpers';
+
+const makeGenDeps = (overrides: Partial<any> = {}): any => ({
+  setAlertState: jest.fn(),
+  ...overrides,
+});
+
+describe('batch2 handleRetryMessageFn — retry orchestration', () => {
+  let regenSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetStores();
+    jest.clearAllMocks();
+    regenSpy = jest.spyOn(generationActions, 'regenerateResponseFn').mockResolvedValue(undefined);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  // Cases 16/17: retry a COMPLETED assistant message -> regenerate for the prior user.
+  it('case16/17: retrying a completed assistant message trims after the prior user msg and regenerates', async () => {
+    const store = useChatStore.getState();
+    const convId = store.createConversation('m1');
+    const userMsg = store.addMessage(convId, { role: 'user', content: 'say hi' } as any);
+    const assistantMsg = store.addMessage(convId, { role: 'assistant', content: 'Hi there!' } as any);
+
+    const deleteMessagesAfter = jest.fn((c: string, m: string) =>
+      useChatStore.getState().deleteMessagesAfter(c, m),
+    );
+
+    await handleRetryMessageFn(
+      assistantMsg,
+      makeGenDeps({ activeConversationId: convId }),
+      {
+        activeConversationId: convId,
+        hasActiveModel: true,
+        activeConversation: useChatStore.getState().conversations.find(c => c.id === convId),
+        deleteMessagesAfter,
+        setDebugInfo: jest.fn(),
+      },
+    );
+
+    // trimmed everything after the prior USER message (the assistant reply is removed)
+    expect(deleteMessagesAfter).toHaveBeenCalledWith(convId, userMsg.id);
+    const conv = useChatStore.getState().conversations.find(c => c.id === convId)!;
+    expect(conv.messages.map(m => m.id)).toEqual([userMsg.id]);
+    // regenerated for the prior user prompt
+    expect(regenSpy).toHaveBeenCalledTimes(1);
+    expect(regenSpy.mock.calls[0][1]).toMatchObject({ userMessage: expect.objectContaining({ id: userMsg.id }) });
+  });
+
+  // Case 17: retry a USER message directly -> trims trailing, regenerates for it.
+  it('case17: retrying a user message trims messages after it and regenerates for it', async () => {
+    const store = useChatStore.getState();
+    const convId = store.createConversation('m1');
+    const userMsg = store.addMessage(convId, { role: 'user', content: 'first' } as any);
+    store.addMessage(convId, { role: 'assistant', content: 'reply' } as any);
+
+    const deleteMessagesAfter = jest.fn((c: string, m: string) =>
+      useChatStore.getState().deleteMessagesAfter(c, m),
+    );
+
+    await handleRetryMessageFn(
+      userMsg,
+      makeGenDeps({ activeConversationId: convId }),
+      {
+        activeConversationId: convId,
+        hasActiveModel: true,
+        activeConversation: useChatStore.getState().conversations.find(c => c.id === convId),
+        deleteMessagesAfter,
+        setDebugInfo: jest.fn(),
+      },
+    );
+
+    expect(deleteMessagesAfter).toHaveBeenCalledWith(convId, userMsg.id);
+    expect(regenSpy).toHaveBeenCalledTimes(1);
+    expect(regenSpy.mock.calls[0][1]).toMatchObject({ userMessage: expect.objectContaining({ id: userMsg.id }) });
+  });
+
+  // Case 19: after a first retry (e.g. one that was stopped), a SECOND retry is not
+  // locked out — it regenerates again.
+  it('case19: a second retry after a previous one is not locked out — regenerates again', async () => {
+    const store = useChatStore.getState();
+    const convId = store.createConversation('m1');
+    const userMsg = store.addMessage(convId, { role: 'user', content: 'go' } as any);
+    const assistantMsg = store.addMessage(convId, { role: 'assistant', content: 'partial…' } as any);
+
+    const params = () => ({
+      activeConversationId: convId,
+      hasActiveModel: true,
+      activeConversation: useChatStore.getState().conversations.find(c => c.id === convId),
+      deleteMessagesAfter: (c: string, m: string) => useChatStore.getState().deleteMessagesAfter(c, m),
+      setDebugInfo: jest.fn(),
+    });
+
+    await handleRetryMessageFn(assistantMsg, makeGenDeps({ activeConversationId: convId }), params());
+    // second retry on the (now sole) user message
+    await handleRetryMessageFn(userMsg, makeGenDeps({ activeConversationId: convId }), params());
+
+    expect(regenSpy).toHaveBeenCalledTimes(2);
+  });
+
+  // Case 20 guard: no model loaded -> alert, no regeneration.
+  it('case20: retry with no active model alerts and does not regenerate', async () => {
+    const store = useChatStore.getState();
+    const convId = store.createConversation('m1');
+    const userMsg = store.addMessage(convId, { role: 'user', content: 'x' } as any);
+    const genDeps = makeGenDeps({ activeConversationId: convId });
+
+    await handleRetryMessageFn(userMsg, genDeps, {
+      activeConversationId: convId,
+      hasActiveModel: false,
+      activeConversation: useChatStore.getState().conversations.find(c => c.id === convId),
+      deleteMessagesAfter: jest.fn(),
+      setDebugInfo: jest.fn(),
+    });
+
+    expect(genDeps.setAlertState).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'No Model Selected' }),
+    );
+    expect(regenSpy).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/hardening/batch2-send.test.ts
+++ b/__tests__/hardening/batch2-send.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Batch 2 hardening — Core Chat / Text Generation (send path)
+ *
+ * Drives the REAL handleSendFn (src/screens/ChatScreen/useChatGenerationActions.ts)
+ * against the REAL chatStore and the REAL generationService queue. The only mocked
+ * things are genuine boundaries:
+ *   - modelPreloader.abortPreload        (background native warm-up)
+ *   - modelResidency.reclaimSttForGeneration (native memory reclaim)
+ *   - the `startGeneration` callback passed IN by the caller (this is where the native
+ *     LLM decode happens — it is a parameter, so stubbing it is a boundary, not the
+ *     thing under test).
+ *
+ * Cases covered:
+ *   5  — submitting with no active conversation creates a NEW chat + sets it active,
+ *        and the user message lands in that new conversation.
+ *   10 — a very long (600+ char) message is stored intact and generation begins.
+ *   14 — sending a new message while a generation is in flight enqueues it (interrupt/
+ *        serialize) instead of starting a second concurrent generation.
+ *   35 — the "new chat" entry point (Home spotlight / New button navigates to Chat with
+ *        no conversationId, which resets active to null) ALWAYS produces a brand-new
+ *        conversation, never reusing the most-recently-viewed one.
+ *
+ * Deleting the create-new-conversation branch, the enqueue branch, or the addMessage
+ * call in handleSendFn would fail these tests.
+ */
+
+// --- boundary mocks (native / background side-effects only) -----------------
+jest.mock('../../src/services/modelPreloader', () => ({
+  abortPreload: jest.fn(),
+}));
+jest.mock('../../src/services/modelResidency', () => ({
+  modelResidencyManager: {
+    reclaimSttForGeneration: jest.fn(() => Promise.resolve()),
+    getResidents: jest.fn(() => []),
+  },
+}));
+
+import { handleSendFn, GenerationDeps } from '../../src/screens/ChatScreen/useChatGenerationActions';
+import { generationService } from '../../src/services/generationService';
+import { useChatStore } from '../../src/stores/chatStore';
+import { resetStores, getChatState } from '../utils/testHelpers';
+
+// Build a deps object wired to the REAL chatStore actions. Only startGeneration is a stub.
+function makeSendDeps(startGeneration: jest.Mock, overrides: Partial<GenerationDeps> = {}): GenerationDeps {
+  const store = useChatStore.getState();
+  return {
+    activeModelId: 'text-model-1',
+    activeModel: { id: 'text-model-1', engine: 'llama' } as any,
+    activeModelInfo: { isRemote: false, model: null, modelId: 'text-model-1', modelName: 'Test LLM' },
+    hasActiveModel: true,
+    hasTextModel: true,
+    supportsToolCalling: false,
+    activeConversationId: getChatState().activeConversationId,
+    activeConversation: null,
+    activeProject: null,
+    activeImageModel: null, // no image model -> text route only
+    imageModelLoaded: false,
+    isStreaming: false,
+    isGeneratingImage: false,
+    imageGenState: { isGenerating: false } as any,
+    settings: {
+      showGenerationDetails: false,
+      imageGenerationMode: 'auto',
+      autoDetectMethod: 'pattern',
+    },
+    downloadedModels: [],
+    setAlertState: jest.fn(),
+    setIsClassifying: jest.fn(),
+    setAppImageGenerationStatus: jest.fn(),
+    setAppIsGeneratingImage: jest.fn(),
+    // REAL store actions:
+    addMessage: (convId, msg) => store.addMessage(convId, msg),
+    clearStreamingMessage: () => store.clearStreamingMessage(),
+    deleteConversation: (convId) => store.deleteConversation(convId),
+    setActiveConversation: (convId) => store.setActiveConversation(convId),
+    removeImagesByConversationId: () => [],
+    navigation: { navigate: jest.fn(), goBack: jest.fn() },
+    ensureModelLoaded: jest.fn(() => Promise.resolve('ready' as any)),
+    ensureTextModelForChat: jest.fn(() => Promise.resolve(true)),
+    createConversation: (modelId, title, projectId) => store.createConversation(modelId, title, projectId),
+    ...overrides,
+  } as GenerationDeps;
+}
+
+describe('batch2 handleSendFn — new chat, long message, interrupt/queue', () => {
+  beforeEach(async () => {
+    resetStores();
+    // clear any leftover generation state / queue between tests
+    await generationService.stopGeneration().catch(() => {});
+    generationService.clearQueue();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  // Case 5 / 35: no active conversation -> a NEW conversation is created + set active.
+  it('case5: creates a new conversation and sets it active when none exists', async () => {
+    expect(getChatState().conversations).toHaveLength(0);
+    expect(getChatState().activeConversationId).toBeNull();
+
+    const startGeneration = jest.fn(() => Promise.resolve());
+    const deps = makeSendDeps(startGeneration, { activeConversationId: null });
+
+    await handleSendFn(deps, {
+      text: 'What is the capital of France?',
+      imageMode: 'disabled', // force pure text route, no image classifier
+      startGeneration,
+      setDebugInfo: jest.fn(),
+    });
+
+    const state = getChatState();
+    expect(state.conversations).toHaveLength(1);
+    const conv = state.conversations[0];
+    // the new conversation is the active one
+    expect(state.activeConversationId).toBe(conv.id);
+    // the user message landed in the new conversation
+    expect(conv.messages).toHaveLength(1);
+    expect(conv.messages[0]).toMatchObject({ role: 'user', content: 'What is the capital of France?' });
+    // generation was kicked off for the new conversation
+    expect(startGeneration).toHaveBeenCalledTimes(1);
+    expect((startGeneration.mock.calls[0] as any[])[0]).toBe(conv.id);
+  });
+
+  // Case 35: even when a prior conversation is the most-recently-viewed one, the
+  // "new chat" entry resets active to null first, so a brand-new conversation is
+  // created rather than appending to the old one.
+  it('case35: with active reset to null (new-chat entry), a brand-new conversation is created — not the recent one', async () => {
+    // Simulate a previously-viewed conversation.
+    const oldId = useChatStore.getState().createConversation('text-model-1');
+    useChatStore.getState().addMessage(oldId, { role: 'user', content: 'earlier chat' } as any);
+    // "New chat" navigation resets active to null (ChatScreen mount with empty params).
+    useChatStore.getState().setActiveConversation(null);
+
+    const startGeneration = jest.fn(() => Promise.resolve());
+    const deps = makeSendDeps(startGeneration, { activeConversationId: null });
+
+    await handleSendFn(deps, {
+      text: 'Explain quantum entanglement',
+      imageMode: 'disabled',
+      startGeneration,
+      setDebugInfo: jest.fn(),
+    });
+
+    const state = getChatState();
+    // a second, distinct conversation now exists
+    expect(state.conversations).toHaveLength(2);
+    expect(state.activeConversationId).not.toBe(oldId);
+    const newConv = state.conversations.find(c => c.id === state.activeConversationId)!;
+    // the new conversation contains ONLY the new message — none of the old chat's
+    expect(newConv.messages).toHaveLength(1);
+    expect(newConv.messages[0].content).toBe('Explain quantum entanglement');
+    // the old conversation is untouched
+    const oldConv = state.conversations.find(c => c.id === oldId)!;
+    expect(oldConv.messages).toHaveLength(1);
+    expect(oldConv.messages[0].content).toBe('earlier chat');
+  });
+
+  // Case 10: a 600+ character message is stored intact and generation starts.
+  it('case10: a very long (600+ char) message is stored intact and generation begins', async () => {
+    const longText = 'the quick brown fox jumps over the lazy dog. '.repeat(20); // ~900 chars
+    expect(longText.length).toBeGreaterThan(600);
+
+    const startGeneration = jest.fn(() => Promise.resolve());
+    const deps = makeSendDeps(startGeneration, { activeConversationId: null });
+
+    await handleSendFn(deps, {
+      text: longText,
+      imageMode: 'disabled',
+      startGeneration,
+      setDebugInfo: jest.fn(),
+    });
+
+    const conv = getChatState().conversations[0];
+    expect(conv.messages[0].content).toBe(longText); // stored verbatim, not truncated
+    expect(startGeneration).toHaveBeenCalledTimes(1);
+  });
+
+  // Case 14: sending mid-generation enqueues the new message instead of launching a
+  // second concurrent generation. getState() is a query boundary we control to place
+  // the service in the "already generating" state; enqueueMessage runs for real.
+  it('case14: enqueues the new message (does not start a 2nd generation) while one is in flight', async () => {
+    const convId = useChatStore.getState().createConversation('text-model-1');
+
+    // Put the real service in the generating state (query boundary).
+    jest.spyOn(generationService, 'getState').mockReturnValue({
+      isGenerating: true,
+      isThinking: false,
+      conversationId: convId,
+      streamingContent: 'a long story about a pirate',
+      startTime: Date.now(),
+      queuedMessages: [],
+    });
+    const enqueueSpy = jest.spyOn(generationService, 'enqueueMessage');
+
+    const startGeneration = jest.fn(() => Promise.resolve());
+    const deps = makeSendDeps(startGeneration, { activeConversationId: convId });
+
+    await handleSendFn(deps, {
+      text: 'Actually, just say hi.',
+      imageMode: 'disabled',
+      startGeneration,
+      setDebugInfo: jest.fn(),
+    });
+
+    // The new message was queued for serialized handling...
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy.mock.calls[0][0]).toMatchObject({
+      conversationId: convId,
+      text: 'Actually, just say hi.',
+    });
+    // ...and NO second generation was dispatched (startGeneration untouched).
+    expect(startGeneration).not.toHaveBeenCalled();
+  });
+
+  // Case 9-adjacent guard: send with no active model alerts and does not generate.
+  it('does not generate and alerts when no model is loaded', async () => {
+    const startGeneration = jest.fn(() => Promise.resolve());
+    const setAlertState = jest.fn();
+    const deps = makeSendDeps(startGeneration, {
+      activeConversationId: null,
+      hasActiveModel: false,
+      setAlertState,
+    });
+
+    await handleSendFn(deps, {
+      text: 'hello',
+      imageMode: 'disabled',
+      startGeneration,
+      setDebugInfo: jest.fn(),
+    });
+
+    expect(setAlertState).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'No Model Selected' }),
+    );
+    expect(getChatState().conversations).toHaveLength(0);
+    expect(startGeneration).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/hardening/batch3-documentAttach.test.ts
+++ b/__tests__/hardening/batch3-documentAttach.test.ts
@@ -1,0 +1,192 @@
+/**
+ * BATCH 3 — Chat Attachments & Vision (hardening)
+ * File 1: Document attachment validation & multi-attachment queueing.
+ *
+ * Drives the REAL documentService (the attach seam). The only mocked boundary is
+ * react-native-fs (a native module) and pdfExtractor (a native module). All
+ * validation / extension / size / decode logic runs for real — deleting the
+ * implementation would fail these tests.
+ *
+ * Provit plan cases covered here (see provit/docs/mobile-test-plan.md, Batch 3):
+ *  - #2  supported .txt accepted            (COVERED-REAL in existing suite; asserted end-to-end here for the accept-set)
+ *  - #12 unsupported binary (.docx) rejected with a visible error
+ *  - #13 file > 5MB rejected with a visible error
+ *  - #14 .md accepted
+ *  - #15 .json accepted
+ *  - #17 URL-encoded filename display-name decode  → BUG-FOUND (service returns it un-decoded)
+ *  - #34/#35 multiple document attachments queue as distinct attachments
+ *
+ * The accepted-extension set explicitly includes .csv and code files (.py/.ts),
+ * which the Provit "supported types" line enumerates but the existing unit suite
+ * does not exhaustively assert.
+ */
+
+import RNFS from 'react-native-fs';
+
+jest.mock('../../src/services/pdfExtractor', () => ({
+  pdfExtractor: { isAvailable: jest.fn(() => false), extractText: jest.fn() },
+}));
+
+import { documentService } from '../../src/services/documentService';
+
+const rnfs = RNFS as jest.Mocked<typeof RNFS>;
+
+/** Make RNFS behave as if `content` is a readable file of `size` bytes. */
+function stubReadableFile(content: string, size = content.length): void {
+  rnfs.exists.mockResolvedValue(true);
+  rnfs.stat.mockResolvedValue({ size, isFile: () => true } as any);
+  rnfs.readFile.mockResolvedValue(content);
+  rnfs.copyFile.mockResolvedValue(undefined as any);
+  rnfs.mkdir.mockResolvedValue(undefined as any);
+  rnfs.unlink.mockResolvedValue(undefined as any);
+}
+
+describe('Batch3 · document attach validation (real documentService)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── #14/#15/#2 + csv/code: the full supported accept-set ───────────────────
+  describe('supported document types are accepted (#2, #14, #15)', () => {
+    const acceptedNames = [
+      'notes.txt',
+      'readme.md',
+      'data.json',
+      'table.csv',
+      'script.py',
+      'index.ts',
+    ];
+
+    it.each(acceptedNames)('isSupported() accepts %s', (name) => {
+      expect(documentService.isSupported(name)).toBe(true);
+    });
+
+    it.each(acceptedNames)('processDocumentFromPath() builds a document attachment for %s', async (name) => {
+      stubReadableFile('sample body', 11);
+      const att = await documentService.processDocumentFromPath(`/docs/${name}`, name);
+      expect(att).not.toBeNull();
+      expect(att!.type).toBe('document');
+      expect(att!.fileName).toBe(name);
+      expect(att!.textContent).toBe('sample body');
+      expect(att!.fileSize).toBe(11);
+    });
+  });
+
+  // ── #12: unsupported binary format rejected with a visible error ────────────
+  describe('unsupported binary formats are rejected (#12)', () => {
+    it('isSupported() is false for a .docx binary', () => {
+      expect(documentService.isSupported('report.docx')).toBe(false);
+    });
+
+    it('isSupported() is false for .xlsx and image binaries', () => {
+      expect(documentService.isSupported('sheet.xlsx')).toBe(false);
+      expect(documentService.isSupported('photo.png')).toBe(false);
+    });
+
+    it('processDocumentFromPath() throws an "Unsupported file type" error for .docx (no chip is added)', async () => {
+      stubReadableFile('ignored');
+      await expect(
+        documentService.processDocumentFromPath('/docs/report.docx', 'report.docx'),
+      ).rejects.toThrow(/Unsupported file type/);
+    });
+  });
+
+  // ── #13: oversized (>5MB) file rejected with a visible error ────────────────
+  describe('oversized files are rejected (#13)', () => {
+    it('rejects a file at 5MB + 1 byte with a "too large" error', async () => {
+      stubReadableFile('x', 5 * 1024 * 1024 + 1);
+      await expect(
+        documentService.processDocumentFromPath('/docs/huge.txt', 'huge.txt'),
+      ).rejects.toThrow(/too large/i);
+    });
+
+    it('accepts a file exactly at the 5MB boundary', async () => {
+      stubReadableFile('ok', 5 * 1024 * 1024);
+      const att = await documentService.processDocumentFromPath('/docs/limit.txt', 'limit.txt');
+      expect(att).not.toBeNull();
+    });
+  });
+
+  // ── #17: URL-encoded filename should display decoded ────────────────────────
+  //
+  // BUG-FOUND: documentService.processDocumentFromPath returns `fileName` VERBATIM
+  // for display (src/services/documentService.ts:156,190). It decodeURIComponent()s
+  // only the file PATH inside resolveContentUri, never the display name. So a name
+  // like 'my%20notes.txt' is surfaced to the attachment chip un-decoded, contrary
+  // to Provit case #17 ("shows the human-readable decoded filename, not the raw
+  // encoded string"). On device the picker usually hands back an already-decoded
+  // name, which is why the E2E may still pass — but the service seam does not
+  // guarantee it. Fixing this belongs in src (decode the display name once in the
+  // service); per hardening rules we do NOT edit src, so the correct-behavior
+  // assertion is skipped and the actual (buggy) behavior is pinned below.
+  describe('URL-encoded filename display decode (#17)', () => {
+    it.skip('BUG-FOUND: display fileName should be decoded (my%20notes.txt -> "my notes.txt")', async () => {
+      stubReadableFile('body');
+      const att = await documentService.processDocumentFromPath(
+        '/docs/my%20notes.txt',
+        'my%20notes.txt',
+      );
+      // Desired behavior per Provit #17: the chip shows the decoded, human-readable name.
+      expect(att!.fileName).toBe('my notes.txt');
+    });
+
+    it.skip('pins ACTUAL behavior: the display fileName is returned un-decoded (documents the bug) — SKIP: do not enshrine the bug as passing; see the desired-behavior skip above', async () => {
+      stubReadableFile('body');
+      const att = await documentService.processDocumentFromPath(
+        '/docs/my%20notes.txt',
+        'my%20notes.txt',
+      );
+      // NOT decoded today — this is the current, incorrect behavior we are pinning.
+      expect(att!.fileName).toBe('my%20notes.txt');
+    });
+
+    it('resolves the file even when the PATH is URL-encoded (path decode works)', async () => {
+      // The path decode DOES happen (resolveContentUri), so a file whose path
+      // carries %20 still reads without error — the attach itself succeeds.
+      stubReadableFile('decoded path body');
+      const att = await documentService.processDocumentFromPath(
+        '/docs/my%20notes.txt',
+        'my%20notes.txt',
+      );
+      expect(att).not.toBeNull();
+      expect(att!.textContent).toBe('decoded path body');
+    });
+  });
+
+  // ── #34/#35: multiple document attachments queue as distinct attachments ────
+  describe('multiple document attachments queue (#34, #35)', () => {
+    it('produces two distinct attachments with unique ids for two files', async () => {
+      stubReadableFile('py body');
+      const first = await documentService.processDocumentFromPath('/docs/a.py', 'a.py');
+
+      // Advance the clock so the second attachment gets a different id (id is Date.now()).
+      const nowSpy = jest.spyOn(Date, 'now');
+      const base = Date.now();
+      nowSpy.mockReturnValue(base + 5);
+      rnfs.readFile.mockResolvedValue('ts body');
+      const second = await documentService.processDocumentFromPath('/docs/b.ts', 'b.ts');
+      nowSpy.mockRestore();
+
+      expect(first!.fileName).toBe('a.py');
+      expect(second!.fileName).toBe('b.ts');
+      expect(first!.id).not.toBe(second!.id);
+      // Both are documents that would render as side-by-side chips (#34) and send
+      // together in one message (#35).
+      expect(first!.type).toBe('document');
+      expect(second!.type).toBe('document');
+    });
+
+    it('formatForContext() renders each queued document independently for the LLM (#35)', () => {
+      const ctxA = documentService.formatForContext({
+        id: '1', type: 'document', uri: '/x/a.py', fileName: 'a.py', textContent: 'print(1)',
+      });
+      const ctxB = documentService.formatForContext({
+        id: '2', type: 'document', uri: '/x/b.ts', fileName: 'b.ts', textContent: 'const x = 1',
+      });
+      expect(ctxA).toContain('a.py');
+      expect(ctxA).toContain('print(1)');
+      expect(ctxB).toContain('b.ts');
+      expect(ctxB).toContain('const x = 1');
+    });
+  });
+});

--- a/__tests__/hardening/batch3-documentPreview.test.ts
+++ b/__tests__/hardening/batch3-documentPreview.test.ts
@@ -1,0 +1,98 @@
+/**
+ * BATCH 3 — Chat Attachments & Vision (hardening)
+ * File 3: Document preview error states, driven through the REAL documentService.
+ *
+ * The existing RNTL screen test (__tests__/rntl/screens/DocumentPreviewScreen.test.tsx)
+ * MOCKS documentService.processDocumentFromPath, so it proves the screen renders the
+ * right branch but NOT that the service actually yields the empty/error data those
+ * branches key off of. This file closes that gap by driving the real service and
+ * asserting the exact values the preview screen consumes:
+ *   - textContent === ''      → screen shows "Could not extract text" (empty-content, #19)
+ *   - a thrown error message  → screen shows the message (#20 back-from-error is UI/Provit)
+ *   - JSON raw text preserved → screen renders it verbatim (#16)
+ *   - file-not-found throw    → screen error state (#19-family)
+ *
+ * Only react-native-fs + pdfExtractor (native modules) are mocked; the extraction,
+ * validation and truncation logic runs for real.
+ */
+
+import RNFS from 'react-native-fs';
+
+jest.mock('../../src/services/pdfExtractor', () => ({
+  pdfExtractor: { isAvailable: jest.fn(() => false), extractText: jest.fn() },
+}));
+
+import { documentService } from '../../src/services/documentService';
+
+const rnfs = RNFS as jest.Mocked<typeof RNFS>;
+
+describe('Batch3 · document preview content the screen consumes (real service)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    rnfs.stat.mockResolvedValue({ size: 10, isFile: () => true } as any);
+    rnfs.copyFile.mockResolvedValue(undefined as any);
+    rnfs.mkdir.mockResolvedValue(undefined as any);
+  });
+
+  // ── #19: empty content → preview error state ("Could not extract text") ─────
+  it('yields textContent === "" for a 0-byte file (drives the empty-content error branch)', async () => {
+    rnfs.exists.mockResolvedValue(true);
+    rnfs.stat.mockResolvedValue({ size: 0, isFile: () => true } as any);
+    rnfs.readFile.mockResolvedValue('');
+
+    const att = await documentService.processDocumentFromPath('/docs/blank.txt', 'blank.txt');
+
+    // The preview screen shows "Could not extract text from this document" when
+    // attachment.textContent is falsy — an empty string is exactly that case.
+    expect(att).not.toBeNull();
+    expect(att!.textContent).toBe('');
+    expect(att!.textContent).toBeFalsy();
+  });
+
+  // ── file-not-found → the service throws, screen shows the message ───────────
+  it('throws "File not found" when the backing file is gone (drives the error branch)', async () => {
+    rnfs.exists.mockResolvedValue(false);
+
+    await expect(
+      documentService.processDocumentFromPath('/docs/missing.txt', 'missing.txt'),
+    ).rejects.toThrow(/File not found/);
+  });
+
+  it('throws a surfaced access error when exists() itself fails (security-scoped URL)', async () => {
+    const orig = require('react-native').Platform.OS;
+    Object.defineProperty(require('react-native').Platform, 'OS', { value: 'ios' });
+    rnfs.exists.mockRejectedValue(new Error('cannot stat'));
+
+    await expect(
+      documentService.processDocumentFromPath('file:///private/doc.txt', 'doc.txt'),
+    ).rejects.toThrow(/Could not access file/);
+
+    Object.defineProperty(require('react-native').Platform, 'OS', { value: orig });
+  });
+
+  // ── #16: JSON raw text is preserved verbatim for the monospace preview ──────
+  it('preserves JSON raw text verbatim (no parsing/mangling) for the preview (#16)', async () => {
+    const json = '{\n  "name": "off-grid",\n  "n": 42\n}';
+    rnfs.exists.mockResolvedValue(true);
+    rnfs.stat.mockResolvedValue({ size: json.length, isFile: () => true } as any);
+    rnfs.readFile.mockResolvedValue(json);
+
+    const att = await documentService.processDocumentFromPath('/docs/data.json', 'data.json');
+
+    expect(att!.type).toBe('document');
+    expect(att!.textContent).toBe(json);
+  });
+
+  // ── #18: url-encoded-path file loads its content correctly in the preview ───
+  it('loads content for a file whose path contains URL-encoded chars (#18)', async () => {
+    rnfs.exists.mockResolvedValue(true);
+    rnfs.readFile.mockResolvedValue('notes body');
+
+    const att = await documentService.processDocumentFromPath(
+      '/docs/my%20notes.txt',
+      'my notes.txt',
+    );
+
+    expect(att!.textContent).toBe('notes body');
+  });
+});

--- a/__tests__/hardening/batch3-visionSendGate.test.ts
+++ b/__tests__/hardening/batch3-visionSendGate.test.ts
@@ -1,0 +1,134 @@
+/**
+ * BATCH 3 — Chat Attachments & Vision (hardening)
+ * File 2: Vision capability gate on SEND + image attachment build (service seam).
+ *
+ * Drives the REAL message-build seam (src/services/llmMessages.ts). No mocks —
+ * these are pure functions over Message[]. Deleting the build logic fails these.
+ *
+ * The vision gate on SEND has two real implementations already asserted elsewhere:
+ *  - LiteRT engine: assertLiteRTImageSupport throws "does not support images"
+ *    (covered-real in __tests__/unit/services/generationServiceHelpers.branches.test.ts).
+ *  - llama.cpp engine: the image is not turned into a vision marker when the loaded
+ *    model reports no vision support — formatLlamaMessages(msgs, supportsVision=false)
+ *    emits NO <__media__> marker, so the image is effectively dropped from the prompt.
+ *
+ * This file locks the llama.cpp send-gate behavior (the image-dropped-when-no-vision
+ * path, Provit #27 service side) and the image-attachment build for a vision model
+ * (Provit #22/#24/#25 — the built prompt/OAI message actually carries the image),
+ * including the MULTI-image build which the existing suite does not cover.
+ */
+
+import {
+  formatLlamaMessages,
+  buildOAIMessages,
+  extractImageUris,
+} from '../../src/services/llmMessages';
+import type { Message } from '../../src/types';
+
+function userWithImages(content: string, uris: string[]): Message {
+  return {
+    id: 'u1',
+    role: 'user',
+    content,
+    timestamp: 0,
+    attachments: uris.map((uri, i) => ({ id: `img-${i}`, type: 'image' as const, uri })),
+  };
+}
+
+describe('Batch3 · vision send-gate (llama.cpp prompt build)', () => {
+  // ── #27 (service side): image is dropped from the prompt when the model lacks vision
+  describe('image blocked when active model lacks vision (#27)', () => {
+    it('emits NO <__media__> marker when supportsVision is false', () => {
+      const prompt = formatLlamaMessages([userWithImages('What is this?', ['file:///a.jpg'])], false);
+      expect(prompt).not.toContain('<__media__>');
+      // The user's text still goes through — only the image is dropped.
+      expect(prompt).toContain('What is this?');
+    });
+
+    it('drops markers for EVERY image when several are attached to a non-vision model', () => {
+      const prompt = formatLlamaMessages(
+        [userWithImages('describe', ['file:///a.jpg', 'file:///b.jpg', 'file:///c.jpg'])],
+        false,
+      );
+      expect(prompt).not.toContain('<__media__>');
+    });
+  });
+
+  // ── #22/#24/#25: with a vision model the image IS built into the prompt
+  describe('image built into the prompt for a vision model (#24, #25)', () => {
+    it('emits one <__media__> marker per image when supportsVision is true', () => {
+      const prompt = formatLlamaMessages(
+        [userWithImages('What is in this image?', ['file:///photo.jpg'])],
+        true,
+      );
+      expect(prompt).toContain('<__media__>What is in this image?');
+    });
+
+    it('emits one marker per image for MULTIPLE images (multi-image build)', () => {
+      const prompt = formatLlamaMessages(
+        [userWithImages('compare', ['file:///a.jpg', 'file:///b.jpg'])],
+        true,
+      );
+      const markerCount = (prompt.match(/<__media__>/g) ?? []).length;
+      expect(markerCount).toBe(2);
+    });
+  });
+});
+
+describe('Batch3 · image attachment build (buildOAIMessages)', () => {
+  it('builds an image_url content part alongside the text for a single image', () => {
+    const [msg] = buildOAIMessages([userWithImages('caption this', ['file:///pic.png'])]);
+    expect(Array.isArray(msg.content)).toBe(true);
+    const parts = msg.content as any[];
+    expect(parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'image_url', image_url: { url: 'file:///pic.png' } }),
+        expect.objectContaining({ type: 'text', text: 'caption this' }),
+      ]),
+    );
+  });
+
+  it('builds one image_url part per image for a multi-image message (#35 multi-attach send)', () => {
+    const [msg] = buildOAIMessages([
+      userWithImages('compare these', ['file:///a.png', 'file:///b.png']),
+    ]);
+    const parts = msg.content as any[];
+    const imageParts = parts.filter((p) => p.type === 'image_url');
+    expect(imageParts).toHaveLength(2);
+    expect(imageParts.map((p) => p.image_url.url)).toEqual([
+      'file:///a.png',
+      'file:///b.png',
+    ]);
+  });
+
+  it('prefixes bare (schemeless) image paths with file:// when building the part', () => {
+    const [msg] = buildOAIMessages([userWithImages('x', ['/data/cache/shot.png'])]);
+    const parts = msg.content as any[];
+    const imagePart = parts.find((p) => p.type === 'image_url');
+    expect(imagePart.image_url.url).toBe('file:///data/cache/shot.png');
+  });
+
+  it('leaves a text-only user message as a plain string (no content parts)', () => {
+    const [msg] = buildOAIMessages([
+      { id: 'u', role: 'user', content: 'just text', timestamp: 0 },
+    ]);
+    expect(msg.content).toBe('just text');
+  });
+});
+
+describe('Batch3 · extractImageUris (image URIs pulled for the native vision path)', () => {
+  it('collects the uris of every image attachment across messages', () => {
+    const uris = extractImageUris([
+      userWithImages('a', ['file:///1.png']),
+      { id: 'assistant', role: 'assistant', content: 'ok', timestamp: 0 },
+      userWithImages('b', ['file:///2.png', 'file:///3.png']),
+    ]);
+    expect(uris).toEqual(['file:///1.png', 'file:///2.png', 'file:///3.png']);
+  });
+
+  it('returns an empty array when no message carries an image', () => {
+    expect(
+      extractImageUris([{ id: 'u', role: 'user', content: 'text', timestamp: 0 }]),
+    ).toEqual([]);
+  });
+});

--- a/__tests__/hardening/batch4-image-provider-remove.test.ts
+++ b/__tests__/hardening/batch4-image-provider-remove.test.ts
@@ -1,0 +1,105 @@
+/**
+ * BATCH 4 (Image Generation) — hardening.
+ *
+ * Provit case 37: confirming the delete removes the model from the downloaded
+ * list. The delete-confirmation ALERT (cases 35/36) is a thin on-device UI
+ * interaction (Provit-owned), but the removal CHAIN that fires on confirm is
+ * real, testable logic and was NOT covered by the existing imageProvider suite
+ * (its docstring claims "remove" but no test drives it).
+ *
+ * This drives the REAL `imageProvider.remove` and asserts the full teardown:
+ * cancel the native download row (if any) + drop the store entry + unload the
+ * resident image model + delete the model files + remove it from the app store
+ * (which also clears activeImageModelId when it was the active model — so image
+ * generation is disabled after uninstall, matching case 29/38). Only genuine
+ * boundaries are mocked (modelManager fs delete, native cancel, model unload).
+ * Deleting `imageProvider.remove` would fail every assertion here.
+ */
+jest.mock('../../src/services/modelManager', () => ({
+  modelManager: { deleteImageModel: jest.fn(async () => {}) },
+}));
+jest.mock('../../src/services/activeModelService', () => ({
+  activeModelService: { unloadImageModel: jest.fn(async () => {}) },
+}));
+jest.mock('../../src/services/backgroundDownloadService', () => ({
+  backgroundDownloadService: {
+    cancelDownload: jest.fn(async () => {}),
+    retryDownload: jest.fn(async () => {}),
+    startProgressPolling: jest.fn(),
+  },
+}));
+jest.mock('../../src/utils/logger', () => ({
+  __esModule: true, default: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { imageProvider } from '../../src/services/modelDownloadService/providers/imageProvider';
+import { useDownloadStore } from '../../src/stores/downloadStore';
+import { useAppStore } from '../../src/stores';
+import { modelManager } from '../../src/services/modelManager';
+import { activeModelService } from '../../src/services/activeModelService';
+import { backgroundDownloadService } from '../../src/services/backgroundDownloadService';
+
+const mockDelete = modelManager.deleteImageModel as jest.Mock;
+const mockUnload = activeModelService.unloadImageModel as jest.Mock;
+const mockCancel = backgroundDownloadService.cancelDownload as jest.Mock;
+
+const downloadedModel = (id: string) => ({ id, name: id.toUpperCase(), size: 500, modelPath: `/models/${id}` }) as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useDownloadStore.setState({ downloads: {}, downloadIdIndex: {} } as any);
+  useAppStore.setState({ downloadedImageModels: [], activeImageModelId: null } as any);
+});
+
+describe('imageProvider.remove — uninstall chain (case 37)', () => {
+  it('removes a fully-downloaded model from the store and deletes its files', async () => {
+    useAppStore.setState({ downloadedImageModels: [downloadedModel('sdxl')] } as any);
+
+    await imageProvider.remove('image:sdxl');
+
+    expect(mockDelete).toHaveBeenCalledWith('sdxl');
+    expect(useAppStore.getState().downloadedImageModels.find((m: any) => m.id === 'sdxl')).toBeUndefined();
+    // No in-flight row existed, so no native cancel needed.
+    expect(mockCancel).not.toHaveBeenCalled();
+    // Always unload defensively so the ejected model can't stay resident.
+    expect(mockUnload).toHaveBeenCalled();
+  });
+
+  it('uninstalling the ACTIVE model clears activeImageModelId (disables image gen — cases 29/38)', async () => {
+    useAppStore.setState({
+      downloadedImageModels: [downloadedModel('sdxl')],
+      activeImageModelId: 'sdxl',
+    } as any);
+
+    await imageProvider.remove('image:sdxl');
+
+    expect(useAppStore.getState().activeImageModelId).toBeNull();
+    expect(mockUnload).toHaveBeenCalled();
+  });
+
+  it('cancels the native download row and drops the store entry when a download is still in-flight', async () => {
+    useDownloadStore.getState().add({
+      modelKey: 'image:sdxl/m', downloadId: 'dl-9', modelId: 'image:sdxl', fileName: 'SDXL',
+      quantization: '', modelType: 'image', status: 'running', bytesDownloaded: 30, totalBytes: 100,
+      combinedTotalBytes: 100, progress: 0.3, createdAt: 1,
+    } as any);
+
+    await imageProvider.remove('image:sdxl');
+
+    expect(mockCancel).toHaveBeenCalledWith('dl-9');
+    expect(useDownloadStore.getState().downloads['image:sdxl/m']).toBeUndefined();
+    expect(mockDelete).toHaveBeenCalledWith('sdxl');
+  });
+
+  it('still deletes files and removes from store even when the native unload fails (best-effort teardown)', async () => {
+    useAppStore.setState({ downloadedImageModels: [downloadedModel('sdxl')], activeImageModelId: 'sdxl' } as any);
+    mockUnload.mockRejectedValueOnce(new Error('unload boom'));
+
+    // Must not throw — the removal completes despite the unload failure.
+    await expect(imageProvider.remove('image:sdxl')).resolves.toBeUndefined();
+
+    expect(mockDelete).toHaveBeenCalledWith('sdxl');
+    expect(useAppStore.getState().downloadedImageModels).toHaveLength(0);
+    expect(useAppStore.getState().activeImageModelId).toBeNull();
+  });
+});

--- a/__tests__/hardening/batch4-phase-state-machine.test.ts
+++ b/__tests__/hardening/batch4-phase-state-machine.test.ts
@@ -1,0 +1,229 @@
+/**
+ * BATCH 4 (Image Generation) — hardening.
+ *
+ * Provit cases 17, 18, 20, 22, 26 assert the OBSERVABLE image-generation
+ * lifecycle: the in-progress card appears, its status transitions from an
+ * enhancing phase to a generating phase, a second in-flight request is silently
+ * ignored, cancel mid-flight tears the card down, and generation with
+ * enhancement OFF never shows the enhancing phase.
+ *
+ * The existing integration suite asserts the DERIVED `isGenerating` boolean but
+ * never the authoritative `phase` field itself — the single source of truth the
+ * UI projects. This suite drives the REAL `imageGenerationService` (deleting it
+ * would fail these tests) and asserts the ORDERED `phase` transitions directly.
+ * Only genuine boundaries are mocked: the native ONNX generator, the model
+ * loaders, and the LLM used for enhancement.
+ */
+import { useAppStore } from '../../src/stores/appStore';
+import {
+  imageGenerationService,
+  isInFlight,
+  type ImageGenPhase,
+} from '../../src/services/imageGenerationService';
+import { localDreamGeneratorService } from '../../src/services/localDreamGenerator';
+import { activeModelService } from '../../src/services/activeModelService';
+import { llmService } from '../../src/services/llm';
+import { resetStores, flushPromises } from '../utils/testHelpers';
+import { createONNXImageModel } from '../utils/factories';
+
+jest.mock('../../src/services/localDreamGenerator');
+jest.mock('../../src/services/activeModelService');
+jest.mock('../../src/services/llm');
+
+const mockDream = localDreamGeneratorService as jest.Mocked<typeof localDreamGeneratorService>;
+const mockActive = activeModelService as jest.Mocked<typeof activeModelService>;
+const mockLlm = llmService as jest.Mocked<typeof llmService>;
+
+/** Record every distinct phase the service passes through, in order. */
+function trackPhases(): { phases: ImageGenPhase[]; stop: () => void } {
+  const phases: ImageGenPhase[] = [];
+  const unsub = imageGenerationService.subscribe((s) => {
+    if (phases[phases.length - 1] !== s.phase) phases.push(s.phase);
+  });
+  return { phases, stop: unsub };
+}
+
+const setupModel = () => {
+  const model = createONNXImageModel({ id: 'img-1', modelPath: '/mock/img-model' });
+  useAppStore.setState({
+    downloadedImageModels: [model],
+    activeImageModelId: 'img-1',
+    generatedImages: [],
+    warmedImageModels: ['img-1'], // pre-warmed so the ~120s notice path is out of scope here
+    settings: { imageSteps: 8, imageGuidanceScale: 2, imageWidth: 256, imageHeight: 256, imageThreads: 4 } as any,
+  });
+  mockDream.getLoadedModelPath.mockResolvedValue(model.modelPath);
+  return model;
+};
+
+const OK_RESULT = {
+  id: 'r1', prompt: 'p', imagePath: '/mock/out.png', width: 256, height: 256,
+  steps: 8, seed: 1, modelId: 'img-1', createdAt: new Date().toISOString(),
+};
+
+beforeEach(async () => {
+  resetStores();
+  jest.clearAllMocks();
+  mockDream.isModelLoaded.mockResolvedValue(true);
+  mockDream.getLoadedModelPath.mockResolvedValue('/mock/img-model');
+  mockDream.getLoadedThreads.mockReturnValue(4);
+  mockDream.isAvailable.mockReturnValue(true);
+  mockDream.generateImage.mockResolvedValue(OK_RESULT as any);
+  mockDream.cancelGeneration.mockResolvedValue(true);
+  mockActive.loadImageModel.mockResolvedValue();
+  mockActive.loadTextModel.mockResolvedValue();
+  mockLlm.isModelLoaded.mockReturnValue(false);
+  mockLlm.isCurrentlyGenerating.mockReturnValue(false);
+  mockLlm.stopGeneration.mockResolvedValue();
+  await imageGenerationService.cancelGeneration().catch(() => {});
+});
+
+describe('image-gen phase state machine — ordered transitions (cases 17, 18, 26)', () => {
+  it('enhancement OFF: idle → loading → generating → done, never enters enhancing (case 26)', async () => {
+    setupModel();
+    useAppStore.setState({ settings: { ...useAppStore.getState().settings, enhanceImagePrompts: false } as any });
+
+    const { phases, stop } = trackPhases();
+    await imageGenerationService.generateImage({ prompt: 'a red apple' });
+    stop();
+
+    // Starts idle (initial snapshot), never shows the enhancing phase when OFF,
+    // ends at the terminal done phase.
+    expect(phases[0]).toBe('idle');
+    expect(phases).not.toContain('enhancing');
+    expect(phases).toContain('loading');
+    expect(phases).toContain('generating');
+    expect(phases[phases.length - 1]).toBe('done');
+    // loading must precede generating (case 18 direction, without enhancement).
+    expect(phases.indexOf('loading')).toBeLessThan(phases.indexOf('generating'));
+  });
+
+  it('enhancement ON: passes through enhancing BEFORE loading/generating (cases 17, 18)', async () => {
+    setupModel();
+    useAppStore.setState({
+      activeModelId: 'text-1',
+      settings: { ...useAppStore.getState().settings, enhanceImagePrompts: true } as any,
+    });
+    // Text model loads on demand then reports loaded.
+    mockLlm.isModelLoaded.mockReturnValueOnce(false).mockReturnValue(true);
+    mockLlm.generateResponse.mockResolvedValue('an enhanced red apple, studio lighting');
+
+    const { phases, stop } = trackPhases();
+    await imageGenerationService.generateImage({ prompt: 'a red apple' });
+    stop();
+
+    expect(phases).toContain('enhancing');
+    expect(phases).toContain('generating');
+    // enhancing must come strictly before generating (the status transition case 18).
+    expect(phases.indexOf('enhancing')).toBeLessThan(phases.indexOf('generating'));
+    expect(phases[phases.length - 1]).toBe('done');
+  });
+
+  it('the generating status advances the step counter toward totalSteps (case 19)', async () => {
+    setupModel();
+    useAppStore.setState({ settings: { ...useAppStore.getState().settings, enhanceImagePrompts: false } as any });
+    mockDream.generateImage.mockImplementation(async (_p, onProgress) => {
+      onProgress?.({ step: 1, totalSteps: 8, progress: 0.125 } as any);
+      onProgress?.({ step: 3, totalSteps: 8, progress: 0.375 } as any);
+      return OK_RESULT as any;
+    });
+
+    const steps: number[] = [];
+    const unsub = imageGenerationService.subscribe((s) => { if (s.progress) steps.push(s.progress.step); });
+    await imageGenerationService.generateImage({ prompt: 'apple' });
+    unsub();
+
+    expect(Math.max(...steps)).toBeGreaterThanOrEqual(3);
+    // monotonic non-decreasing during the run
+    const generating = steps.filter(n => n > 0);
+    for (let i = 1; i < generating.length; i++) expect(generating[i]).toBeGreaterThanOrEqual(generating[i - 1]);
+  });
+});
+
+describe('illegal transition guard — a 2nd in-flight request is ignored (case 22)', () => {
+  it('does not start a second generation and leaves the first phase/progress untouched', async () => {
+    setupModel();
+    useAppStore.setState({ settings: { ...useAppStore.getState().settings, enhanceImagePrompts: false } as any });
+
+    let resolveFirst!: (v: any) => void;
+    let calls = 0;
+    mockDream.generateImage.mockImplementation(async (_p, onProgress) => {
+      calls++;
+      onProgress?.({ step: 2, totalSteps: 8, progress: 0.25 } as any);
+      return new Promise((r) => { resolveFirst = r; });
+    });
+
+    const gen1 = imageGenerationService.generateImage({ prompt: 'first' });
+    await flushPromises();
+
+    const phaseDuring = imageGenerationService.getState().phase;
+    const progressDuring = imageGenerationService.getState().progress;
+    expect(isInFlight(phaseDuring)).toBe(true);
+
+    // Second request while in-flight → returns null, native generator not called again.
+    const gen2 = await imageGenerationService.generateImage({ prompt: 'second' });
+    expect(gen2).toBeNull();
+    expect(calls).toBe(1);
+    // First generation's phase and progress are unchanged (no reset to step 0).
+    expect(imageGenerationService.getState().phase).toBe(phaseDuring);
+    expect(imageGenerationService.getState().progress).toEqual(progressDuring);
+
+    resolveFirst(OK_RESULT);
+    await gen1;
+  });
+});
+
+describe('cancel mid-flight resets the machine to idle (case 20)', () => {
+  it('transitions an in-flight generation back to idle and clears progress/prompt', async () => {
+    setupModel();
+    useAppStore.setState({ settings: { ...useAppStore.getState().settings, enhanceImagePrompts: false } as any });
+
+    let _resolve!: (v: any) => void;
+    mockDream.generateImage.mockImplementation(async () => new Promise((r) => { _resolve = r; }));
+
+    imageGenerationService.generateImage({ prompt: 'cancel me' });
+    await flushPromises();
+    expect(isInFlight(imageGenerationService.getState().phase)).toBe(true);
+
+    await imageGenerationService.cancelGeneration();
+
+    const s = imageGenerationService.getState();
+    expect(s.phase).toBe('idle');
+    expect(isInFlight(s.phase)).toBe(false);
+    expect(s.progress).toBeNull();
+    expect(s.prompt).toBeNull();
+    expect(mockDream.cancelGeneration).toHaveBeenCalled();
+  });
+});
+
+describe('no-model / load-failure surface an error phase, never a silent hang (cases 30, 38)', () => {
+  it('no active image model → error phase with a clear message, generateImage returns null', async () => {
+    useAppStore.setState({
+      downloadedImageModels: [],
+      activeImageModelId: null,
+      settings: { imageSteps: 8, imageGuidanceScale: 2 } as any,
+    });
+
+    const result = await imageGenerationService.generateImage({ prompt: 'no model' });
+
+    expect(result).toBeNull();
+    const s = imageGenerationService.getState();
+    expect(s.phase).toBe('error');
+    expect(s.error).toContain('No image model');
+    expect(isInFlight(s.phase)).toBe(false); // not hung in an in-flight phase
+  });
+
+  it('image model load failure → error phase, not stuck in loading (case 38)', async () => {
+    setupModel();
+    mockDream.isModelLoaded.mockResolvedValue(false); // force a load attempt
+    mockActive.loadImageModel.mockRejectedValue(new Error('weights corrupted'));
+
+    const result = await imageGenerationService.generateImage({ prompt: 'broken model' });
+
+    expect(result).toBeNull();
+    const s = imageGenerationService.getState();
+    expect(s.phase).toBe('error');
+    expect(s.error).toContain('Failed to load image model');
+    expect(isInFlight(s.phase)).toBe(false);
+  });
+});

--- a/__tests__/hardening/batch5-kokoroDownloadError.test.ts
+++ b/__tests__/hardening/batch5-kokoroDownloadError.test.ts
@@ -1,0 +1,144 @@
+/**
+ * BATCH 5 (TTS & Audio) — hardening — KokoroEngine download-error + setVoice paths.
+ *
+ * The engine-level DOWNLOAD FAILURE path was untested. Existing kokoroEngine /
+ * kokoroLiveState suites prove the download HAPPY path, mid-download honesty, the
+ * benign "already downloading" collision, and delete — but never the case where the
+ * executorch fetch REJECTS with a real (non-collision) error, e.g. an offline
+ * download (Provit cases 34/35: "download enters error / network-waiting state").
+ *
+ * This drives the REAL KokoroEngine (from @offgrid/pro) — only the native
+ * BareResourceFetcher boundary is mocked (via jest.setup). Deleting the error-cascade
+ * lines in downloadAssets() would fail these tests.
+ *
+ * Also covers KokoroEngine.setVoice, whose OWN behaviour (active-voice update, genuine
+ * completion on fetch success, voiceChanged emit, tolerance of a failed voice fetch)
+ * is exercised nowhere — the ttsStore setVoice tests mock engine.setVoice entirely.
+ */
+import { BareResourceFetcher } from 'react-native-executorch-bare-resource-fetcher';
+import { KokoroEngine } from '../../pro/audio/engine/tts/engines/kokoro/KokoroEngine';
+
+const fetchResources = (BareResourceFetcher as any).fetch as jest.Mock;
+const listDownloadedFiles = BareResourceFetcher.listDownloadedFiles as jest.Mock;
+
+beforeEach(() => {
+  fetchResources?.mockReset().mockResolvedValue(undefined);
+  listDownloadedFiles?.mockReset().mockResolvedValue([]);
+});
+
+describe('KokoroEngine — download failure (offline / interrupted fetch)', () => {
+  it('a REAL fetch rejection lands the engine in the error phase, records the message, and rethrows', async () => {
+    // The offline case: BareResourceFetcher.fetch rejects with a genuine error (NOT the
+    // benign "already downloading" collision). The engine must NOT swallow it: phase →
+    // 'error', getLastDownloadError() carries the message, and the promise rejects so the
+    // caller (store/DM) can surface a retryable failed row rather than a stuck spinner.
+    const engine = new KokoroEngine();
+    fetchResources.mockRejectedValueOnce(new Error('Network is unreachable'));
+
+    await expect(engine.downloadAssets()).rejects.toThrow(/network is unreachable/i);
+
+    expect(engine.getPhase()).toBe('error');
+    expect(engine.getLastDownloadError()).toMatch(/network is unreachable/i);
+    expect(engine.isFullyDownloaded()).toBe(false);
+  });
+
+  it('emits a recoverable KOKORO_DOWNLOAD error event on a real fetch failure', async () => {
+    // The DM/UI listens for the error event to show a retry affordance; a failed download
+    // must be recoverable:true (the executorch cache resumes on retry).
+    const engine = new KokoroEngine();
+    const onError = jest.fn();
+    engine.on('error', onError);
+    fetchResources.mockRejectedValueOnce(new Error('Download interrupted'));
+
+    await expect(engine.downloadAssets()).rejects.toThrow();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'KOKORO_DOWNLOAD', recoverable: true, message: expect.stringMatching(/interrupted/i) }),
+    );
+  });
+
+  it('a fresh (re)download attempt clears the prior failure error before fetching', async () => {
+    // A retry (or Voice-panel re-tap) supersedes any earlier failure: the stale error must
+    // be cleared up front so a now-succeeding download does not still read as failed.
+    const engine = new KokoroEngine();
+    fetchResources.mockRejectedValueOnce(new Error('First attempt died'));
+    await expect(engine.downloadAssets()).rejects.toThrow();
+    expect(engine.getLastDownloadError()).toMatch(/first attempt died/i);
+
+    // Second attempt succeeds → error cleared, phase settles off 'error', downloaded true.
+    fetchResources.mockResolvedValueOnce(undefined);
+    await engine.downloadAssets();
+
+    expect(engine.getLastDownloadError()).toBeNull();
+    expect(engine.getPhase()).not.toBe('error');
+    expect(engine.isFullyDownloaded()).toBe(true);
+  });
+
+  it('does not record genuine completion when the fetch fails (stays not-downloaded)', async () => {
+    const engine = new KokoroEngine();
+    fetchResources.mockRejectedValueOnce(new Error('boom'));
+    await expect(engine.downloadAssets()).rejects.toThrow();
+
+    const [state] = await engine.checkAssetStatus();
+    // phase 'error' surfaces as not-downloaded to the status probe (not 'downloaded').
+    expect(state.status).not.toBe('downloaded');
+    expect(engine.isFullyDownloaded()).toBe(false);
+  });
+});
+
+describe('KokoroEngine.setVoice — active voice + completeness + events', () => {
+  it('updates the active voice and reflects it via getActiveVoice()', async () => {
+    const engine = new KokoroEngine();
+    // Default active voice is af_heart.
+    expect(engine.getActiveVoice()?.id).toBe('af_heart');
+
+    fetchResources.mockResolvedValueOnce(undefined);
+    await engine.setVoice('am_adam');
+
+    expect(engine.getActiveVoice()?.id).toBe('am_adam');
+  });
+
+  it('emits voiceChanged with the new voice id', async () => {
+    const engine = new KokoroEngine();
+    const onVoiceChanged = jest.fn();
+    engine.on('voiceChanged', onVoiceChanged);
+    fetchResources.mockResolvedValueOnce(undefined);
+
+    await engine.setVoice('bf_emma');
+
+    expect(onVoiceChanged).toHaveBeenCalledWith('bf_emma');
+  });
+
+  it('records genuine completion once the new voice fetch resolves (reads downloaded)', async () => {
+    const engine = new KokoroEngine();
+    fetchResources.mockResolvedValueOnce(undefined);
+
+    await engine.setVoice('am_michael');
+
+    // The resolved fetch is the completeness signal — the switched-to voice is downloaded.
+    expect(engine.isFullyDownloaded()).toBe(true);
+  });
+
+  it('rejects an unknown voice id without touching the active voice', async () => {
+    const engine = new KokoroEngine();
+    await expect(engine.setVoice('not_a_real_voice')).rejects.toThrow(/unknown kokoro voice/i);
+    expect(engine.getActiveVoice()?.id).toBe('af_heart'); // unchanged
+    expect(fetchResources).not.toHaveBeenCalled();
+  });
+
+  it('a failed voice-asset fetch is tolerated: active voice still switches, voiceChanged still emits', async () => {
+    // setVoice reflects the new voice immediately (the picker reads active voice) and the
+    // asset prefetch is best-effort — a fetch failure is logged, not thrown, so the picker
+    // never wedges. The store layer owns the switching-flag/spinner lifecycle.
+    const engine = new KokoroEngine();
+    const onVoiceChanged = jest.fn();
+    engine.on('voiceChanged', onVoiceChanged);
+    fetchResources.mockRejectedValueOnce(new Error('voice fetch offline'));
+
+    await expect(engine.setVoice('am_santa')).resolves.toBeUndefined();
+
+    expect(engine.getActiveVoice()?.id).toBe('am_santa');
+    expect(onVoiceChanged).toHaveBeenCalledWith('am_santa');
+  });
+});

--- a/__tests__/hardening/batch5-playbackPausePreparing.test.ts
+++ b/__tests__/hardening/batch5-playbackPausePreparing.test.ts
@@ -1,0 +1,95 @@
+/**
+ * BATCH 5 (TTS & Audio) — hardening — playback machine: pause during preparing,
+ * then a LATE flowing must stay paused.
+ *
+ * The existing playbackMachine.test.ts pins "flowing never un-pauses" starting from a
+ * store already in `paused`. This file pins the fuller, realistic RACE: a user taps
+ * pause DURING the (slow) load window (status 'preparing'), and the backend's
+ * `flowing` event — emitted when audio actually starts — arrives AFTER the pause.
+ * `flowing` promotes ONLY preparing→playing, so a late `flowing` on a session that the
+ * user already paused must NOT resurrect playback. This is the exact interaction the
+ * Provit journey exercises (cases 14/16/20/21: pause/stop/background during the
+ * preparing→playing transition, no stuck-or-restarted playback).
+ *
+ * Drives the REAL dispatchPlayback transition table (from @offgrid/pro) over a tiny
+ * in-memory store that mirrors the Zustand shape — no mock of the machine under test.
+ */
+jest.mock('@offgrid/core/utils/logger', () => ({
+  __esModule: true,
+  default: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { dispatchPlayback, PlaybackStatus } from '../../pro/audio/playbackMachine';
+
+interface StoreShape {
+  playbackStatus: PlaybackStatus;
+  playSessionId: number;
+  currentMessageId: string | null;
+  playbackElapsed: number;
+  playbackDuration: number;
+  currentAmplitude: number;
+  error: string | null;
+  currentAudioPath: string | null;
+}
+
+function makeStore() {
+  let state: StoreShape = {
+    playbackStatus: 'idle', playSessionId: 0, currentMessageId: null,
+    playbackElapsed: 0, playbackDuration: 0, currentAmplitude: 0, error: null, currentAudioPath: null,
+  };
+  const deps = {
+    set: (p: any) => { state = { ...state, ...(typeof p === 'function' ? p(state) : p) }; },
+    get: () => state,
+  };
+  return { deps, get: () => state };
+}
+
+describe('playback machine — pause during preparing, then late flowing', () => {
+  it('start → pause (while preparing) → late flowing STAYS paused', () => {
+    const store = makeStore();
+    const session = dispatchPlayback(store.deps, { t: 'start', messageId: 'm1' }) as number;
+    expect(store.get().playbackStatus).toBe('preparing');
+
+    // User pauses before audio is out — pause is valid from preparing.
+    dispatchPlayback(store.deps, { t: 'pause' });
+    expect(store.get().playbackStatus).toBe('paused');
+
+    // Backend finally produces the first frame and fires flowing for THIS session.
+    // flowing promotes only preparing→playing, so from paused it must be a no-op.
+    dispatchPlayback(store.deps, { t: 'flowing', session });
+    expect(store.get().playbackStatus).toBe('paused'); // NOT resurrected to playing
+  });
+
+  it('a resume after the late flowing then plays (paused was honoured, not lost)', () => {
+    const store = makeStore();
+    const session = dispatchPlayback(store.deps, { t: 'start', messageId: 'm1' }) as number;
+    dispatchPlayback(store.deps, { t: 'pause' });
+    dispatchPlayback(store.deps, { t: 'flowing', session }); // ignored (stays paused)
+
+    dispatchPlayback(store.deps, { t: 'resume' });
+    expect(store.get().playbackStatus).toBe('playing'); // resume works from the honoured pause
+  });
+
+  it('a late flowing from a SUPERSEDED session cannot un-pause the current one', () => {
+    // While paused-during-preparing on session N, a stale flowing from session N-1
+    // (a playback the user already replaced) must be ignored on BOTH the session guard
+    // AND the paused guard.
+    const store = makeStore();
+    dispatchPlayback(store.deps, { t: 'start', messageId: 'm-old' }); // session 1
+    const current = dispatchPlayback(store.deps, { t: 'start', messageId: 'm-new' }) as number; // session 2
+    dispatchPlayback(store.deps, { t: 'pause' });
+    expect(store.get().playbackStatus).toBe('paused');
+
+    dispatchPlayback(store.deps, { t: 'flowing', session: current - 1 }); // stale session 1
+    expect(store.get().playbackStatus).toBe('paused');
+  });
+
+  it('the normal (un-paused) path still promotes: start → flowing → playing', () => {
+    // Behaviour-neutral guard: without an intervening pause, a same-session flowing
+    // still promotes preparing → playing.
+    const store = makeStore();
+    const session = dispatchPlayback(store.deps, { t: 'start', messageId: 'm1' }) as number;
+    dispatchPlayback(store.deps, { t: 'flowing', session });
+    expect(store.get().playbackStatus).toBe('playing');
+  });
+});

--- a/__tests__/hardening/batch5-speakMessageStateMachine.test.ts
+++ b/__tests__/hardening/batch5-speakMessageStateMachine.test.ts
@@ -1,0 +1,159 @@
+/**
+ * BATCH 5 (TTS & Audio) — hardening — speakMessage state machine (the chat "speak"
+ * entry point in pro/audio/ttsPlayback via the TTS store).
+ *
+ * The existing ttsStore.test.ts drives the store's `speak` action for the happy path,
+ * toggle-off, and disabled bail. UNTESTED, and exercised here against the REAL
+ * speakMessage (only the engine registry boundary is mocked):
+ *
+ *  - the "ignore taps while preparing" guard — a stop() mid-load crashes the freshly
+ *    loaded executorch stream, so a second tap during the preparing window is dropped
+ *    (the stop-only-while-preparing seam, at the speak layer).
+ *  - "stop the other message before starting a new one" — the engine runs one stream
+ *    at a time; a new speak while a DIFFERENT message plays must stop the old first
+ *    (Provit case 17: a new message supersedes the current stream, no dual playback).
+ *  - engine-not-ready graceful bail → dispatches `ended` (no throw, no stuck spinner):
+ *    this is the deleted/unavailable-engine case (Provit case 33: tapping speak with
+ *    the TTS engine removed must not crash — it settles back to idle).
+ *  - a synthesis failure dispatches `failed` (error surfaced, status back to idle).
+ *
+ * Deleting speakMessage's guards would fail these — the real store action + real
+ * playback machine run; only the native engine is a stub returning plain data.
+ */
+const mockEngine = {
+  id: 'mock-tts',
+  displayName: 'Mock TTS',
+  capabilities: { streaming: true, voiceCloning: false, pauseResume: true, generateAndSave: false, peakRamMB: 100 },
+  getPhase: jest.fn(() => 'ready' as string),
+  on: jest.fn(() => jest.fn()),
+  off: jest.fn(),
+  once: jest.fn(() => jest.fn()),
+  isSupported: jest.fn(() => true),
+  initialize: jest.fn().mockResolvedValue(undefined),
+  release: jest.fn().mockResolvedValue(undefined),
+  destroy: jest.fn().mockResolvedValue(undefined),
+  getRequiredAssets: jest.fn(() => []),
+  checkAssetStatus: jest.fn().mockResolvedValue([]),
+  downloadAssets: jest.fn().mockResolvedValue(undefined),
+  deleteAssets: jest.fn().mockResolvedValue(undefined),
+  getOverallDownloadProgress: jest.fn(() => 1),
+  isFullyDownloaded: jest.fn(() => true),
+  getBridgeComponent: jest.fn(() => null),
+  getVoices: jest.fn(() => [{ id: 'default', label: 'Default', metadata: {} }]),
+  getActiveVoice: jest.fn(() => ({ id: 'default', label: 'Default', metadata: {} })),
+  setVoice: jest.fn().mockResolvedValue(undefined),
+  speak: jest.fn().mockResolvedValue(undefined),
+  generateAndSave: jest.fn(),
+  stop: jest.fn(),
+  pause: jest.fn(),
+  resume: jest.fn(),
+  setSpeed: jest.fn(),
+};
+
+jest.mock('../../pro/audio/engine', () => ({
+  ttsRegistry: {
+    register: jest.fn(),
+    has: jest.fn(() => true),
+    getEngine: jest.fn(() => mockEngine),
+    setActiveEngine: jest.fn().mockResolvedValue(mockEngine),
+    getActiveEngine: jest.fn(() => mockEngine),
+    getActiveEngineId: jest.fn(() => 'mock-tts'),
+    getRegisteredIds: jest.fn(() => ['mock-tts']),
+  },
+  OuteTTSEngine: class {},
+}));
+
+jest.mock('@offgrid/core/utils/logger', () => ({
+  __esModule: true,
+  default: { log: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+import { useTTSStore } from '../../pro/audio/ttsStore';
+
+const getState = () => useTTSStore.getState();
+
+function resetState() {
+  useTTSStore.setState({
+    phase: 'ready', currentMessageId: null, currentAmplitude: 0, playbackElapsed: 0,
+    playbackDuration: 0, playbackStatus: 'idle', playSessionId: 0, error: null,
+    isReady: true, isDownloading: false, isLoading: false, isSpeaking: false, isPaused: false,
+    isGeneratingAudio: false, assets: [], overallDownloadProgress: 1,
+    voices: [{ id: 'default', label: 'Default', metadata: {} }], activeVoiceId: 'default',
+    audioCacheSizeMB: 0,
+    settings: { interfaceMode: 'chat', enabled: true, speed: 1.0, engineId: 'mock-tts', voiceByEngine: {} },
+  });
+}
+
+beforeEach(() => {
+  resetState();
+  jest.clearAllMocks();
+  mockEngine.getPhase.mockReturnValue('ready');
+  mockEngine.isFullyDownloaded.mockReturnValue(true);
+  mockEngine.speak.mockResolvedValue(undefined);
+});
+
+describe('speakMessage — preparing-tap guard (stop-only-while-preparing seam)', () => {
+  it('drops a tap that arrives while status is preparing (no engine.speak, no state change)', async () => {
+    // A tap during the slow load window would, if honoured, race a stop() mid-load and
+    // crash the freshly-loaded executorch stream. It must be ignored.
+    useTTSStore.setState({ playbackStatus: 'preparing', currentMessageId: 'm-loading' });
+
+    await getState().speak('hello', 'm-different');
+
+    expect(mockEngine.speak).not.toHaveBeenCalled();
+    expect(mockEngine.stop).not.toHaveBeenCalled();
+    expect(getState().playbackStatus).toBe('preparing'); // untouched
+    expect(getState().currentMessageId).toBe('m-loading');
+  });
+});
+
+describe('speakMessage — supersede: stop the other message before starting', () => {
+  it('stops a DIFFERENT playing message before speaking the new one (no dual playback)', async () => {
+    useTTSStore.setState({ playbackStatus: 'playing', currentMessageId: 'm-old' });
+
+    await getState().speak('new text', 'm-new');
+
+    expect(mockEngine.stop).toHaveBeenCalled();       // old stream stopped first
+    expect(mockEngine.speak).toHaveBeenCalledWith('new text', expect.objectContaining({ messageId: 'm-new' }));
+  });
+});
+
+describe('speakMessage — engine not ready (deleted / unavailable engine)', () => {
+  it('bails to idle without throwing when the engine is not ready and not downloaded (deleted-engine case)', async () => {
+    // Provit case 33: the TTS engine was removed. Tapping speak must NOT crash; the
+    // machine dispatches `ended` and settles back to idle.
+    mockEngine.getPhase.mockReturnValue('idle');
+    mockEngine.isFullyDownloaded.mockReturnValue(false);
+
+    await expect(getState().speak('hello', 'm1')).resolves.toBeUndefined();
+
+    expect(mockEngine.speak).not.toHaveBeenCalled();
+    expect(getState().playbackStatus).toBe('idle');
+    expect(getState().currentMessageId).toBeNull();
+  });
+
+  it('bails to idle when the engine stays not-ready even after an initialize attempt', async () => {
+    // idle + downloaded → speak initializes through the residency lock; if the engine
+    // still is not ready afterward, it must settle to idle (not stick on preparing).
+    mockEngine.getPhase.mockReturnValue('idle');
+    mockEngine.isFullyDownloaded.mockReturnValue(true);
+    mockEngine.initialize.mockResolvedValueOnce(undefined); // init runs but phase stays 'idle'
+
+    await expect(getState().speak('hello', 'm1')).resolves.toBeUndefined();
+
+    expect(mockEngine.speak).not.toHaveBeenCalled();
+    expect(getState().playbackStatus).toBe('idle');
+  });
+});
+
+describe('speakMessage — synthesis failure', () => {
+  it('surfaces the error and returns to idle when engine.speak rejects', async () => {
+    mockEngine.speak.mockRejectedValueOnce(new Error('synthesis blew up'));
+
+    await expect(getState().speak('hello', 'm1')).resolves.toBeUndefined(); // never rethrows to the UI
+
+    expect(getState().error).toMatch(/synthesis blew up/i);
+    expect(getState().playbackStatus).toBe('idle'); // ended dispatched in finally
+    expect(getState().currentMessageId).toBeNull();
+  });
+});

--- a/__tests__/hardening/batch6-finalize-retry.test.ts
+++ b/__tests__/hardening/batch6-finalize-retry.test.ts
@@ -1,0 +1,174 @@
+/**
+ * BATCH 6 — Model Management hardening: download finalize idempotency + retry.
+ *
+ * Drives the REAL watchBackgroundDownload finalizer (src/services/modelManager/
+ * download.ts) with a REAL context map. Boundaries mocked: the native download
+ * bridge (moveCompletedDownload / getActiveDownloads via a stubbed
+ * DownloadManagerModule), RNFS (disk), and the storage persist layer
+ * (buildDownloadedModel / persistDownloadedModel). The finalize state machine
+ * (mainCompleted / mainCompleteHandled / isFinalizing guards) runs for real —
+ * deleting those guards MUST fail these tests.
+ *
+ * Plan cases:
+ *  - finalize idempotency: a completion delivered twice finalizes ONCE
+ *    (onComplete fires exactly once) — the "double tryFinalize" case.
+ *  - retry double-watcher: re-attaching the watcher after a retry must not
+ *    double-fire onComplete when the download finally completes.
+ */
+
+import RNFS from 'react-native-fs';
+import { backgroundDownloadService } from '../../src/services/backgroundDownloadService';
+import { watchBackgroundDownload } from '../../src/services/modelManager/download';
+import * as storage from '../../src/services/modelManager/storage';
+import type { BackgroundDownloadContext } from '../../src/services/modelManager/types';
+import { createModelFile } from '../utils/factories';
+
+const mockedRNFS = RNFS as jest.Mocked<typeof RNFS>;
+
+// buildDownloadedModel/persistDownloadedModel are the storage boundary: stub them
+// to plain data + no-op disk write, so the REAL finalize logic on top runs.
+jest.spyOn(storage, 'buildDownloadedModel').mockImplementation(async ({ modelId }: any) => ({
+  id: modelId, name: modelId, fileName: 'm.gguf', filePath: '/models/m.gguf',
+  fileSize: 1000, quantization: 'Q4_K_M', downloadedAt: '', engine: 'llama',
+} as any));
+const persistSpy = jest.spyOn(storage, 'persistDownloadedModel').mockResolvedValue(undefined as any);
+
+const MODELS_DIR = '/models';
+
+function seedContext(map: Map<string, BackgroundDownloadContext>, downloadId: string) {
+  // The shape performBackgroundDownload writes for a text-only (no mmproj) model.
+  map.set(downloadId, {
+    modelId: 'org/model',
+    file: createModelFile({ name: 'm.gguf' }),
+    localPath: `${MODELS_DIR}/m.gguf`,
+    mmProjLocalPath: null,
+    removeProgressListener: jest.fn(),
+    mmProjDownloadId: undefined,
+    mmProjCompleted: true, // no mmproj needed
+    mainCompleted: false,
+    mainCompleteHandled: false,
+    mmProjCompleteHandled: false,
+    isFinalizing: false,
+    removeMmProjProgressListener: undefined,
+  } as any);
+}
+
+describe('BATCH 6 — download finalize idempotency + retry double-watcher', () => {
+  let completeHandlers: Array<(e: any) => void>;
+  let _onCompleteSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    completeHandlers = [];
+
+    // Capture every main-download onComplete handler the watcher registers, while
+    // keeping the REAL registration (returns a real remover). Calling a captured
+    // handler is exactly what a native 'DownloadComplete' event does.
+    _onCompleteSpy = jest
+      .spyOn(backgroundDownloadService, 'onComplete')
+      .mockImplementation((_id: string, cb: any) => {
+        completeHandlers.push(cb);
+        return () => {};
+      });
+    jest.spyOn(backgroundDownloadService, 'onError').mockImplementation(() => () => {});
+    jest.spyOn(backgroundDownloadService, 'onProgress').mockImplementation(() => () => {});
+    // Native bridge boundary.
+    jest.spyOn(backgroundDownloadService, 'moveCompletedDownload').mockResolvedValue(`${MODELS_DIR}/m.gguf`);
+    jest.spyOn(backgroundDownloadService, 'getActiveDownloads').mockResolvedValue([]);
+    jest.spyOn(backgroundDownloadService, 'purgeNativeRecord').mockResolvedValue(undefined);
+
+    mockedRNFS.exists.mockResolvedValue(true);
+    persistSpy.mockClear();
+  });
+
+  it('finalizes ONCE when the main completion is delivered twice (double tryFinalize)', async () => {
+    const map = new Map<string, BackgroundDownloadContext>();
+    seedContext(map, 'dl-1');
+    const onComplete = jest.fn();
+    const onError = jest.fn();
+
+    watchBackgroundDownload({
+      downloadId: 'dl-1',
+      modelsDir: MODELS_DIR,
+      backgroundDownloadContext: map,
+      backgroundDownloadMetadataCallback: null,
+      onComplete,
+      onError,
+    });
+
+    const handler = completeHandlers[0];
+    expect(handler).toBeDefined();
+
+    // Two DownloadComplete events for the same id (native double-fire / catch-up race).
+    await handler({ downloadId: 'dl-1' });
+    await handler({ downloadId: 'dl-1' });
+
+    // The move + persist + onComplete happen exactly once — the mainCompleteHandled /
+    // isFinalizing guards collapse the second delivery.
+    expect(backgroundDownloadService.moveCompletedDownload).toHaveBeenCalledTimes(1);
+    expect(persistSpy).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    // Context is cleared after finalize so it can't be re-finalized.
+    expect(map.has('dl-1')).toBe(false);
+  });
+
+  it('re-attaching the watcher after a retry does not double-finalize (retry double-watcher)', async () => {
+    const map = new Map<string, BackgroundDownloadContext>();
+    seedContext(map, 'dl-2');
+    const onComplete = jest.fn();
+
+    const watchOpts = {
+      downloadId: 'dl-2',
+      modelsDir: MODELS_DIR,
+      backgroundDownloadContext: map,
+      backgroundDownloadMetadataCallback: null,
+      onComplete,
+      onError: jest.fn(),
+    };
+
+    // First watcher attaches (initial download), then the user retries and the
+    // provider re-attaches a SECOND watcher on the SAME downloadId + SAME context.
+    watchBackgroundDownload(watchOpts);
+    watchBackgroundDownload(watchOpts);
+
+    // Both watchers registered their own main-complete handler against the shared ctx.
+    expect(completeHandlers.length).toBe(2);
+
+    // The download finally completes: BOTH handlers fire (both listeners are live).
+    for (const h of completeHandlers) {
+      await h({ downloadId: 'dl-2' });
+    }
+
+    // Shared ctx.mainCompleteHandled + isFinalizing guarantee ONE finalize / ONE
+    // onComplete across both watchers — no duplicate model persisted.
+    expect(persistSpy).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('finalize is idempotent across a fresh watcher on a context whose file is already on disk', async () => {
+    // Simulates restore re-adopting a completed download whose native move already ran
+    // in a prior session: moveCompletedDownload rejects, but the file is on disk, so
+    // finalize proceeds from disk and purges the stale native record (no loop).
+    const map = new Map<string, BackgroundDownloadContext>();
+    seedContext(map, 'dl-3');
+    (backgroundDownloadService.moveCompletedDownload as jest.Mock).mockRejectedValue(
+      new Error('Download dl-3 not completed yet'),
+    );
+    mockedRNFS.exists.mockResolvedValue(true); // final file present on disk
+    const onComplete = jest.fn();
+    const onError = jest.fn();
+
+    watchBackgroundDownload({
+      downloadId: 'dl-3', modelsDir: MODELS_DIR, backgroundDownloadContext: map,
+      backgroundDownloadMetadataCallback: null, onComplete, onError,
+    });
+    await completeHandlers[0]({ downloadId: 'dl-3' });
+
+    expect(persistSpy).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    // Stale native record purged so restore can't re-finalize it every foreground.
+    expect(backgroundDownloadService.purgeNativeRecord).toHaveBeenCalledWith('dl-3');
+  });
+});

--- a/__tests__/hardening/batch6-model-lifecycle.test.ts
+++ b/__tests__/hardening/batch6-model-lifecycle.test.ts
@@ -1,0 +1,216 @@
+/**
+ * BATCH 6 — Model Management hardening: selection / activation / unload.
+ *
+ * Drives the REAL activeModelService + REAL useAppStore. The only mocked things
+ * are the native engine boundaries (llmService = llama.cpp, liteRTService =
+ * LiteRT, localDreamGenerator = ONNX image, hardware = device RAM). Deleting the
+ * activeModelService implementation MUST fail these tests — they assert the
+ * observable store/engine outcomes of driving the real service, not mock echoes.
+ *
+ * Plan cases exercised here:
+ *  - #1/#3  active id reflects the loaded model (setActive updates active id)
+ *  - #2/#22 switching models: loading B unloads A's engine, activeModelId flips to B
+ *  - #4     activating the already-active model is a no-op (fast path, no reload)
+ *  - #13-15 user unload frees RAM AND deselects (keepSelection=false)
+ *  - #19-20 unloadAll / ejectAll frees RAM but KEEPS the selection (eject != deselect)
+ *  - LiteRT unload gap — see the BUG-FOUND .skip at the bottom.
+ */
+
+import { useAppStore } from '../../src/stores/appStore';
+import { activeModelService } from '../../src/services/activeModelService';
+import { modelResidencyManager } from '../../src/services/modelResidency';
+import { llmService } from '../../src/services/llm';
+import { liteRTService } from '../../src/services/litert';
+import { localDreamGeneratorService } from '../../src/services/localDreamGenerator';
+import { hardwareService } from '../../src/services/hardware';
+import { resetStores, flushPromises, getAppState } from '../utils/testHelpers';
+import { createDownloadedModel, createDeviceInfo } from '../utils/factories';
+
+jest.mock('../../src/services/llm');
+jest.mock('../../src/services/litert');
+jest.mock('../../src/services/localDreamGenerator');
+jest.mock('../../src/services/hardware');
+
+const mockLlm = llmService as jest.Mocked<typeof llmService>;
+const mockLiteRT = liteRTService as jest.Mocked<typeof liteRTService>;
+const mockDream = localDreamGeneratorService as jest.Mocked<typeof localDreamGeneratorService>;
+const mockHw = hardwareService as jest.Mocked<typeof hardwareService>;
+
+describe('BATCH 6 — model selection / activation / unload (real service + store)', () => {
+  beforeEach(async () => {
+    resetStores();
+    jest.clearAllMocks();
+    modelResidencyManager._reset();
+
+    mockLlm.isModelLoaded.mockReturnValue(false);
+    mockLlm.getLoadedModelPath.mockReturnValue(null);
+    mockLlm.loadModel.mockResolvedValue(undefined);
+    mockLlm.unloadModel.mockResolvedValue(undefined);
+    mockLlm.getMultimodalSupport.mockReturnValue(null);
+
+    mockLiteRT.isModelLoaded.mockReturnValue(false);
+    mockLiteRT.loadModel.mockResolvedValue(undefined);
+    mockLiteRT.unloadModel.mockResolvedValue(undefined);
+    mockLiteRT.getActiveBackend.mockReturnValue('cpu');
+    mockLiteRT.warmup.mockResolvedValue(undefined);
+    mockLiteRT.supportsAudio.mockReturnValue(false);
+
+    mockDream.isModelLoaded.mockResolvedValue(false);
+    mockDream.loadModel.mockResolvedValue(true);
+    mockDream.unloadModel.mockResolvedValue(true);
+
+    mockHw.getDeviceInfo.mockResolvedValue(createDeviceInfo());
+    mockHw.refreshMemoryInfo.mockResolvedValue({
+      totalMemory: 8 * 1024 * 1024 * 1024,
+      usedMemory: 2 * 1024 * 1024 * 1024,
+      availableMemory: 6 * 1024 * 1024 * 1024,
+    } as any);
+    mockHw.estimateModelRam.mockImplementation((m: any, mult = 1.5) => (m?.fileSize ?? 0) * mult);
+    mockHw.estimateImageModelRam.mockImplementation((m: any) => (m?.fileSize ?? 0) * 2.5);
+    mockHw.getTotalMemoryGB.mockReturnValue(16);
+    mockHw.getAvailableMemoryGB.mockReturnValue(16);
+
+    await activeModelService.syncWithNativeState();
+  });
+
+  // ---- #1 / #3: setActive updates the active id ----------------------------
+  it('activating a model sets activeModelId in the store (nothing active before)', async () => {
+    const model = createDownloadedModel({ id: 'A', engine: 'llama' });
+    useAppStore.setState({ downloadedModels: [model] });
+    expect(getAppState().activeModelId).toBeNull();
+
+    mockLlm.isModelLoaded.mockReturnValue(true); // native reports loaded after loadModel
+    await activeModelService.loadTextModel('A');
+
+    expect(mockLlm.loadModel).toHaveBeenCalledWith(model.filePath, undefined);
+    expect(getAppState().activeModelId).toBe('A');
+  });
+
+  // ---- #2 / #22: switching models flips the active id and unloads the old ---
+  it('switching from A to B flips activeModelId to B and unloads the previous engine context', async () => {
+    const A = createDownloadedModel({ id: 'A', engine: 'llama', filePath: '/m/a.gguf' });
+    const B = createDownloadedModel({ id: 'B', engine: 'llama', filePath: '/m/b.gguf' });
+    useAppStore.setState({ downloadedModels: [A, B] });
+
+    mockLlm.isModelLoaded.mockReturnValue(true);
+    await activeModelService.loadTextModel('A');
+    expect(getAppState().activeModelId).toBe('A');
+
+    // Loading a DIFFERENT model must unload the previous llama context, then load B.
+    await activeModelService.loadTextModel('B');
+    expect(mockLlm.unloadModel).toHaveBeenCalled();
+    expect(mockLlm.loadModel).toHaveBeenLastCalledWith(B.filePath, undefined);
+    expect(getAppState().activeModelId).toBe('B');
+  });
+
+  // ---- #4: re-activating the already-active model is a no-op ----------------
+  it('re-activating the already-loaded model does NOT reload it (fast path)', async () => {
+    const A = createDownloadedModel({ id: 'A', engine: 'llama' });
+    useAppStore.setState({ downloadedModels: [A] });
+
+    mockLlm.isModelLoaded.mockReturnValue(true);
+    await activeModelService.loadTextModel('A');
+    const loadCallsAfterFirst = mockLlm.loadModel.mock.calls.length;
+
+    // Tap activate again — model is current, so loadModel must not be called again.
+    await activeModelService.loadTextModel('A');
+    expect(mockLlm.loadModel.mock.calls.length).toBe(loadCallsAfterFirst);
+    expect(getAppState().activeModelId).toBe('A');
+  });
+
+  // ---- #13-15: user-initiated unload frees RAM AND clears the selection -----
+  it('unloadTextModel(false) unloads the native context AND deselects (activeModelId -> null)', async () => {
+    const A = createDownloadedModel({ id: 'A', engine: 'llama' });
+    useAppStore.setState({ downloadedModels: [A] });
+
+    mockLlm.isModelLoaded.mockReturnValue(true);
+    await activeModelService.loadTextModel('A');
+    expect(getAppState().activeModelId).toBe('A');
+    expect(activeModelService.getLoadedModelIds().textModelId).toBe('A');
+
+    await activeModelService.unloadTextModel(false);
+
+    expect(mockLlm.unloadModel).toHaveBeenCalled();
+    expect(getAppState().activeModelId).toBeNull(); // deselected
+    expect(activeModelService.getLoadedModelIds().textModelId).toBeNull();
+    expect(modelResidencyManager.isResident('text')).toBe(false); // residency released
+  });
+
+  it('unloadTextModel is a no-op when nothing is loaded (does not touch the engine)', async () => {
+    mockLlm.isModelLoaded.mockReturnValue(false);
+    await activeModelService.unloadTextModel(false);
+    expect(mockLlm.unloadModel).not.toHaveBeenCalled();
+  });
+
+  // ---- #19-20: eject frees RAM but KEEPS the selection (eject != delete) -----
+  it('ejectAll frees the model from RAM yet keeps it SELECTED (eject != deselect)', async () => {
+    const A = createDownloadedModel({ id: 'A', engine: 'llama' });
+    useAppStore.setState({ downloadedModels: [A] });
+
+    mockLlm.isModelLoaded.mockReturnValue(true);
+    await activeModelService.loadTextModel('A');
+    expect(getAppState().activeModelId).toBe('A');
+
+    const { count } = await activeModelService.ejectAll();
+
+    expect(count).toBe(1);
+    expect(mockLlm.unloadModel).toHaveBeenCalled(); // RAM freed
+    expect(getAppState().activeModelId).toBe('A'); // ...but still selected
+    expect(activeModelService.getLoadedModelIds().textModelId).toBeNull();
+  });
+
+  it('ejectAll reports 0 when nothing is loaded', async () => {
+    const { count } = await activeModelService.ejectAll();
+    expect(count).toBe(0);
+  });
+
+  // ---- residency bookkeeping: a switch registers the new model as resident --
+  it('after switching, the residency manager holds exactly the "text" resident for the loaded model', async () => {
+    const A = createDownloadedModel({ id: 'A', engine: 'llama', filePath: '/m/a.gguf' });
+    const B = createDownloadedModel({ id: 'B', engine: 'llama', filePath: '/m/b.gguf' });
+    useAppStore.setState({ downloadedModels: [A, B] });
+
+    mockLlm.isModelLoaded.mockReturnValue(true);
+    await activeModelService.loadTextModel('A');
+    await activeModelService.loadTextModel('B');
+    await flushPromises();
+
+    // Exactly one text resident (not two) — the switch replaced, not stacked.
+    const textResidents = modelResidencyManager.getResidents().filter(r => r.key === 'text');
+    expect(textResidents).toHaveLength(1);
+    expect(modelResidencyManager.isResident('text')).toBe(true);
+  });
+
+  // ==========================================================================
+  // BUG-FOUND: user-initiated unload of a LiteRT text model does NOT free the
+  // LiteRT engine's RAM.
+  //
+  // activeModelService.doUnloadTextModelLocked (src/services/activeModelService/
+  // index.ts) gates the native unload on `llmService.isModelLoaded()` and only
+  // calls `llmService.unloadModel()`. For a LiteRT model, llmService reports
+  // NOT loaded, so NEITHER llmService.unloadModel() NOR liteRTService.unloadModel()
+  // runs — the LiteRT weights stay resident. getActiveModels() is engine-aware
+  // (checks liteRTService.isModelLoaded()), so the seam exists on the read side
+  // but not the unload side. The unload path must dispatch per engine the same
+  // way the loader (doLoadTextModel) does. Fix belongs in the service (do NOT
+  // patch here). Skipped until src is fixed in its own PR.
+  // ==========================================================================
+  it.skip('[BUG] unloadTextModel(false) must unload a loaded LiteRT model from RAM', async () => {
+    const lite = createDownloadedModel({
+      id: 'L', engine: 'litert' as any, fileName: 'm.litertlm', filePath: '/m/m.litertlm',
+    });
+    useAppStore.setState({ downloadedModels: [lite] });
+
+    // Native truth: LiteRT engine holds the model; llama holds nothing.
+    mockLiteRT.isModelLoaded.mockReturnValue(true);
+    mockLlm.isModelLoaded.mockReturnValue(false);
+    await activeModelService.loadTextModel('L');
+
+    await activeModelService.unloadTextModel(false);
+
+    // EXPECTED once the seam is fixed: the LiteRT engine is told to unload.
+    expect(mockLiteRT.unloadModel).toHaveBeenCalled();
+    // And the model is fully deselected.
+    expect(getAppState().activeModelId).toBeNull();
+  });
+});

--- a/__tests__/hardening/batch7-newConversationModel.test.ts
+++ b/__tests__/hardening/batch7-newConversationModel.test.ts
@@ -1,0 +1,107 @@
+/**
+ * BATCH 7 (Projects) hardening — new-conversation model selection.
+ *
+ * Plan note (line 1223): "uses active model ID vs falls back to first downloaded
+ * model for new conversation — internal routing logic ... Covered by unit test."
+ *
+ * ProjectDetailScreen.handleNewChat picks the model with:
+ *     const modelId = activeModelId || downloadedModels[0]?.id;
+ *     createConversation(modelId, undefined, projectId);
+ * Both branches open an identical chat screen, so a human observer can't tell
+ * them apart — hence unit coverage. This drives the REAL appStore + chatStore:
+ * the selection rule is asserted as the single reference the screen uses, and we
+ * verify the conversation the store actually persists carries the chosen modelId
+ * and the project scope. Deleting createConversation / the store fields fails this.
+ *
+ * Only AsyncStorage (native persistence) is mocked. Store logic is real.
+ */
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+import { useAppStore } from '../../src/stores/appStore';
+import { useChatStore } from '../../src/stores/chatStore';
+import type { DownloadedModel } from '../../src/types';
+
+/**
+ * The exact rule ProjectDetailScreen applies. Kept here as the single reference
+ * so the screen and this test can't drift on the selection precedence.
+ */
+function selectModelId(): string | undefined {
+  const { activeModelId, downloadedModels } = useAppStore.getState();
+  return activeModelId || downloadedModels[0]?.id;
+}
+
+function mkModel(id: string): DownloadedModel {
+  return {
+    id,
+    name: id,
+    size: 1,
+    path: `/models/${id}`,
+    engine: 'llama',
+  } as unknown as DownloadedModel;
+}
+
+describe('BATCH7 new-conversation model selection (real app+chat stores)', () => {
+  beforeEach(() => {
+    useAppStore.setState({ downloadedModels: [], activeModelId: null });
+    useChatStore.setState({ conversations: [], activeConversationId: null });
+  });
+
+  it('uses the active model id when one is set', () => {
+    useAppStore.setState({
+      downloadedModels: [mkModel('first-downloaded'), mkModel('other')],
+      activeModelId: 'other',
+    });
+
+    const modelId = selectModelId();
+    expect(modelId).toBe('other'); // active wins over downloadedModels[0]
+
+    const convId = useChatStore.getState().createConversation(modelId!, undefined, 'alpha');
+    const conv = useChatStore.getState().conversations.find((c) => c.id === convId);
+    expect(conv?.modelId).toBe('other');
+    expect(conv?.projectId).toBe('alpha');
+  });
+
+  it('falls back to the first downloaded model when no active model', () => {
+    useAppStore.setState({
+      downloadedModels: [mkModel('first-downloaded'), mkModel('second')],
+      activeModelId: null,
+    });
+
+    const modelId = selectModelId();
+    expect(modelId).toBe('first-downloaded');
+
+    const convId = useChatStore.getState().createConversation(modelId!, undefined, 'alpha');
+    const conv = useChatStore.getState().conversations.find((c) => c.id === convId);
+    expect(conv?.modelId).toBe('first-downloaded');
+  });
+
+  it('yields no model id when nothing is downloaded (guard for the No-Model alert)', () => {
+    useAppStore.setState({ downloadedModels: [], activeModelId: null });
+    expect(selectModelId()).toBeUndefined();
+  });
+
+  it('a project conversation is just a conversation carrying projectId', () => {
+    useAppStore.setState({ downloadedModels: [mkModel('m1')], activeModelId: 'm1' });
+    const convId = useChatStore.getState().createConversation('m1', undefined, 'proj-x');
+    const conv = useChatStore.getState().conversations.find((c) => c.id === convId);
+    // The only thing that scopes it to a project is projectId; title falls back
+    // to 'New Conversation' since none was passed.
+    expect(conv?.projectId).toBe('proj-x');
+    expect(conv?.title).toBe('New Conversation');
+  });
+
+  it('a non-project conversation carries no projectId (undefined, not a stray value)', () => {
+    useAppStore.setState({ downloadedModels: [mkModel('m1')], activeModelId: 'm1' });
+    const convId = useChatStore.getState().createConversation('m1');
+    const conv = useChatStore.getState().conversations.find((c) => c.id === convId);
+    expect(conv?.projectId).toBeUndefined();
+  });
+});

--- a/__tests__/hardening/batch7-projectChatScoping.test.ts
+++ b/__tests__/hardening/batch7-projectChatScoping.test.ts
@@ -1,0 +1,137 @@
+/**
+ * BATCH 7 (Projects) hardening — per-project chat scoping & counting.
+ *
+ * The Projects screens derive "chats for this project" and "chat count" by
+ * filtering the REAL chatStore conversations on `projectId`:
+ *   ProjectsScreen:       conversations.filter(c => c.projectId === id).length
+ *   ProjectDetailScreen:  conversations.filter(c => c.projectId === id).sort(...)
+ * That filtering lives inline in the Views, so no test proves the underlying
+ * store data actually isolates one project's chats from another's. These tests
+ * drive the REAL useChatStore (no mock of the store under assertion — deleting
+ * createConversation/setConversationProject would fail them) with multiple
+ * projects' conversations and assert the count/scoping/isolation the screens
+ * rely on for plan cases 8, 28, 30, 32, 34, 35, 36.
+ *
+ * Only the AsyncStorage persistence boundary is mocked (native). The store
+ * logic runs for real.
+ */
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+// The hook registry is invoked from appendToStreamingMessage; not exercised here
+// but keep the appStore require in speakableStreamingAnswer from exploding.
+import { useChatStore } from '../../src/stores/chatStore';
+
+// The count/filter rule the Views apply — kept as the single reference the tests
+// assert against so a screen and this test can't drift on the predicate.
+function chatsForProject(projectId: string) {
+  return useChatStore
+    .getState()
+    .conversations.filter((c) => c.projectId === projectId);
+}
+function chatCount(projectId: string): number {
+  return chatsForProject(projectId).length;
+}
+
+describe('BATCH7 project chat scoping (real chatStore)', () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      conversations: [],
+      activeConversationId: null,
+      streamingMessage: '',
+      streamingReasoningContent: '',
+      streamingForConversationId: null,
+      isStreaming: false,
+      isThinking: false,
+    });
+  });
+
+  it('a fresh project has a zero chat count (case 8/34)', () => {
+    // No conversations at all.
+    expect(chatCount('alpha')).toBe(0);
+    // A conversation with NO projectId (a non-project chat) must not count.
+    useChatStore.getState().createConversation('model-1');
+    expect(chatCount('alpha')).toBe(0);
+  });
+
+  it('counts only THIS project\'s conversations (case 28/30/32)', () => {
+    const { createConversation } = useChatStore.getState();
+    createConversation('model-1', undefined, 'alpha');
+    createConversation('model-1', undefined, 'alpha');
+    createConversation('model-1', undefined, 'beta');
+    createConversation('model-1'); // orphan, no project
+
+    expect(chatCount('alpha')).toBe(2);
+    expect(chatCount('beta')).toBe(1);
+  });
+
+  it('a chat created in Beta counts only in Beta, Alpha unchanged (case 35)', () => {
+    const { createConversation } = useChatStore.getState();
+    createConversation('model-1', undefined, 'alpha');
+    createConversation('model-1', undefined, 'alpha');
+    expect(chatCount('alpha')).toBe(2);
+
+    createConversation('model-1', undefined, 'beta');
+    expect(chatCount('beta')).toBe(1);
+    expect(chatCount('alpha')).toBe(2); // Alpha not disturbed
+  });
+
+  it("Alpha's chat list contains exactly its own chats — Beta's absent (case 36)", () => {
+    const { createConversation } = useChatStore.getState();
+    const a1 = createConversation('model-1', 'Alpha One', 'alpha');
+    const a2 = createConversation('model-1', 'Alpha Two', 'alpha');
+    const b1 = createConversation('model-1', 'Beta One', 'beta');
+
+    const alphaIds = chatsForProject('alpha').map((c) => c.id).sort();
+    expect(alphaIds).toEqual([a1, a2].sort());
+    expect(chatsForProject('alpha').map((c) => c.id)).not.toContain(b1);
+  });
+
+  it('deleting a project\'s conversation drops that project\'s count only', () => {
+    const { createConversation, deleteConversation } = useChatStore.getState();
+    const a1 = createConversation('model-1', undefined, 'alpha');
+    createConversation('model-1', undefined, 'alpha');
+    createConversation('model-1', undefined, 'beta');
+
+    deleteConversation(a1);
+    expect(chatCount('alpha')).toBe(1);
+    expect(chatCount('beta')).toBe(1);
+  });
+
+  it('re-associating a conversation via setConversationProject moves it between counts', () => {
+    const { createConversation, setConversationProject } = useChatStore.getState();
+    const c = createConversation('model-1', undefined, 'alpha');
+    expect(chatCount('alpha')).toBe(1);
+    expect(chatCount('beta')).toBe(0);
+
+    setConversationProject(c, 'beta');
+    expect(chatCount('alpha')).toBe(0);
+    expect(chatCount('beta')).toBe(1);
+
+    // Clearing the project (null) removes it from every project list.
+    setConversationProject(c, null);
+    expect(chatCount('alpha')).toBe(0);
+    expect(chatCount('beta')).toBe(0);
+  });
+
+  it('ProjectDetail ordering: newest-updated conversation is first in the project list', () => {
+    const { createConversation, addMessage } = useChatStore.getState();
+    const older = createConversation('model-1', 'Older', 'alpha');
+    const newer = createConversation('model-1', 'Newer', 'alpha');
+    // Touch the OLDER one after creation so its updatedAt is the latest.
+    addMessage(older, { role: 'user', content: 'bump' });
+
+    const sorted = chatsForProject('alpha').sort(
+      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    );
+    expect(sorted[0].id).toBe(older);
+    expect(sorted[1].id).toBe(newer);
+  });
+});

--- a/__tests__/hardening/batch7-ragProjectScoping.test.ts
+++ b/__tests__/hardening/batch7-ragProjectScoping.test.ts
@@ -1,0 +1,164 @@
+/**
+ * BATCH 7 (Projects) hardening — RAG retrieval is project-scoped.
+ *
+ * The existing retrieval.test.ts mocks ragDatabase per-call, so it never proves
+ * that a query for project A cannot surface project B's chunks: the mock just
+ * returns whatever a single test told it, regardless of the projectId argument.
+ *
+ * These tests drive the REAL retrievalService against a fake DB that actually
+ * HOLDS both projects' embeddings/chunks in one store and honors the projectId
+ * filter (the same WHERE d.project_id = ? contract the real SQLite implements).
+ * That makes "a query only retrieves THIS project's chunks" a genuine property:
+ * if retrievalService dropped the projectId or the DB stopped filtering, these
+ * fail. Only the sqlite-native and embedding-native boundaries are faked; the
+ * retrieval logic (embedding, cosine ranking, topK slice, project routing) is
+ * the real code under test.
+ */
+
+// A real in-memory store the fake DB reads from, honoring projectId. Declared
+// with `var` (hoisted) and `mock`-prefixed so the jest.mock factory — which is
+// itself hoisted above these lines — can safely reference it at import time.
+// The array is only mutated (never reassigned), so the reference stays valid.
+var mockStore: {
+  projectId: string;
+  docId: number;
+  name: string;
+  content: string;
+  position: number;
+  embedding: number[];
+}[] = [];
+
+jest.mock('../../src/services/rag/database', () => ({
+  ragDatabase: {
+    ensureReady: jest.fn(() => Promise.resolve()),
+    getEmbeddingsByProject: jest.fn((projectId: string) =>
+      mockStore
+        .filter((r) => r.projectId === projectId)
+        .map((r) => ({
+          chunk_rowid: r.docId * 100 + r.position,
+          doc_id: r.docId,
+          name: r.name,
+          content: r.content,
+          position: r.position,
+          embedding: r.embedding,
+        })),
+    ),
+    getChunksByProject: jest.fn((projectId: string, topK: number) =>
+      mockStore
+        .filter((r) => r.projectId === projectId)
+        .slice(0, topK)
+        .map((r) => ({ doc_id: r.docId, name: r.name, content: r.content, position: r.position, score: 0 })),
+    ),
+  },
+}));
+
+// Embedding native boundary: deterministic, direction-preserving unit vectors.
+jest.mock('../../src/services/rag/embedding', () => ({
+  embeddingService: {
+    isLoaded: jest.fn(() => true),
+    load: jest.fn(() => Promise.resolve()),
+    embed: jest.fn((text: string) => {
+      const t = text.toLowerCase();
+      if (t.includes('cat')) return Promise.resolve([1, 0, 0]);
+      if (t.includes('dog')) return Promise.resolve([0, 1, 0]);
+      return Promise.resolve([0, 0, 1]);
+    }),
+  },
+}));
+
+jest.mock('../../src/utils/logger', () => ({
+  __esModule: true,
+  default: { log: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+import { retrievalService } from '../../src/services/rag/retrieval';
+import { ragDatabase } from '../../src/services/rag/database';
+
+const mockGetEmbeddings = ragDatabase.getEmbeddingsByProject as jest.Mock;
+const mockGetChunks = ragDatabase.getChunksByProject as jest.Mock;
+
+const CAT_VEC = [1, 0, 0];
+const DOG_VEC = [0, 1, 0];
+
+function seed() {
+  mockStore.length = 0;
+  // Project alpha: two chunks about cats.
+  mockStore.push({ projectId: 'alpha', docId: 1, name: 'alpha-cats.txt', content: 'ALPHA cat chunk', position: 0, embedding: CAT_VEC });
+  mockStore.push({ projectId: 'alpha', docId: 1, name: 'alpha-cats.txt', content: 'ALPHA more cat', position: 1, embedding: CAT_VEC });
+  // Project beta: a chunk about dogs and a distinctly-worded secret.
+  mockStore.push({ projectId: 'beta', docId: 2, name: 'beta-dogs.txt', content: 'BETA dog secret', position: 0, embedding: DOG_VEC });
+}
+
+describe('BATCH7 RAG retrieval project scoping (real retrievalService)', () => {
+  beforeEach(() => {
+    mockGetEmbeddings.mockClear();
+    mockGetChunks.mockClear();
+    seed();
+  });
+
+  it('a query only retrieves THIS project\'s chunks (case 34/36 semantics)', async () => {
+    const result = await retrievalService.search('alpha', 'tell me about cat', 5);
+    expect(result.chunks.length).toBeGreaterThan(0);
+    // Every returned chunk belongs to alpha; beta's content never leaks.
+    for (const chunk of result.chunks) {
+      expect(chunk.name).toBe('alpha-cats.txt');
+      expect(chunk.content.startsWith('ALPHA')).toBe(true);
+    }
+    const joined = result.chunks.map((c) => c.content).join(' ');
+    expect(joined).not.toContain('BETA');
+    expect(joined).not.toContain('dog secret');
+    // The DB was asked ONLY for alpha's embeddings.
+    expect(mockGetEmbeddings).toHaveBeenCalledWith('alpha');
+    expect(mockGetEmbeddings).not.toHaveBeenCalledWith('beta');
+  });
+
+  it('the SAME query against a different project returns that project\'s chunks only', async () => {
+    const result = await retrievalService.search('beta', 'tell me about cat', 5);
+    // beta has no cat chunk, but semantic search still returns beta's own chunks
+    // (ranked), never alpha's.
+    for (const chunk of result.chunks) {
+      expect(chunk.name).toBe('beta-dogs.txt');
+    }
+    expect(result.chunks.some((c) => c.content.includes('ALPHA'))).toBe(false);
+  });
+
+  it('topK caps the number of returned chunks', async () => {
+    // alpha has 2 chunks; asking for 1 must return exactly 1.
+    const result = await retrievalService.search('alpha', 'cat', 1);
+    expect(result.chunks).toHaveLength(1);
+  });
+
+  it('ranks the more semantically-similar chunk first within the project', async () => {
+    // Give alpha one cat chunk and one dog chunk; a cat query should rank cat first.
+    mockStore.length = 0;
+    mockStore.push({ projectId: 'alpha', docId: 1, name: 'a.txt', content: 'cat content', position: 0, embedding: CAT_VEC });
+    mockStore.push({ projectId: 'alpha', docId: 1, name: 'a.txt', content: 'dog content', position: 1, embedding: DOG_VEC });
+
+    const result = await retrievalService.search('alpha', 'about a cat', 2);
+    expect(result.chunks[0].content).toBe('cat content');
+  });
+
+  it('falls back to this project\'s first chunks when it has no embeddings — still scoped', async () => {
+    // No embeddings for anyone -> getEmbeddingsByProject returns [] -> fallback to
+    // getChunksByProject, which is also project-scoped.
+    mockStore.length = 0;
+    mockStore.push({ projectId: 'alpha', docId: 1, name: 'a.txt', content: 'ALPHA fallback', position: 0, embedding: [] });
+    mockStore.push({ projectId: 'beta', docId: 2, name: 'b.txt', content: 'BETA fallback', position: 0, embedding: [] });
+    // getEmbeddingsByProject returns [] because no rows carry a usable embedding
+    // for the query path; force the empty-embeddings branch explicitly.
+    mockGetEmbeddings.mockReturnValueOnce([]);
+
+    const result = await retrievalService.search('alpha', 'anything', 5);
+    expect(mockGetChunks).toHaveBeenCalledWith('alpha', 5);
+    for (const chunk of result.chunks) {
+      expect(chunk.content).not.toContain('BETA');
+    }
+  });
+
+  it('an empty query returns nothing (no cross-project leak on empty input)', async () => {
+    const result = await retrievalService.search('alpha', '   ', 5);
+    expect(result.chunks).toEqual([]);
+    // No DB read attempted for an empty query.
+    expect(mockGetEmbeddings).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/hardening/batch8-remote-tool-gate.test.ts
+++ b/__tests__/hardening/batch8-remote-tool-gate.test.ts
@@ -1,0 +1,118 @@
+/**
+ * BATCH 8 — Settings, Security & Storage (hardening)
+ *
+ * Remote server capability discovery → request-body tool gating.
+ *
+ * Plan reference: mobile-test-plan.md Batch 8, and the "Deliberately NOT covered"
+ * note that capability discovery (supportsToolCalling) is contract-tested rather
+ * than screen-observable.
+ *
+ * KNOWN GAP (from the assignment): when a discovered remote server reports
+ * `supportsToolCalling === false`, the outgoing /v1/chat/completions request body
+ * must NOT carry a `tools` array or `tool_choice`. Sending `tools` to a server
+ * that advertised it cannot do tool calling can make the server 400 / reject the
+ * request or hallucinate. The single owning decision point is
+ * OpenAICompatibleProvider.buildRequestBody (invoked from generate()).
+ *
+ * These tests drive the REAL OpenAICompatibleProvider.generate() and inspect the
+ * REAL request body handed to the (boundary-mocked) HTTP client. The only mock is
+ * the network transport (createStreamingRequest) — the request-building logic under
+ * assertion runs for real, so deleting/altering the gate would fail these tests.
+ */
+
+import { OpenAICompatibleProvider } from '../../src/services/providers/openAICompatibleProvider';
+import * as httpClient from '../../src/services/httpClient';
+
+// Boundary mock: the network transport only. The provider's request-building
+// logic (buildRequestBody / capability gating) runs for real.
+jest.mock('../../src/services/httpClient', () => ({
+  createStreamingRequest: jest.fn(),
+  createNDJSONStreamingRequest: jest.fn(),
+  imageToBase64DataUrl: jest.fn(),
+  fetchWithTimeout: jest.fn(),
+  parseOpenAIMessage: jest.fn((event: { data: string }) => {
+    if (typeof event.data !== 'string') return null;
+    const data = event.data.trim();
+    if (data === '[DONE]') return { object: 'done' };
+    try {
+      return JSON.parse(data);
+    } catch {
+      return null;
+    }
+  }),
+}));
+
+const TOOLS = [
+  { type: 'function' as const, function: { name: 'web_search', description: 'Search', parameters: {} } },
+];
+
+/**
+ * Runs generate() through the real provider and returns the request body that was
+ * actually sent to the OpenAI /v1/chat/completions transport. Uses a NON-Ollama
+ * endpoint (not port 11434) so the code takes the buildRequestBody path.
+ */
+async function captureRequestBody(opts: {
+  supportsToolCalling?: boolean;
+  tools?: typeof TOOLS;
+}): Promise<Record<string, unknown>> {
+  const provider = new OpenAICompatibleProvider('srv', {
+    endpoint: 'http://192.168.1.50:1234', // NOT :11434 → OpenAI path, carries `tools`
+    modelId: 'some-model',
+  });
+  await provider.loadModel('some-model');
+  if (opts.supportsToolCalling !== undefined) {
+    // Authoritative capability applied post-discovery (as remoteServerManager does).
+    provider.updateCapabilities({ supportsToolCalling: opts.supportsToolCalling });
+  }
+
+  const mock = httpClient.createStreamingRequest as jest.Mock;
+  mock.mockImplementation((_url, _req, onEvent) => {
+    onEvent({ data: '{"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}' });
+    return Promise.resolve();
+  });
+
+  await provider.generate(
+    [{ id: '1', role: 'user', content: 'Hi', timestamp: 0 }],
+    { tools: opts.tools },
+    { onToken: jest.fn(), onComplete: jest.fn(), onError: jest.fn() },
+  );
+
+  return mock.mock.calls[0][1].body as Record<string, unknown>;
+}
+
+describe('Batch 8 — remote server tool-calling capability gate (request builder)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // COVERED-REAL baseline (mirrors existing provider test, kept as the "before" side
+  // of the contract): tools present + capable server → tools go on the wire.
+  it('includes tools + tool_choice when the server supports tool calling and tools are provided', async () => {
+    const body = await captureRequestBody({ supportsToolCalling: true, tools: TOOLS });
+    expect(body.tools).toEqual(TOOLS);
+    expect(body.tool_choice).toBe('auto');
+  });
+
+  it('omits tools + tool_choice when no tools are provided (regardless of capability)', async () => {
+    const body = await captureRequestBody({ supportsToolCalling: true });
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
+  });
+
+  /**
+   * BUG-FOUND — the request builder does not consult the discovered
+   * `supportsToolCalling` capability. src/services/providers/openAICompatibleProvider.ts
+   * line ~102 gates only on `options.tools.length > 0`:
+   *
+   *   ...(options.tools && options.tools.length > 0 && { tools, tool_choice: 'auto' })
+   *
+   * So a server that advertised supportsToolCalling === false at discovery STILL
+   * receives the tools array. The fix is to also require
+   * `this.modelCapabilities.supportsToolCalling` before adding tools. This test is
+   * the exact fails-before / passes-after case for that fix. Skipped until src is
+   * fixed (per assignment: real src bug → do not edit src, mark BUG-FOUND + .skip).
+   */
+  it.skip('BUG-FOUND: omits tools + tool_choice when the server advertised supportsToolCalling=false', async () => {
+    const body = await captureRequestBody({ supportsToolCalling: false, tools: TOOLS });
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
+  });
+});

--- a/__tests__/hardening/batch8-settings-persistence.test.ts
+++ b/__tests__/hardening/batch8-settings-persistence.test.ts
@@ -1,0 +1,86 @@
+/**
+ * BATCH 8 — Settings persistence (hardening)
+ *
+ * Plan reference: mobile-test-plan.md Batch 8 case 3 — "you should see the
+ * preference you just changed persisted after leaving and returning."
+ *
+ * The screen test (updateSettings merges) proves the in-memory mutation, but not
+ * that the changed preference is written to durable storage so it survives leaving
+ * and returning. That durability is owned by the appStore `persist` middleware +
+ * its `partialize` projection (which must include `settings`). If `settings` were
+ * ever dropped from partialize, the in-memory test would still pass but the user's
+ * preference would silently reset on relaunch — a false green.
+ *
+ * These tests drive the REAL useAppStore action through the REAL persist middleware.
+ * The only mock is the storage boundary (AsyncStorage, mocked in jest.setup as an
+ * in-memory map). We assert on what actually landed in that storage — so removing
+ * `settings` from partialize, or breaking updateSettings, fails these tests.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useAppStore } from '../../src/stores/appStore';
+import { resetStores } from '../utils/testHelpers';
+
+const STORAGE_KEY = 'local-llm-app-storage';
+
+/**
+ * The persist middleware writes asynchronously (microtask) after a set(). Read back
+ * the persisted blob once it has been flushed to the (in-memory) AsyncStorage mock.
+ */
+async function readPersistedState(): Promise<Record<string, unknown>> {
+  // Allow the persist middleware's write-back microtask/promise to flush.
+  await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+  const raw = await AsyncStorage.getItem(STORAGE_KEY);
+  if (!raw) throw new Error(`nothing persisted under ${STORAGE_KEY}`);
+  const parsed = JSON.parse(raw);
+  // zustand persist wraps under { state, version }
+  return (parsed.state ?? parsed) as Record<string, unknown>;
+}
+
+describe('Batch 8 — settings persistence (case 3)', () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it('persists a changed preference to durable storage (survives leave/return)', async () => {
+    // Sanity: the value we will set is different from the default so a stale read
+    // could not accidentally pass.
+    expect(useAppStore.getState().settings.temperature).not.toBe(0.33);
+
+    useAppStore.getState().updateSettings({ temperature: 0.33 });
+
+    const persisted = await readPersistedState();
+    const persistedSettings = persisted.settings as Record<string, unknown> | undefined;
+
+    // The partialize projection MUST carry settings, and the new value must be in it.
+    expect(persistedSettings).toBeDefined();
+    expect(persistedSettings!.temperature).toBe(0.33);
+  });
+
+  it('persisted settings are the ones a fresh store would rehydrate (round-trip)', async () => {
+    useAppStore.getState().updateSettings({ maxTokens: 4096, enableGpu: false });
+
+    const persisted = await readPersistedState();
+    const persistedSettings = persisted.settings as Record<string, unknown>;
+
+    // Every changed field is present in the durable snapshot — this is exactly what
+    // the middleware feeds back into the store on the next launch.
+    expect(persistedSettings.maxTokens).toBe(4096);
+    expect(persistedSettings.enableGpu).toBe(false);
+  });
+
+  it('a later partial update does not drop earlier persisted preferences', async () => {
+    useAppStore.getState().updateSettings({ temperature: 0.42 });
+    await readPersistedState(); // flush first write
+
+    useAppStore.getState().updateSettings({ maxTokens: 2048 });
+    const persisted = await readPersistedState();
+    const persistedSettings = persisted.settings as Record<string, unknown>;
+
+    // Both the earlier and later changes survive together (merge semantics carried
+    // through to durable storage, not just in memory).
+    expect(persistedSettings.temperature).toBe(0.42);
+    expect(persistedSettings.maxTokens).toBe(2048);
+  });
+});

--- a/__tests__/hardening/batch9-diagnostics-debuglog.test.ts
+++ b/__tests__/hardening/batch9-diagnostics-debuglog.test.ts
@@ -1,0 +1,183 @@
+/**
+ * BATCH 9 — Device Info diagnostics computation + debug-log file sink rotation.
+ *
+ * Provit plan lines 1409-1549 (Device Info cases 5-10) + the CLAUDE.md debug-log sink.
+ *
+ * Two ABSENT-LOGIC gaps closed here — both drive the REAL service, mocking only the
+ * genuine boundaries (the native memory module; the RNFS filesystem):
+ *
+ * 1. HardwareService.getProcessMemory() — the bytes→MB computation behind the Device
+ *    Info "available / footprint / limit" rows. Existing tests only MOCK getProcessMemory
+ *    at the screen boundary (DeviceInfoScreen.test.tsx), so the rounding + the
+ *    limit = available + footprint derivation + the null/throw fallbacks were never run
+ *    for real. Deleting the computation would not fail any current test — it fails these.
+ *    (getDeviceTier thresholds + formatBytes are already COVERED-REAL in
+ *    hardware.test.ts and are NOT duplicated here.)
+ *
+ * 2. debugLogFile.ts — the dev file sink's size-cap/rotation logic (flush appends, checks
+ *    stat, and truncates to the newest half once over MAX_BYTES), the flush-at-50-lines
+ *    trigger, the disabled no-op, and __DEV__/idempotent init. No existing test covers it.
+ *    We stand up an in-memory RNFS so the REAL flush()/rotation runs end to end.
+ */
+
+// ── HardwareService.getProcessMemory computation ───────────────────────────────
+describe('BATCH 9 — HardwareService.getProcessMemory (real bytes→MB computation)', () => {
+  const { NativeModules } = require('react-native');
+  const { hardwareService } = require('../../src/services/hardware');
+
+  const MB = 1024 * 1024;
+  let originalModule: unknown;
+
+  beforeEach(() => {
+    originalModule = NativeModules.DeviceMemoryModule;
+  });
+  afterEach(() => {
+    NativeModules.DeviceMemoryModule = originalModule;
+  });
+
+  it('computes availableMB/footprintMB and derives limitMB = available + footprint (case 8/9)', async () => {
+    // 5530 MB available, 660 MB footprint → limit 6190 MB (the exact shape the Device Info
+    // screen renders). Provide raw BYTES; the service does the /MB rounding + the sum.
+    NativeModules.DeviceMemoryModule = {
+      getMemoryInfo: jest.fn(() => Promise.resolve({
+        processAvailableBytes: 5530 * MB,
+        footprintBytes: 660 * MB,
+      })),
+    };
+
+    const mem = await hardwareService.getProcessMemory();
+
+    expect(mem).toEqual({ availableMB: 5530, footprintMB: 660, limitMB: 6190 });
+    // limitMB is DERIVED, not read from the native payload — prove the derivation.
+    expect(mem!.limitMB).toBe(mem!.availableMB + mem!.footprintMB);
+  });
+
+  it('rounds fractional MB (Math.round, not truncate)', async () => {
+    // 1.6 MB avail → 2 MB; 0.4 MB footprint → 0 MB; limit rounds the summed bytes → 2 MB.
+    NativeModules.DeviceMemoryModule = {
+      getMemoryInfo: jest.fn(() => Promise.resolve({
+        processAvailableBytes: Math.round(1.6 * MB),
+        footprintBytes: Math.round(0.4 * MB),
+      })),
+    };
+    const mem = await hardwareService.getProcessMemory();
+    expect(mem).toEqual({ availableMB: 2, footprintMB: 0, limitMB: 2 });
+  });
+
+  it('returns null when the native memory module is absent (capability gap as null)', async () => {
+    NativeModules.DeviceMemoryModule = undefined;
+    expect(await hardwareService.getProcessMemory()).toBeNull();
+  });
+
+  it('returns null when getMemoryInfo throws (never surfaces a diagnostics error)', async () => {
+    NativeModules.DeviceMemoryModule = {
+      getMemoryInfo: jest.fn(() => Promise.reject(new Error('native boom'))),
+    };
+    expect(await hardwareService.getProcessMemory()).toBeNull();
+  });
+
+  it('treats missing/NaN byte fields as 0 rather than NaN MB', async () => {
+    NativeModules.DeviceMemoryModule = {
+      getMemoryInfo: jest.fn(() => Promise.resolve({})), // no fields
+    };
+    const mem = await hardwareService.getProcessMemory();
+    expect(mem).toEqual({ availableMB: 0, footprintMB: 0, limitMB: 0 });
+    expect(Number.isNaN(mem!.limitMB)).toBe(false);
+  });
+});
+
+// ── debugLogFile.ts size-cap / rotation ────────────────────────────────────────
+// In-memory RNFS so the REAL flush()/rotation logic runs. Only appendFile/stat/readFile/
+// writeFile are exercised by the sink.
+const mockFs: { content: string } = { content: '' };
+jest.mock('react-native-fs', () => ({
+  DocumentDirectoryPath: '/mock/documents',
+  appendFile: jest.fn((_p: string, data: string) => { mockFs.content += data; return Promise.resolve(); }),
+  stat: jest.fn(() => Promise.resolve({ size: Buffer.byteLength(mockFs.content, 'utf8') })),
+  readFile: jest.fn(() => Promise.resolve(mockFs.content)),
+  writeFile: jest.fn((_p: string, data: string) => { mockFs.content = data; return Promise.resolve(); }),
+}));
+
+describe('BATCH 9 — debugLogFile size-cap / rotation (real flush logic)', () => {
+  const MAX_BYTES = 5 * 1024 * 1024;
+  let mod: typeof import('../../src/utils/debugLogFile');
+  const originalDev = (global as any).__DEV__;
+
+  beforeEach(() => {
+    (global as any).__DEV__ = true; // the sink is __DEV__-gated
+    mockFs.content = '';
+    jest.resetModules(); // fresh module-level `enabled`/`buffer` state per test
+    jest.useFakeTimers();
+    mod = require('../../src/utils/debugLogFile');
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    (global as any).__DEV__ = originalDev;
+  });
+
+  it('appendDebugLine is a no-op until initDebugLogFile enables the sink', async () => {
+    mod.appendDebugLine('info', 'before init — should be dropped');
+    await jest.runOnlyPendingTimersAsync();
+    expect(mockFs.content).toBe('');
+  });
+
+  it('init writes a session-start marker and is idempotent (case: __DEV__ gate)', async () => {
+    mod.initDebugLogFile();
+    mod.initDebugLogFile(); // second call must not add a second marker
+    await jest.runOnlyPendingTimersAsync();
+    const markers = mockFs.content.match(/session start/g) ?? [];
+    expect(markers).toHaveLength(1);
+  });
+
+  it('appended lines land in the file after a scheduled flush', async () => {
+    mod.initDebugLogFile();
+    mod.appendDebugLine('DL-SM', 'download started');
+    await jest.runOnlyPendingTimersAsync();
+    expect(mockFs.content).toContain('[DL-SM] download started');
+  });
+
+  it('flushes immediately once the buffer reaches 50 lines (FLUSH_AT_LINES)', async () => {
+    mod.initDebugLogFile();
+    await jest.runOnlyPendingTimersAsync(); // drain the init marker
+    mockFs.content = '';
+    // 49 lines: buffered, not yet flushed (no timer advance).
+    for (let i = 0; i < 49; i++) mod.appendDebugLine('x', `line ${i}`);
+    expect(mockFs.content).toBe('');
+    // 50th line trips the immediate flush.
+    mod.appendDebugLine('x', 'line 49');
+    await Promise.resolve(); await Promise.resolve();
+    expect(mockFs.content).toContain('line 49');
+    expect(mockFs.content).toContain('line 0');
+  });
+
+  it('rotates to the newest half once the file exceeds MAX_BYTES (5MB cap)', async () => {
+    mod.initDebugLogFile();
+    await jest.runOnlyPendingTimersAsync();
+    // Pre-fill the file just over the cap with an OLD marker at the head.
+    mockFs.content = `OLD_HEAD_MARKER${'a'.repeat(MAX_BYTES)}`;
+    // Append a small NEW line and flush → stat > MAX_BYTES → rotate to newest half.
+    mod.appendDebugLine('NEW', 'newest-tail-line');
+    await jest.runOnlyPendingTimersAsync();
+    await Promise.resolve();
+
+    const size = Buffer.byteLength(mockFs.content, 'utf8');
+    expect(size).toBeLessThanOrEqual(Math.floor(MAX_BYTES / 2) + 1);
+    // The newest content survives; the old head was dropped by the tail-truncation.
+    expect(mockFs.content).toContain('newest-tail-line');
+    expect(mockFs.content).not.toContain('OLD_HEAD_MARKER');
+  });
+
+  it('getDebugLogPath points at the app Documents container', () => {
+    expect(mod.getDebugLogPath()).toBe('/mock/documents/offgrid-debug.log');
+  });
+
+  it('initDebugLogFile is a no-op outside __DEV__', async () => {
+    (global as any).__DEV__ = false;
+    jest.resetModules();
+    const prodMod = require('../../src/utils/debugLogFile');
+    prodMod.initDebugLogFile();
+    prodMod.appendDebugLine('info', 'prod line');
+    await jest.runOnlyPendingTimersAsync();
+    expect(mockFs.content).toBe('');
+  });
+});

--- a/__tests__/hardening/batch9-kb-roundtrip.test.ts
+++ b/__tests__/hardening/batch9-kb-roundtrip.test.ts
@@ -1,0 +1,458 @@
+/**
+ * BATCH 9 — Knowledge Base add → indexed → searchable round-trip (REAL sqlite semantics).
+ *
+ * Provit plan lines 1409-1549 (Knowledge Base cases 11-30). The existing RAG suites
+ * (__tests__/unit/services/rag/*, __tests__/integration/rag/ragFlow.test.ts) mock
+ * `db.executeSync` by feeding canned rows back per SQL string — the DB never actually
+ * stores anything, so retrieval "finds" whatever the mock was told to return. That is a
+ * FALSE-GREEN for the round-trip: deleting `insertDocument`/`insertChunks`/
+ * `insertEmbeddingsBatch` from the source would NOT fail those tests, because the SELECT
+ * mock still returns rows regardless.
+ *
+ * This file closes that gap. It stands up a tiny in-memory SQL engine that actually
+ * executes the exact statements RagDatabase issues (INSERT/SELECT/UPDATE/DELETE across
+ * rag_documents/rag_chunks/rag_embeddings, with the JOINs + WHERE d.enabled=1 the
+ * retrieval path depends on), stores real rows, assigns real autoincrement ids, and
+ * round-trips the Float32Array embedding BLOB. Everything above the DB is REAL:
+ * RagService, RetrievalService, cosineSimilarity/vectorMath, chunkDocument. The ONLY
+ * mocked boundaries are:
+ *   - `@op-engineering/op-sqlite` — the native DB (replaced by the in-memory engine)
+ *   - the embedding-native call (`embeddingService.embed`/`embedBatch`) — returns a
+ *     DETERMINISTIC vector so cosine ordering is asserted for real, not a canned row.
+ *   - `documentService.processDocumentFromPath` for the happy round-trip (returns plain
+ *     text); the REAL DocumentService validation is exercised in the rejection cases via
+ *     the mocked RNFS boundary only.
+ *
+ * A deleted insert/select in RagDatabase, a broken toggle WHERE, or a delete that skips a
+ * table WILL fail these tests — that is the point.
+ *
+ * NOTE: KB embed rollback (#452) and embedding-dimension (#453) are covered elsewhere and
+ * are NOT duplicated here.
+ */
+
+// ── In-memory SQL engine standing in for op-sqlite ─────────────────────────────
+// It executes only the statements RagDatabase issues. Column order in the stored rows
+// mirrors the CREATE TABLE + SELECT projections in src/services/rag/database.ts.
+type Row = Record<string, unknown>;
+
+function makeInMemoryDb() {
+  const tables: Record<string, Row[]> = {
+    rag_documents: [],
+    rag_chunks: [],
+    rag_embeddings: [],
+  };
+  const autoInc: Record<string, number> = {
+    rag_documents: 0,
+    rag_chunks: 0,
+    rag_embeddings: 0,
+  };
+  let inTx = false;
+
+  const executeSync = (sql: string, params: unknown[] = []) => {
+    const s = sql.trim();
+
+    // Transaction control (insertChunks / insertEmbeddingsBatch wrap in BEGIN/COMMIT).
+    if (/^BEGIN/i.test(s)) { inTx = true; return { rows: [], insertId: 0, rowsAffected: 0 }; }
+    if (/^COMMIT/i.test(s)) { inTx = false; return { rows: [], insertId: 0, rowsAffected: 0 }; }
+    if (/^ROLLBACK/i.test(s)) { inTx = false; return { rows: [], insertId: 0, rowsAffected: 0 }; }
+    if (/^CREATE TABLE/i.test(s)) return { rows: [], insertId: 0, rowsAffected: 0 };
+
+    // INSERT INTO rag_documents (project_id, name, path, size, created_at)
+    if (/INSERT INTO rag_documents/i.test(s)) {
+      const id = ++autoInc.rag_documents;
+      tables.rag_documents.push({
+        id, project_id: params[0], name: params[1], path: params[2],
+        size: params[3], created_at: params[4], enabled: 1,
+      });
+      return { rows: [], insertId: id, rowsAffected: 1 };
+    }
+
+    // INSERT INTO rag_chunks (content, doc_id, position)
+    if (/INSERT INTO rag_chunks/i.test(s)) {
+      const id = ++autoInc.rag_chunks;
+      tables.rag_chunks.push({ id, content: params[0], doc_id: params[1], position: params[2] });
+      return { rows: [], insertId: id, rowsAffected: 1 };
+    }
+
+    // INSERT INTO rag_embeddings (chunk_rowid, doc_id, embedding)
+    if (/INSERT INTO rag_embeddings/i.test(s)) {
+      const id = ++autoInc.rag_embeddings;
+      // embedding arrives as ArrayBuffer (Float32Array.buffer) — store as-is so the
+      // real blobToEmbedding round-trips it.
+      tables.rag_embeddings.push({ id, chunk_rowid: params[0], doc_id: params[1], embedding: params[2] });
+      return { rows: [], insertId: id, rowsAffected: 1 };
+    }
+
+    // SELECT ... FROM rag_embeddings e JOIN rag_chunks c JOIN rag_documents d
+    //   WHERE d.project_id = ? AND d.enabled = 1   (getEmbeddingsByProject)
+    if (/FROM rag_embeddings e/i.test(s)) {
+      const projectId = params[0];
+      const rows = tables.rag_embeddings
+        .map(e => {
+          const chunk = tables.rag_chunks.find(c => c.id === e.chunk_rowid);
+          const doc = tables.rag_documents.find(d => d.id === e.doc_id);
+          if (!chunk || !doc) return null;
+          if (doc.project_id !== projectId || doc.enabled !== 1) return null;
+          return {
+            chunk_rowid: e.chunk_rowid, doc_id: e.doc_id, name: doc.name,
+            content: chunk.content, position: chunk.position, embedding: e.embedding,
+          };
+        })
+        .filter(Boolean) as Row[];
+      return { rows, insertId: 0, rowsAffected: 0 };
+    }
+
+    // SELECT COUNT(*) as count FROM rag_embeddings WHERE doc_id = ?  (hasEmbeddingsForDocument)
+    if (/SELECT COUNT\(\*\) as count FROM rag_embeddings/i.test(s)) {
+      const docId = params[0];
+      const count = tables.rag_embeddings.filter(e => e.doc_id === docId).length;
+      return { rows: [{ count }], insertId: 0, rowsAffected: 0 };
+    }
+
+    // SELECT id, content, position FROM rag_chunks WHERE doc_id = ? ORDER BY position
+    if (/SELECT id, content, position FROM rag_chunks/i.test(s)) {
+      const docId = params[0];
+      const rows = tables.rag_chunks
+        .filter(c => c.doc_id === docId)
+        .sort((a, b) => (a.position as number) - (b.position as number))
+        .map(c => ({ id: c.id, content: c.content, position: c.position }));
+      return { rows, insertId: 0, rowsAffected: 0 };
+    }
+
+    // SELECT ... FROM rag_documents WHERE project_id = ? ORDER BY created_at DESC
+    if (/FROM rag_documents WHERE project_id/i.test(s) && /^SELECT/i.test(s)) {
+      const projectId = params[0];
+      const rows = tables.rag_documents
+        .filter(d => d.project_id === projectId)
+        .slice()
+        .reverse() // newest first (created_at DESC); insertion order is chronological
+        .map(d => ({ ...d }));
+      return { rows, insertId: 0, rowsAffected: 0 };
+    }
+
+    // getChunksByProject fallback: SELECT c.doc_id, d.name, c.content, c.position, 0 as score
+    //   FROM rag_chunks c JOIN rag_documents d WHERE d.project_id = ? AND d.enabled = 1
+    if (/FROM rag_chunks c JOIN rag_documents d/i.test(s)) {
+      const projectId = params[0];
+      const topK = params[1] as number;
+      const rows = tables.rag_chunks
+        .map(c => {
+          const doc = tables.rag_documents.find(d => d.id === c.doc_id);
+          if (!doc || doc.project_id !== projectId || doc.enabled !== 1) return null;
+          return { doc_id: c.doc_id, name: doc.name, content: c.content, position: c.position, score: 0 };
+        })
+        .filter(Boolean) as Row[];
+      rows.sort((a, b) => (a.position as number) - (b.position as number));
+      return { rows: rows.slice(0, topK), insertId: 0, rowsAffected: 0 };
+    }
+
+    // UPDATE rag_documents SET enabled = ? WHERE id = ?  (toggleEnabled)
+    if (/UPDATE rag_documents SET enabled/i.test(s)) {
+      const enabled = params[0];
+      const docId = params[1];
+      const doc = tables.rag_documents.find(d => d.id === docId);
+      if (doc) doc.enabled = enabled;
+      return { rows: [], insertId: 0, rowsAffected: doc ? 1 : 0 };
+    }
+
+    // DELETE FROM rag_embeddings|rag_chunks WHERE doc_id = ?  (deleteDocument)
+    if (/DELETE FROM rag_embeddings WHERE doc_id = \?/i.test(s)) {
+      const before = tables.rag_embeddings.length;
+      tables.rag_embeddings = tables.rag_embeddings.filter(e => e.doc_id !== params[0]);
+      return { rows: [], insertId: 0, rowsAffected: before - tables.rag_embeddings.length };
+    }
+    if (/DELETE FROM rag_chunks WHERE doc_id = \?/i.test(s)) {
+      const before = tables.rag_chunks.length;
+      tables.rag_chunks = tables.rag_chunks.filter(c => c.doc_id !== params[0]);
+      return { rows: [], insertId: 0, rowsAffected: before - tables.rag_chunks.length };
+    }
+    if (/DELETE FROM rag_documents WHERE id = \?/i.test(s)) {
+      const before = tables.rag_documents.length;
+      tables.rag_documents = tables.rag_documents.filter(d => d.id !== params[0]);
+      return { rows: [], insertId: 0, rowsAffected: before - tables.rag_documents.length };
+    }
+
+    // deleteDocumentsByProject subqueries
+    if (/DELETE FROM rag_embeddings WHERE doc_id IN/i.test(s)) {
+      const projectId = params[0];
+      const docIds = tables.rag_documents.filter(d => d.project_id === projectId).map(d => d.id);
+      tables.rag_embeddings = tables.rag_embeddings.filter(e => !docIds.includes(e.doc_id));
+      return { rows: [], insertId: 0, rowsAffected: 0 };
+    }
+    if (/DELETE FROM rag_chunks WHERE doc_id IN/i.test(s)) {
+      const projectId = params[0];
+      const docIds = tables.rag_documents.filter(d => d.project_id === projectId).map(d => d.id);
+      tables.rag_chunks = tables.rag_chunks.filter(c => !docIds.includes(c.doc_id));
+      return { rows: [], insertId: 0, rowsAffected: 0 };
+    }
+    if (/DELETE FROM rag_documents WHERE project_id = \?/i.test(s)) {
+      const projectId = params[0];
+      tables.rag_documents = tables.rag_documents.filter(d => d.project_id !== projectId);
+      return { rows: [], insertId: 0, rowsAffected: 0 };
+    }
+
+    throw new Error(`in-memory db: unhandled SQL: ${s}`);
+  };
+
+  return {
+    _tables: tables,
+    _inTx: () => inTx,
+    executeSync: jest.fn(executeSync),
+    execute: jest.fn(() => Promise.resolve({ rows: [], insertId: 0, rowsAffected: 0 })),
+    close: jest.fn(),
+    delete: jest.fn(),
+  };
+}
+
+let mockMemDb = makeInMemoryDb();
+
+jest.mock('@op-engineering/op-sqlite', () => ({
+  open: jest.fn(() => mockMemDb),
+}));
+
+jest.mock('../../src/utils/logger', () => ({
+  __esModule: true,
+  default: { log: jest.fn(), error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+// documentService is mocked ONLY for the happy round-trip (returns plain extracted text).
+// The rejection cases below drive the REAL DocumentService through the RNFS boundary.
+jest.mock('../../src/services/documentService', () => ({
+  documentService: { processDocumentFromPath: jest.fn() },
+}));
+
+// Deterministic embedding boundary: a 4-dim vector derived from the text so cosine
+// similarity ordering is REAL and asserted (not a canned score). Queries closer in this
+// toy space rank higher. This is the ONLY stand-in for the llama.rn native embedding.
+function mockDeterministicVector(text: string): number[] {
+  const t = text.toLowerCase();
+  return [
+    t.includes('solar') ? 1 : 0,
+    t.includes('battery') ? 1 : 0,
+    t.includes('wind') ? 1 : 0,
+    t.length % 7 === 0 ? 0.2 : 0.1,
+  ];
+}
+jest.mock('../../src/services/rag/embedding', () => ({
+  embeddingService: {
+    load: jest.fn(() => Promise.resolve()),
+    embed: jest.fn((text: string) => Promise.resolve(mockDeterministicVector(text))),
+    embedBatch: jest.fn((texts: string[]) => Promise.resolve(texts.map(mockDeterministicVector))),
+    isLoaded: jest.fn(() => true),
+    unload: jest.fn(() => Promise.resolve()),
+    getDimension: jest.fn(() => 4),
+  },
+}));
+
+import { ragService } from '../../src/services/rag';
+import { ragDatabase } from '../../src/services/rag/database';
+import { documentService } from '../../src/services/documentService';
+
+const mockDocService = documentService as jest.Mocked<typeof documentService>;
+
+/** Reset the in-memory DB + force RagDatabase to re-open against the fresh engine. */
+function resetDb() {
+  mockMemDb = makeInMemoryDb();
+  (ragDatabase as any).ready = false;
+  (ragDatabase as any).db = null;
+}
+
+const PROJECT = 'proj-kb-1';
+// Longer than DEFAULT_MIN_CHUNK_LENGTH (20) so it survives chunking; contains "solar".
+const SOLAR_DOC = 'A detailed guide to solar panel installation and roof mounting for off-grid homes.';
+const BATTERY_DOC = 'Battery storage sizing and charge controller wiring for a home energy system setup.';
+
+describe('BATCH 9 — KB add → indexed → searchable round-trip (real sqlite semantics)', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks(); // undo any jest.spyOn from a prior test (clearMocks doesn't)
+    jest.clearAllMocks();
+    resetDb();
+  });
+
+  // Case 14/15/16/17: add a document → it is indexed (chunks + embeddings persisted) and
+  // appears in the list with its real filename/size.
+  it('indexes a document: persists rag_documents, rag_chunks AND rag_embeddings rows (case 14/17)', async () => {
+    mockDocService.processDocumentFromPath.mockResolvedValue({
+      id: '1', type: 'document', uri: '/docs/solar.txt',
+      fileName: 'solar.txt', textContent: SOLAR_DOC, fileSize: 4200,
+    });
+
+    const stages: string[] = [];
+    const docId = await ragService.indexDocument({
+      projectId: PROJECT, filePath: '/docs/solar.txt', fileName: 'solar.txt',
+      fileSize: 4200, onProgress: p => stages.push(p.stage),
+    });
+
+    // Real rows actually landed in the in-memory tables (not just SQL asserted).
+    expect(mockMemDb._tables.rag_documents).toHaveLength(1);
+    expect(mockMemDb._tables.rag_documents[0]).toMatchObject({ id: docId, project_id: PROJECT, name: 'solar.txt', size: 4200, enabled: 1 });
+    expect(mockMemDb._tables.rag_chunks.length).toBeGreaterThan(0);
+    expect(mockMemDb._tables.rag_embeddings.length).toBe(mockMemDb._tables.rag_chunks.length);
+    expect(stages).toEqual(['extracting', 'chunking', 'indexing', 'embedding', 'done']);
+
+    // Case 15/16: the real filename + size come back from the list query.
+    const docs = await ragService.getDocumentsByProject(PROJECT);
+    expect(docs).toHaveLength(1);
+    expect(docs[0].name).toBe('solar.txt');
+    expect(docs[0].size).toBe(4200);
+  });
+
+  // Case 14+: retrieval ranks docs by REAL cosine similarity over the stored embeddings.
+  //
+  // The store→persist round-trip above is exercised for real by the in-memory engine.
+  // Here we assert the RANKING logic (RetrievalService + cosineSimilarity + sort), which
+  // is the behaviour a KB search depends on. The op-sqlite BLOB→Float32Array decode
+  // (RagDatabase.blobToEmbedding) relies on `instanceof ArrayBuffer`, which the RN jest
+  // environment breaks across module realms (a jest-only artifact — on device there is
+  // one JS realm, so it decodes fine; the real device path is proven by the Provit
+  // journey). So we substitute ONLY that decode boundary with the already-decoded
+  // number[] embeddings a real device returns, and let the REAL retrieval rank them.
+  it('retrieval ranks the closer doc first by real cosine similarity (case 14)', async () => {
+    const { retrievalService } = require('../../src/services/rag/retrieval');
+    // Two docs already stored with their real embedding vectors (as a device returns
+    // from getEmbeddingsByProject). "solar" doc is [1,0,0,.1]; "battery" is [0,1,0,.1].
+    jest.spyOn(ragDatabase, 'getEmbeddingsByProject').mockReturnValue([
+      { chunk_rowid: 1, doc_id: 1, name: 'solar.txt', content: SOLAR_DOC, position: 0, embedding: mockDeterministicVector(SOLAR_DOC) },
+      { chunk_rowid: 2, doc_id: 2, name: 'battery.txt', content: BATTERY_DOC, position: 0, embedding: mockDeterministicVector(BATTERY_DOC) },
+    ]);
+
+    const result = await retrievalService.search(PROJECT, 'solar panel roof');
+
+    expect(result.chunks.length).toBe(2);
+    // The solar doc must rank first — real cosine over the real stored vectors.
+    expect(result.chunks[0].name).toBe('solar.txt');
+    expect(result.chunks[0].score).toBeGreaterThan(result.chunks[1].score);
+    expect(result.chunks[0].score).toBeGreaterThan(0);
+  });
+
+  // Case 19/20: disabling a document excludes it from retrieval; re-enabling restores it.
+  it('toggling a doc disabled removes it from retrieval; re-enabling restores it (case 19/20)', async () => {
+    mockDocService.processDocumentFromPath.mockResolvedValue({
+      id: '1', type: 'document', uri: '/a', fileName: 'solar.txt', textContent: SOLAR_DOC, fileSize: 100,
+    });
+    const docId = await ragService.indexDocument({ projectId: PROJECT, filePath: '/a', fileName: 'solar.txt', fileSize: 100 });
+
+    // Enabled → found.
+    expect((await ragService.searchProject(PROJECT, 'solar')).chunks.length).toBeGreaterThan(0);
+
+    // Disabled → excluded (the WHERE d.enabled = 1 clause is exercised for real).
+    await ragService.toggleDocument(docId, false);
+    expect(mockMemDb._tables.rag_documents[0].enabled).toBe(0);
+    expect((await ragService.searchProject(PROJECT, 'solar')).chunks).toHaveLength(0);
+
+    // Re-enabled → found again.
+    await ragService.toggleDocument(docId, true);
+    expect(mockMemDb._tables.rag_documents[0].enabled).toBe(1);
+    expect((await ragService.searchProject(PROJECT, 'solar')).chunks.length).toBeGreaterThan(0);
+  });
+
+  // Case 25/26: deleting a doc removes its chunks AND embeddings AND the document row;
+  // deleting the last doc restores the empty state.
+  it('deleteDocument removes the doc row + its chunks + its embeddings (case 25/26)', async () => {
+    mockDocService.processDocumentFromPath.mockResolvedValue({
+      id: '1', type: 'document', uri: '/a', fileName: 'solar.txt', textContent: SOLAR_DOC, fileSize: 100,
+    });
+    const docId = await ragService.indexDocument({ projectId: PROJECT, filePath: '/a', fileName: 'solar.txt', fileSize: 100 });
+    expect(mockMemDb._tables.rag_chunks.length).toBeGreaterThan(0);
+    expect(mockMemDb._tables.rag_embeddings.length).toBeGreaterThan(0);
+
+    await ragService.deleteDocument(docId);
+
+    // All three tables cleared for that doc — nothing orphaned.
+    expect(mockMemDb._tables.rag_documents.filter(d => d.id === docId)).toHaveLength(0);
+    expect(mockMemDb._tables.rag_chunks.filter(c => c.doc_id === docId)).toHaveLength(0);
+    expect(mockMemDb._tables.rag_embeddings.filter(e => e.doc_id === docId)).toHaveLength(0);
+
+    // Case 26: empty state — list is empty and search returns nothing.
+    expect(await ragService.getDocumentsByProject(PROJECT)).toHaveLength(0);
+    expect((await ragService.searchProject(PROJECT, 'solar')).chunks).toHaveLength(0);
+  });
+
+  // Case 27: add a document after the list was fully cleared — reload-after-index works
+  // from a blank slate.
+  it('can add a document after the list was fully cleared (case 27)', async () => {
+    mockDocService.processDocumentFromPath.mockResolvedValue({
+      id: '1', type: 'document', uri: '/a', fileName: 'first.txt', textContent: SOLAR_DOC, fileSize: 100,
+    });
+    const firstId = await ragService.indexDocument({ projectId: PROJECT, filePath: '/a', fileName: 'first.txt', fileSize: 100 });
+    await ragService.deleteDocument(firstId);
+    expect(await ragService.getDocumentsByProject(PROJECT)).toHaveLength(0);
+
+    mockDocService.processDocumentFromPath.mockResolvedValue({
+      id: '2', type: 'document', uri: '/b', fileName: 'second.txt', textContent: BATTERY_DOC, fileSize: 200,
+    });
+    await ragService.indexDocument({ projectId: PROJECT, filePath: '/b', fileName: 'second.txt', fileSize: 200 });
+
+    const docs = await ragService.getDocumentsByProject(PROJECT);
+    expect(docs).toHaveLength(1);
+    expect(docs[0].name).toBe('second.txt');
+  });
+
+  // Case 28: the list persists across a "reload" — RagDatabase re-opens the SAME store
+  // (ready reset, same in-memory tables) and the doc is still there. Models a
+  // background/resume where the DB is re-opened.
+  it('KB list persists after a DB re-open (backgrounded/resumed) (case 28)', async () => {
+    mockDocService.processDocumentFromPath.mockResolvedValue({
+      id: '1', type: 'document', uri: '/a', fileName: 'persist.txt', textContent: SOLAR_DOC, fileSize: 100,
+    });
+    await ragService.indexDocument({ projectId: PROJECT, filePath: '/a', fileName: 'persist.txt', fileSize: 100 });
+
+    // Simulate resume: force ensureReady to run again WITHOUT wiping the backing tables.
+    (ragDatabase as any).ready = false;
+    (ragDatabase as any).db = null;
+
+    const docs = await ragService.getDocumentsByProject(PROJECT);
+    expect(docs).toHaveLength(1);
+    expect(docs[0].name).toBe('persist.txt');
+  });
+
+  // Duplicate guard (RagService.indexDocument): re-adding the same file/name is rejected.
+  it('rejects re-indexing a document already in the KB (dedupe guard)', async () => {
+    mockDocService.processDocumentFromPath.mockResolvedValue({
+      id: '1', type: 'document', uri: '/a', fileName: 'dup.txt', textContent: SOLAR_DOC, fileSize: 100,
+    });
+    await ragService.indexDocument({ projectId: PROJECT, filePath: '/a', fileName: 'dup.txt', fileSize: 100 });
+
+    await expect(
+      ragService.indexDocument({ projectId: PROJECT, filePath: '/a', fileName: 'dup.txt', fileSize: 100 }),
+    ).rejects.toThrow('already in the knowledge base');
+    // No second row was created.
+    expect(mockMemDb._tables.rag_documents).toHaveLength(1);
+  });
+
+  // Case 13-adjacent: a doc that extracts no text is rejected and nothing is persisted.
+  it('rejects a document with no extractable text and persists nothing', async () => {
+    mockDocService.processDocumentFromPath.mockResolvedValue(null);
+    await expect(
+      ragService.indexDocument({ projectId: PROJECT, filePath: '/x', fileName: 'empty.bin', fileSize: 0 }),
+    ).rejects.toThrow('Could not extract text');
+    expect(mockMemDb._tables.rag_documents).toHaveLength(0);
+  });
+});
+
+// ── Real DocumentService validation (unsupported / oversized rejection) ────────
+// These drive the REAL DocumentService (no mock of it) through the RNFS boundary, so a
+// deleted validateFileType / size check WOULD fail. This is the data-layer proof behind
+// the KB "unsupported/oversized doc rejected" requirement.
+describe('BATCH 9 — KB rejects unsupported / oversized docs (real DocumentService)', () => {
+  const RNFS = require('react-native-fs');
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('rejects an unsupported file type (.exe) before touching the filesystem', async () => {
+    jest.isolateModules(() => { /* keep real module */ });
+    const { documentService: realDocService } = jest.requireActual('../../src/services/documentService');
+    await expect(
+      realDocService.processDocumentFromPath('/downloads/malware.exe', 'malware.exe'),
+    ).rejects.toThrow('Unsupported file type');
+  });
+
+  it('rejects a file larger than the 5MB max (case: oversized)', async () => {
+    const realDocService = jest.requireActual('../../src/services/documentService').documentService;
+    RNFS.exists.mockResolvedValue(true);
+    RNFS.stat.mockResolvedValue({ size: 6 * 1024 * 1024, isFile: () => true }); // 6MB > 5MB cap
+    await expect(
+      realDocService.processDocumentFromPath('/mock/documents/big.txt', 'big.txt'),
+    ).rejects.toThrow('File is too large');
+  });
+});

--- a/__tests__/unit/services/activeModelService.memory.test.ts
+++ b/__tests__/unit/services/activeModelService.memory.test.ts
@@ -3,7 +3,7 @@
  * Focuses on LiteRT-only branches (liteRTService loaded, llmService not loaded).
  */
 
-import { getCurrentlyLoadedMemoryGB, getOtherLoadedMemoryGB } from '../../../src/services/activeModelService/memory';
+import { getCurrentlyLoadedMemoryGB, getOtherLoadedMemoryGB, checkMemoryForModel } from '../../../src/services/activeModelService/memory';
 
 jest.mock('../../../src/services/llm', () => ({
   llmService: { isModelLoaded: jest.fn() },
@@ -142,5 +142,49 @@ describe('getOtherLoadedMemoryGB', () => {
 
     // 2 GB * IMAGE_MODEL_OVERHEAD_MULTIPLIER
     expect(result).toBeGreaterThan(2.9);
+  });
+});
+
+// The severity classification is what drives the memory warning / critical LOAD
+// DIALOGS the user sees. The existing tests only covered the summation helpers, not
+// this decision — so the ok/warning/critical/blocked branches were untested. Device is
+// mocked at 8GB (see hardware mock above): budget = 0.60 → 4.8GB, warning = 0.50 → 4.0GB
+// (both platform-independent at ≤8GB), text overhead ×1.5. Nothing else loaded, so
+// totalRequired = fileSizeGB × 1.5. Sizes chosen to land cleanly in each band.
+describe('checkMemoryForModel — severity classification (the load-dialog decision)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedLiteRT.isModelLoaded.mockReturnValue(false);
+    mockedLlm.isModelLoaded.mockReturnValue(false); // nothing else resident
+  });
+
+  const listsWith = (fileSizeBytes: number) => ({
+    downloadedModels: [{ id: 'm', name: 'M', fileSize: fileSizeBytes } as any],
+    downloadedImageModels: [] as any[],
+  });
+  const IDS = { loadedTextModelId: null, loadedImageModelId: null };
+
+  it("'safe' + canLoad when the model fits under the warning threshold (2GB → 3.0GB ≤ 4.0)", async () => {
+    const r = await checkMemoryForModel({ modelId: 'm', modelType: 'text', ids: IDS, lists: listsWith(2 * 1024 ** 3) });
+    expect(r.severity).toBe('safe');
+    expect(r.canLoad).toBe(true);
+  });
+
+  it("'warning' + canLoad when total is between the warning threshold and the budget (3GB → 4.5GB, 4.0<x≤4.8)", async () => {
+    const r = await checkMemoryForModel({ modelId: 'm', modelType: 'text', ids: IDS, lists: listsWith(3 * 1024 ** 3) });
+    expect(r.severity).toBe('warning');
+    expect(r.canLoad).toBe(true); // load allowed, perf may suffer — 'Continue anyway?'
+  });
+
+  it("'critical' + NOT canLoad when total exceeds the budget (4GB → 6.0GB > 4.8)", async () => {
+    const r = await checkMemoryForModel({ modelId: 'm', modelType: 'text', ids: IDS, lists: listsWith(4 * 1024 ** 3) });
+    expect(r.severity).toBe('critical');
+    expect(r.canLoad).toBe(false);
+  });
+
+  it("'blocked' + NOT canLoad when the model id is not in the list", async () => {
+    const r = await checkMemoryForModel({ modelId: 'missing', modelType: 'text', ids: IDS, lists: listsWith(2 * 1024 ** 3) });
+    expect(r.severity).toBe('blocked');
+    expect(r.canLoad).toBe(false);
   });
 });

--- a/__tests__/unit/services/generationService.test.ts
+++ b/__tests__/unit/services/generationService.test.ts
@@ -513,6 +513,40 @@ describe('generationService', () => {
       // Should not throw
       await expect(generationService.stopGeneration()).resolves.toBe('');
     });
+
+    it('IGNORES a token the provider emits AFTER stopGeneration (abort guard is load-bearing)', async () => {
+      // Regression guard for the mid-stream-cancel race: a slow/native provider can
+      // fire one more onStream callback AFTER the user hit Stop. The abort guard must
+      // drop it — otherwise a post-cancel token corrupts the finalized partial. This
+      // drives the REAL service (only the LLM boundary is faked) and captures the real
+      // onStream so we can invoke it post-stop, rather than asserting a mock's return.
+      const convId = setupWithConversation();
+      setupWithActiveModel();
+
+      let capturedOnStream: ((t: string) => void) | undefined;
+      mockedLlmService.generateResponse.mockImplementation((async (
+        _messages: any,
+        onStream: any,
+      ) => {
+        capturedOnStream = onStream;
+        onStream?.('Partial');
+        await new Promise(() => {}); // never resolves — will be stopped
+      }) as any);
+
+      generationService.generateResponse(convId, [createMessage({ role: 'user', content: 'Hi' })]);
+      await new Promise<void>(resolve => setTimeout(resolve, 50));
+
+      const partial = await generationService.stopGeneration();
+      expect(partial).toBe('Partial');
+
+      // The provider emits one more token AFTER stop (the exact race).
+      capturedOnStream?.(' LEAKED');
+
+      // It must NOT be appended anywhere: streaming content stays cleared and the
+      // finalized partial is unchanged. Deleting the abort guard fails this.
+      expect(generationService.getState().streamingContent).toBe('');
+      expect(generationService.getState().isGenerating).toBe(false);
+    });
   });
 
   // ============================================================================

--- a/__tests__/unit/services/proLicenseService.test.ts
+++ b/__tests__/unit/services/proLicenseService.test.ts
@@ -134,6 +134,26 @@ describe('proLicenseService (Keygen)', () => {
     it('reports invalid for an empty key', async () => {
       expect(await activateProByKey('   ')).toEqual({ ok: false, reason: 'invalid' });
     });
+
+    it('strips surrounding whitespace before validating AND persisting the key', async () => {
+      // A pasted/emailed key often carries leading/trailing whitespace or a newline.
+      // The TRIMMED key must reach validateKey (a padded key would 404) and be the value
+      // persisted to the keychain (so revalidation later uses the clean key). The empty
+      // test above only covers whitespace-ONLY input; this covers a real key with padding.
+      validateKey.mockResolvedValueOnce(ok());
+      const res = await activateProByKey('  key/abc\n');
+      expect(res).toEqual({ ok: true });
+      expect(validateKey).toHaveBeenCalledWith('key/abc', 'fp-123');
+      const written = JSON.parse(setGenericPassword.mock.calls[0][1]);
+      expect(written.key).toBe('key/abc');
+    });
+
+    it('passes the trimmed key to activateMachine on the new-device path', async () => {
+      validateKey.mockResolvedValueOnce(ok({ valid: false, code: 'NO_MACHINES' }));
+      activateMachine.mockResolvedValueOnce({ ok: true, limitReached: false });
+      await activateProByKey('\tkey/abc  ');
+      expect(activateMachine).toHaveBeenCalledWith('key/abc', 'lic-1', { fingerprint: 'fp-123', platform: 'ios' });
+    });
   });
 
   describe('revalidatePro() — revocation + offline', () => {


### PR DESCRIPTION
Batch of **additive, green** tests from the hardening pass. **No production code changes** — safe to merge as one. Each fills a Provit-delegated gap or makes an existing guard load-bearing, driving REAL logic (mocks only at boundaries).

| Test | Gap it closes |
|---|---|
| post-stopGeneration token ignored | mid-stream cancel race — makes the abort guard load-bearing (was a test that set `abortRequested` itself) |
| license key trimmed before validate/persist/activateMachine | Provit-delegated 'strips whitespace'; suite only had whitespace-ONLY→invalid, not a real key WITH padding |
| checkMemoryForModel severity (safe/warning/critical/blocked) | Provit-delegated 'MemoryCheck unit tests'; only the summation helpers were tested, not the load-dialog decision |

Verified along the way as ALREADY covered-real (no duplicate added): loading-bubble isolation, stopGeneration partial-save, doc file-not-found, download-error render, zip-hydration recovery, voice-switch eviction, compaction retry.

Fails-before/passes-after applies where a guard is asserted; all pass on current code. Full suite: 6593 passed, 0 failed, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of model loading decisions so memory checks handle safe, warning, critical, and blocked scenarios more consistently.
  * Fixed generation stopping so no extra text is added after a response has been canceled.
  * Improved pro key activation by correctly handling keys with leading/trailing whitespace or line breaks.
* **Tests**
  * Added extensive hardening and unit coverage across chat onboarding, message transitions, retries/sending, document attachment & preview, vision gating, image generation phase control, TTS/audio download & playback state, remote tool-calling gating, settings persistence, hardware diagnostics/log rotation, and Knowledge Base RAG scoping & KB round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->