### PR TITLE
fix(models): unload a loaded LiteRT text model too (RAM leak + residency desync)

### DIFF
--- a/__tests__/hardening/batch6-model-lifecycle.test.ts
+++ b/__tests__/hardening/batch6-model-lifecycle.test.ts
@@ -195,7 +195,7 @@ describe('BATCH 6 — model selection / activation / unload (real service + stor
   // way the loader (doLoadTextModel) does. Fix belongs in the service (do NOT
   // patch here). Skipped until src is fixed in its own PR.
   // ==========================================================================
-  it.skip('[BUG] unloadTextModel(false) must unload a loaded LiteRT model from RAM', async () => {
+  it('unloadTextModel(false) unloads a loaded LiteRT model from RAM (engine-aware unload)', async () => {
     const lite = createDownloadedModel({
       id: 'L', engine: 'litert' as any, fileName: 'm.litertlm', filePath: '/m/m.litertlm',
     });

--- a/__tests__/hardening/batch6-model-lifecycle.test.ts
+++ b/__tests__/hardening/batch6-model-lifecycle.test.ts
@@ -213,4 +213,35 @@ describe('BATCH 6 — model selection / activation / unload (real service + stor
     // And the model is fully deselected.
     expect(getAppState().activeModelId).toBeNull();
   });
+
+  // Focused engine-branch coverage (review #459): each engine's unload is dispatched
+  // ONLY for that engine — the other engine's unload must NOT be called. Pins the
+  // per-engine branching directly, not just the LiteRT outcome above.
+  describe('doUnloadTextModelLocked — per-engine dispatch (only the loaded engine unloads)', () => {
+    it('LiteRT loaded → liteRTService.unloadModel called, llmService.unloadModel NOT', async () => {
+      const lite = createDownloadedModel({ id: 'L', engine: 'litert' as any, fileName: 'm.litertlm', filePath: '/m/m.litertlm' });
+      useAppStore.setState({ downloadedModels: [lite] });
+      mockLiteRT.isModelLoaded.mockReturnValue(true);
+      mockLlm.isModelLoaded.mockReturnValue(false);
+      await activeModelService.loadTextModel('L');
+
+      await activeModelService.unloadTextModel(false);
+
+      expect(mockLiteRT.unloadModel).toHaveBeenCalled();
+      expect(mockLlm.unloadModel).not.toHaveBeenCalled();
+    });
+
+    it('llama loaded → llmService.unloadModel called, liteRTService.unloadModel NOT', async () => {
+      const gguf = createDownloadedModel({ id: 'G', engine: 'llama' as any, fileName: 'm.gguf', filePath: '/m/m.gguf' });
+      useAppStore.setState({ downloadedModels: [gguf] });
+      mockLlm.isModelLoaded.mockReturnValue(true);
+      mockLiteRT.isModelLoaded.mockReturnValue(false);
+      await activeModelService.loadTextModel('G');
+
+      await activeModelService.unloadTextModel(false);
+
+      expect(mockLlm.unloadModel).toHaveBeenCalled();
+      expect(mockLiteRT.unloadModel).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/services/activeModelService/index.ts
+++ b/src/services/activeModelService/index.ts
@@ -212,15 +212,26 @@ class ActiveModelService {
       await this.textLoadPromise;
     }
     const storeActiveModelId = useAppStore.getState().activeModelId;
-    const isNativeLoaded = llmService.isModelLoaded();
+    // Engine-aware: a text model lives in llmService (GGUF/llama) OR liteRTService
+    // (LiteRT). The read side (getActiveModels/isTextModelCurrent) and the load side
+    // already dispatch per engine; the unload side must too, or unloading a loaded
+    // LiteRT model frees NOTHING (llmService.isModelLoaded() is false for it) — a RAM
+    // leak, and modelResidencyManager.release('text') below then desyncs (the budget
+    // thinks the RAM is free while LiteRT still holds it → a later load can OOM/jetsam).
+    const llamaLoaded = llmService.isModelLoaded();
+    const liteRTLoaded = liteRTService.isModelLoaded();
+    const isNativeLoaded = llamaLoaded || liteRTLoaded;
     if (!storeActiveModelId && !this.loadedTextModelId && !isNativeLoaded) {
       return;
     }
     this.loadingState.text = true;
     this.notifyListeners();
     try {
-      if (isNativeLoaded) {
+      if (llamaLoaded) {
         await llmService.unloadModel();
+      }
+      if (liteRTLoaded) {
+        await liteRTService.unloadModel();
       }
       this.loadedTextModelId = null;
       if (!keepSelection) {


### PR DESCRIPTION
## Problem
`activeModelService.doUnloadTextModelLocked` checked only `llmService.isModelLoaded()` and only called `llmService.unloadModel()`. For a loaded **LiteRT** text model that check is `false`, so the native unload was skipped — `liteRTService.unloadModel()` was never called and the engine's RAM stayed resident.

Worse: `modelResidencyManager.release('text')` still ran and `loadedTextModelId` was nulled, so the residency budget believed the RAM was freed while LiteRT still held it → a subsequent load could be admitted into occupied RAM → **OOM/jetsam**. Affects `unloadTextModel`, eviction, and Eject All for LiteRT models.

The read side (`getActiveModels`/`isTextModelCurrent`) and the load side already dispatch per engine; the unload side was the one asymmetric seam.

## Fix
Check both engines' loaded-state and unload whichever is loaded, mirroring the load path.

## Test (fails-before / passes-after)
Un-skipped the batch6 BUG-FOUND case: load a LiteRT model → unload → assert `liteRTService.unloadModel()` called + full deselect. Fails on main (never called). Drives the real service; only native engines mocked. 146 passed, tsc clean.

## Self-audit
- **SOLID:** unload now dispatches per engine like load/read — closes the asymmetric seam. (Follow-up noted: a `TextEngine` interface would collapse all three per-engine branches into one; larger refactor, separate PR.)
- **No false-green:** real `activeModelService` drives it; deleting the liteRT unload branch fails the test.
- **Platform parity:** LiteRT is Android-only but the code path is platform-agnostic; the RAM/residency consequence is worse on tight devices.
- **Provit:** pending oracle — covered by model load/unload + memory journeys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated text model unloading to be engine-aware, ensuring the correct backend unloads the active model and that the app clears the active model state reliably.
  * Improved RAM/residency consistency during unloads and strengthened model deselection behavior when unloading.
* **Tests**
  * Re-enabled a hardening regression test for LiteRT unload behavior.
  * Added coverage to verify unload dispatch is routed to the correct backend for LiteRT vs llama models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->