### PR TITLE
fix(remote): gate tools on discovered supportsToolCalling (OpenAI + Ollama paths)

### DIFF
--- a/__tests__/hardening/batch8-remote-tool-gate.test.ts
+++ b/__tests__/hardening/batch8-remote-tool-gate.test.ts
@@ -97,20 +97,40 @@ describe('Batch 8 — remote server tool-calling capability gate (request builde
     expect(body.tool_choice).toBeUndefined();
   });
 
-  /**
-   * BUG-FOUND — the request builder does not consult the discovered
-   * `supportsToolCalling` capability. src/services/providers/openAICompatibleProvider.ts
-   * line ~102 gates only on `options.tools.length > 0`:
-   *
-   *   ...(options.tools && options.tools.length > 0 && { tools, tool_choice: 'auto' })
-   *
-   * So a server that advertised supportsToolCalling === false at discovery STILL
-   * receives the tools array. The fix is to also require
-   * `this.modelCapabilities.supportsToolCalling` before adding tools. This test is
-   * the exact fails-before / passes-after case for that fix. Skipped until src is
-   * fixed (per assignment: real src bug → do not edit src, mark BUG-FOUND + .skip).
-   */
-  it.skip('BUG-FOUND: omits tools + tool_choice when the server advertised supportsToolCalling=false', async () => {
+  // The Ollama /api/chat path (port 11434) has its own request builder — gate mirrored there.
+  async function captureOllamaBody(supportsToolCalling: boolean): Promise<Record<string, unknown>> {
+    const provider = new OpenAICompatibleProvider('srv', {
+      endpoint: 'http://192.168.1.50:11434', // :11434 → Ollama NDJSON path
+      modelId: 'some-model',
+    });
+    await provider.loadModel('some-model');
+    provider.updateCapabilities({ supportsToolCalling });
+    const mock = httpClient.createNDJSONStreamingRequest as jest.Mock;
+    mock.mockImplementation((_url, _req, onLine) => {
+      onLine(JSON.stringify({ message: { content: 'ok' }, done: true }));
+      return Promise.resolve();
+    });
+    await provider.generate(
+      [{ id: '1', role: 'user', content: 'Hi', timestamp: 0 }],
+      { tools: TOOLS },
+      { onToken: jest.fn(), onComplete: jest.fn(), onError: jest.fn() },
+    );
+    return mock.mock.calls[0][1].body as Record<string, unknown>;
+  }
+
+  it('Ollama path: sends tools when capable', async () => {
+    expect((await captureOllamaBody(true)).tools).toEqual(TOOLS);
+  });
+
+  it('Ollama path: omits tools when supportsToolCalling=false', async () => {
+    expect((await captureOllamaBody(false)).tools).toBeUndefined();
+  });
+
+  // FIXED: the request builder now gates tools on the discovered supportsToolCalling
+  // capability (openAICompatibleProvider.ts buildRequestBody). A server that advertised
+  // supportsToolCalling===false no longer receives a tools payload it would 400/ignore.
+  // Fails-before (tools present) / passes-after.
+  it('omits tools + tool_choice when the server advertised supportsToolCalling=false', async () => {
     const body = await captureRequestBody({ supportsToolCalling: false, tools: TOOLS });
     expect(body.tools).toBeUndefined();
     expect(body.tool_choice).toBeUndefined();

--- a/__tests__/unit/services/remoteServerManager.test.ts
+++ b/__tests__/unit/services/remoteServerManager.test.ts
@@ -267,6 +267,45 @@ describe('remoteServerManager', () => {
       expect(mockLoadModel).toHaveBeenCalledWith('llama2');
     });
 
+    it('propagates the discovered supportsToolCalling capability into the provider', async () => {
+      // Guards the inert-fix bug: the request builders gate tools on
+      // provider.modelCapabilities.supportsToolCalling, so discovery MUST copy the
+      // discovered value in — otherwise it stays at the provider default (true) and the
+      // gate never suppresses tools for a non-tool-calling model.
+      // OpenAICompatibleProvider is mocked as jest.fn() at the top of this file; the
+      // code guards `provider instanceof OpenAICompatibleProvider`, so the mock provider
+      // must be an instance of that mock constructor for the capability-apply branch to run.
+      const { OpenAICompatibleProvider } = require('../../../src/services/providers/openAICompatibleProvider');
+      const updateSpy = jest.fn();
+      const realProvider = Object.assign(Object.create(OpenAICompatibleProvider.prototype), {
+        loadModel: jest.fn().mockResolvedValue(undefined),
+        unloadModel: jest.fn(),
+        isModelLoaded: jest.fn().mockReturnValue(true),
+        getLoadedModelId: jest.fn().mockReturnValue('m'),
+        isReady: jest.fn().mockResolvedValue(true),
+        updateCapabilities: updateSpy,
+        capabilities: { supportsToolCalling: true },
+      });
+      (providerRegistry.getProvider as jest.Mock).mockReturnValue(realProvider);
+      (providerRegistry.setActiveProvider as jest.Mock).mockReturnValue(true);
+      (useRemoteServerStore.getState as jest.Mock).mockReturnValue({
+        setActiveServerId: jest.fn(),
+        setActiveRemoteTextModelId: jest.fn(),
+        setActiveRemoteImageModelId: jest.fn(),
+        getServerById: jest.fn().mockReturnValue(null),
+        getModelById: jest.fn().mockReturnValue({
+          id: 'm',
+          capabilities: { supportsVision: false, supportsThinking: false, acceptsThinkingKwarg: false, supportsToolCalling: false },
+        }),
+      });
+
+      await remoteServerManager.setActiveRemoteTextModel('server-123', 'm');
+
+      // The discovered supportsToolCalling:false must reach the provider — without this
+      // propagation the request-body gate is inert (stays at the default true).
+      expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ supportsToolCalling: false }));
+    });
+
     it('should handle missing provider gracefully', async () => {
       (providerRegistry.getProvider as jest.Mock).mockReturnValue(undefined);
       (useRemoteServerStore.getState as jest.Mock).mockReturnValue({

--- a/src/services/providers/openAICompatibleProvider.ts
+++ b/src/services/providers/openAICompatibleProvider.ts
@@ -22,6 +22,7 @@ import type {
   OpenAIConfig,
   OpenAIStreamState,
 } from './openAICompatibleTypes';
+import { shouldIncludeTools } from './openAICompatibleTypes';
 
 export type { OpenAIChatMessage, OpenAIToolCall, OpenAIConfig } from './openAICompatibleTypes';
 
@@ -99,10 +100,10 @@ export class OpenAICompatibleProvider implements LLMProvider {
       // A client-side cap (default 1024) silently truncates reasoning models that
       // need a larger budget for <think> blocks (Qwen3, DeepSeek-R1, etc).
       ...(options.topP !== undefined && { top_p: options.topP }),
-      // Only send tools to a server that advertised tool-calling at discovery. A model
-      // with supportsToolCalling=false 400s (or silently ignores) a tools payload, so
-      // gating here — not just on "were tools requested" — keeps the wire clean.
-      ...(this.modelCapabilities.supportsToolCalling && options.tools && options.tools.length > 0 && { tools: options.tools, tool_choice: 'auto' }),
+      // Only send tools to a server that advertised tool-calling at discovery (one shared
+      // gate, mirrored on the Ollama path). A supportsToolCalling=false model 400s or
+      // ignores a tools payload.
+      ...(shouldIncludeTools(this.modelCapabilities.supportsToolCalling, options.tools) && { tools: options.tools, tool_choice: 'auto' }),
       // Control Qwen3 thinking per-request via chat_template_kwargs, but only for
       // servers that advertised (at discovery) that they honor it. Gating on a
       // discovered capability — not the endpoint's port — keeps the "which server

--- a/src/services/providers/openAICompatibleProvider.ts
+++ b/src/services/providers/openAICompatibleProvider.ts
@@ -99,7 +99,10 @@ export class OpenAICompatibleProvider implements LLMProvider {
       // A client-side cap (default 1024) silently truncates reasoning models that
       // need a larger budget for <think> blocks (Qwen3, DeepSeek-R1, etc).
       ...(options.topP !== undefined && { top_p: options.topP }),
-      ...(options.tools && options.tools.length > 0 && { tools: options.tools, tool_choice: 'auto' }),
+      // Only send tools to a server that advertised tool-calling at discovery. A model
+      // with supportsToolCalling=false 400s (or silently ignores) a tools payload, so
+      // gating here — not just on "were tools requested" — keeps the wire clean.
+      ...(this.modelCapabilities.supportsToolCalling && options.tools && options.tools.length > 0 && { tools: options.tools, tool_choice: 'auto' }),
       // Control Qwen3 thinking per-request via chat_template_kwargs, but only for
       // servers that advertised (at discovery) that they honor it. Gating on a
       // discovered capability — not the endpoint's port — keeps the "which server
@@ -136,6 +139,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
           endpoint: this.config.endpoint,
           modelId: this.config.modelId,
           abort: () => this.abortController?.abort(),
+          supportsToolCalling: this.modelCapabilities.supportsToolCalling,
         });
       }
 

--- a/src/services/providers/openAICompatibleStream.ts
+++ b/src/services/providers/openAICompatibleStream.ts
@@ -11,6 +11,7 @@ import type {
   OpenAIStreamState,
   OllamaChatRequest,
 } from './openAICompatibleTypes';
+import { shouldIncludeTools } from './openAICompatibleTypes';
 
 /**
  * Streaming parser for <think>...</think> tags embedded in delta.content.
@@ -286,8 +287,8 @@ export async function generateOllamaChatImpl(
 
   const requestBody: Record<string, unknown> = {
     model: modelId, messages: ollamaMessages, stream: true, think: thinkingEnabled,
-    // Mirror the OpenAI path: only send tools to a server that advertised tool-calling.
-    ...(supportsToolCalling && options.tools && options.tools.length > 0 && { tools: options.tools }),
+    // Same shared gate as the OpenAI path — only send tools to a tool-calling server.
+    ...(shouldIncludeTools(supportsToolCalling, options.tools) && { tools: options.tools }),
     options: {
       ...(options.temperature !== undefined && { temperature: options.temperature }),
       // num_predict intentionally omitted — Ollama defaults to -1 (until natural stop).

--- a/src/services/providers/openAICompatibleStream.ts
+++ b/src/services/providers/openAICompatibleStream.ts
@@ -238,7 +238,7 @@ export async function generateOllamaChatImpl(
   openaiMessages: OpenAIChatMessage[],
   req: OllamaChatRequest,
 ): Promise<void> {
-  const { options, callbacks, signal, endpoint, modelId, abort } = req;
+  const { options, callbacks, signal, endpoint, modelId, abort, supportsToolCalling } = req;
   const thinkingEnabled = options.enableThinking !== false;
 
   // Convert to Ollama message format
@@ -286,7 +286,8 @@ export async function generateOllamaChatImpl(
 
   const requestBody: Record<string, unknown> = {
     model: modelId, messages: ollamaMessages, stream: true, think: thinkingEnabled,
-    ...(options.tools && options.tools.length > 0 && { tools: options.tools }),
+    // Mirror the OpenAI path: only send tools to a server that advertised tool-calling.
+    ...(supportsToolCalling && options.tools && options.tools.length > 0 && { tools: options.tools }),
     options: {
       ...(options.temperature !== undefined && { temperature: options.temperature }),
       // num_predict intentionally omitted — Ollama defaults to -1 (until natural stop).

--- a/src/services/providers/openAICompatibleTypes.ts
+++ b/src/services/providers/openAICompatibleTypes.ts
@@ -57,4 +57,7 @@ export interface OllamaChatRequest {
   endpoint: string;
   modelId: string;
   abort: () => void;
+  /** Discovered tool-calling capability. When false, tools are omitted from the
+   *  request body (a non-tool-calling model 400s or ignores a tools payload). */
+  supportsToolCalling: boolean;
 }

--- a/src/services/providers/openAICompatibleTypes.ts
+++ b/src/services/providers/openAICompatibleTypes.ts
@@ -3,6 +3,19 @@
  */
 import type { GenerationOptions, StreamCallbacks } from './types';
 
+/**
+ * Whether a request body should carry a `tools` payload: only when the model advertised
+ * tool-calling AND the caller actually passed tools. Defined once and used by BOTH the
+ * OpenAI (/v1/chat/completions) and Ollama (/api/chat) request builders so the gate can't
+ * drift between the two paths.
+ */
+export function shouldIncludeTools(
+  supportsToolCalling: boolean,
+  tools: GenerationOptions['tools'],
+): boolean {
+  return !!supportsToolCalling && !!tools && tools.length > 0;
+}
+
 /** OpenAI chat message */
 export interface OpenAIChatMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';

--- a/src/services/remoteServerManagerUtils.ts
+++ b/src/services/remoteServerManagerUtils.ts
@@ -124,8 +124,12 @@ export async function setActiveRemoteTextModelImpl(
         supportsVision: discoveredModel.capabilities.supportsVision,
         supportsThinking: discoveredModel.capabilities.supportsThinking,
         acceptsThinkingKwarg: discoveredModel.capabilities.acceptsThinkingKwarg,
+        // Propagate the discovered tool-calling capability too — the request builders
+        // gate tools on it, so without this it stays at the provider default (true) and
+        // the gate never suppresses tools for a non-tool-calling model.
+        supportsToolCalling: discoveredModel.capabilities.supportsToolCalling,
       });
-      logger.log('[RemoteServerManager] Applied discovered capabilities for', modelId, '— supportsVision:', discoveredModel.capabilities.supportsVision, 'supportsThinking:', discoveredModel.capabilities.supportsThinking, 'acceptsThinkingKwarg:', discoveredModel.capabilities.acceptsThinkingKwarg);
+      logger.log('[RemoteServerManager] Applied discovered capabilities for', modelId, '— supportsVision:', discoveredModel.capabilities.supportsVision, 'supportsThinking:', discoveredModel.capabilities.supportsThinking, 'acceptsThinkingKwarg:', discoveredModel.capabilities.acceptsThinkingKwarg, 'supportsToolCalling:', discoveredModel.capabilities.supportsToolCalling);
     }
     providerRegistry.setActiveProvider(serverId);
     logger.log('[RemoteServerManager] Provider ready:', await provider.isReady());


### PR DESCRIPTION
## Problem
Both remote request builders added a `tools` payload whenever `options.tools` was non-empty, **never** consulting the discovered `modelCapabilities.supportsToolCalling`:
- `openAICompatibleProvider.ts:102` (OpenAI `/v1/chat/completions`)
- `openAICompatibleStream.ts:289` (Ollama `/api/chat`)

A remote model that advertised `supportsToolCalling=false` at discovery still got `tools`+`tool_choice` on the wire → server 400s / ignores / hallucinates. **No upstream gate exists** — `generationToolLoop` passes tools unconditionally; the only handling is a *reactive* grammar-error retry that strips tools *after* a failure. Confirmed live by two independent reviewers.

## Fix
Both builders now require `supportsToolCalling` before adding tools. Threaded the capability into `OllamaChatRequest` so the native path gates identically — one rule, both paths, no divergence.

## Test (fails-before / passes-after)
Un-skipped the batch8 BUG-FOUND case + added Ollama-path variants. Drives the REAL `provider.generate()`; only the network transport is mocked, so removing the gate fails the tests. 79 passed, tsc clean.

## Self-audit
- **SOLID:** gate is the discovered capability (data), applied once per path; no `Platform.OS`/`instanceof` branch. Capability threaded through the typed `OllamaChatRequest` contract, not read from a global.
- **No false-green:** real provider request-building runs; deleting the gate fails the tests.
- **Platform parity:** both remote transports gated; iOS/Android identical (remote path is platform-agnostic).
- **Provit:** pending oracle — covered by remote tool-calling journeys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool-related request fields are now included only when the selected server/model supports tool calling, avoiding unsupported-request errors.
  * For unsupported models, tool options and automatic tool selection are omitted.
  * Ollama streaming requests now respect the same tool-calling capability rules as other compatible providers.

* **Tests**
  * Expanded coverage for tool-calling request-body behavior across supported/unsupported scenarios, including Ollama-specific streaming.
  * Added a unit test ensuring discovered tool-calling capability is propagated to the active provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->