### PR TITLE
refactor(downloads): single-source isStaleDownload predicate + real Clear-All test

### DIFF
--- a/__tests__/hardening/batch8-storage-clear-stale.test.ts
+++ b/__tests__/hardening/batch8-storage-clear-stale.test.ts
@@ -1,0 +1,92 @@
+/**
+ * BATCH 8 — Storage Settings: stale-download detection + Clear All.
+ *
+ * Plan cases 25/26: recognise stale download entries and clear them.
+ *
+ * The stale predicate + clear-all set now live ONCE in the download store
+ * (isStaleDownload / selectStaleDownloads) and StorageSettingsScreen renders/clears
+ * from them. These tests drive the REAL exported predicate and the REAL
+ * useDownloadStore.remove — not a re-implemented copy — so a drift in the predicate
+ * (or deleting remove) fails them.
+ */
+import { useDownloadStore, isStaleDownload, selectStaleDownloads } from '../../src/stores/downloadStore';
+import type { DownloadEntry } from '../../src/stores/downloadStore';
+
+const entry = (over: Partial<DownloadEntry>): DownloadEntry => ({
+  modelKey: 'org/repo/m.gguf' as any,
+  downloadId: 'dl-1',
+  modelId: 'org/repo',
+  fileName: 'm.gguf',
+  quantization: 'Q4_K_M',
+  modelType: 'text' as any,
+  status: 'completed',
+  progress: 1,
+  bytesDownloaded: 100,
+  totalBytes: 100,
+  combinedTotalBytes: 100,
+  createdAt: 0,
+  ...over,
+});
+
+const seed = (entries: DownloadEntry[]) => {
+  const map: Record<string, DownloadEntry> = {};
+  for (const e of entries) map[e.modelKey] = e;
+  useDownloadStore.setState({ downloads: map, downloadIdIndex: {} } as any);
+};
+
+beforeEach(() => {
+  useDownloadStore.setState({ downloads: {}, downloadIdIndex: {} } as any);
+});
+
+describe('isStaleDownload — the real predicate the screen uses', () => {
+  it('a complete entry (all fields) is NOT stale', () => {
+    expect(isStaleDownload(entry({}))).toBe(false);
+  });
+  it('missing modelId → stale', () => {
+    expect(isStaleDownload(entry({ modelId: '' as any }))).toBe(true);
+  });
+  it('missing fileName → stale', () => {
+    expect(isStaleDownload(entry({ fileName: '' as any }))).toBe(true);
+  });
+  it('missing combinedTotalBytes (0/undefined) → stale', () => {
+    expect(isStaleDownload(entry({ combinedTotalBytes: 0 }))).toBe(true);
+    expect(isStaleDownload(entry({ combinedTotalBytes: undefined as any }))).toBe(true);
+  });
+});
+
+describe('selectStaleDownloads + Clear All (cases 25, 26)', () => {
+  it('recognises exactly the stale entries in a mixed store', () => {
+    seed([
+      entry({ modelKey: 'a/good.gguf' as any }),                       // healthy
+      entry({ modelKey: 'b/nomodel' as any, modelId: '' as any }),     // stale
+      entry({ modelKey: 'c/noname' as any, fileName: '' as any }),     // stale
+      entry({ modelKey: 'd/nobytes' as any, combinedTotalBytes: 0 }),  // stale
+    ]);
+    const stale = selectStaleDownloads(useDownloadStore.getState().downloads);
+    expect(stale.map(s => s.modelKey).sort()).toEqual(['b/nomodel', 'c/noname', 'd/nobytes']);
+  });
+
+  it('Clear All removes every stale entry and keeps the healthy one (real store.remove)', () => {
+    seed([
+      entry({ modelKey: 'a/good.gguf' as any }),
+      entry({ modelKey: 'b/nomodel' as any, modelId: '' as any }),
+      entry({ modelKey: 'c/nobytes' as any, combinedTotalBytes: 0 }),
+    ]);
+    const { remove } = useDownloadStore.getState();
+    // The exact loop the screen's Clear All onPress runs.
+    for (const s of selectStaleDownloads(useDownloadStore.getState().downloads)) remove(s.modelKey);
+
+    const after = useDownloadStore.getState().downloads;
+    expect(Object.keys(after)).toEqual(['a/good.gguf']);
+    expect(selectStaleDownloads(after)).toHaveLength(0); // idempotent: nothing left to clean
+  });
+
+  it('Clear All is a no-op when there are no stale entries', () => {
+    seed([entry({ modelKey: 'a/good.gguf' as any })]);
+    const { remove } = useDownloadStore.getState();
+    const stale = selectStaleDownloads(useDownloadStore.getState().downloads);
+    expect(stale).toHaveLength(0);
+    for (const s of stale) remove(s.modelKey);
+    expect(Object.keys(useDownloadStore.getState().downloads)).toEqual(['a/good.gguf']);
+  });
+});

--- a/__tests__/rntl/screens/StorageSettingsScreen.test.tsx
+++ b/__tests__/rntl/screens/StorageSettingsScreen.test.tsx
@@ -101,6 +101,9 @@ jest.mock('../../../src/stores', () => ({
 }));
 
 jest.mock('../../../src/stores/downloadStore', () => ({
+  // Keep the REAL pure predicates (isStaleDownload / selectStaleDownloads) — they have
+  // no dependencies, so mocking them would only risk drift from the store's coverage.
+  ...jest.requireActual('../../../src/stores/downloadStore'),
   useDownloadStore: (selector?: any) => {
     const entries: Record<string, any> = {};
     mockStaleDownloadStoreEntries.forEach((e, i) => { entries[`key-${i}`] = e; });

--- a/src/screens/StorageSettingsScreen.tsx
+++ b/src/screens/StorageSettingsScreen.tsx
@@ -13,7 +13,7 @@ import { CustomAlert, showAlert, hideAlert, AlertState, initialAlertState } from
 import { useTheme, useThemedStyles } from '../theme';
 import { SPACING } from '../constants';
 import { useAppStore, useChatStore } from '../stores';
-import { useDownloadStore } from '../stores/downloadStore';
+import { useDownloadStore, selectStaleDownloads } from '../stores/downloadStore';
 import { hardwareService, modelManager } from '../services';
 import { OrphanedFilesSection } from './OrphanedFilesSection';
 import { createStyles } from './StorageSettingsScreen.styles';
@@ -36,11 +36,10 @@ export const StorageSettingsScreen: React.FC = () => {
 
   const imageStorageUsed = downloadedImageModels.reduce((total, m) => total + (m.size || 0), 0);
 
-  // A "stale" entry is a store entry missing the basic fields needed to
-  // display or finalize it. Now sourced from the unified download store.
-  const staleDownloads = Object.values(downloads).filter(entry => {
-    return !entry.modelId || !entry.fileName || !entry.combinedTotalBytes;
-  });
+  // A "stale" entry is a store entry missing the basic fields needed to display or
+  // finalize it. The predicate lives ONCE in the download store (selectStaleDownloads
+  // → isStaleDownload) so the screen and its tests can't drift.
+  const staleDownloads = selectStaleDownloads(downloads);
 
   const loadStorageInfo = useCallback(async () => {
     const used = await modelManager.getStorageUsed();

--- a/src/stores/downloadStore.ts
+++ b/src/stores/downloadStore.ts
@@ -66,6 +66,24 @@ export function isDownloadingStatus(status: DownloadStatus): boolean {
   return isActiveStatus(status) && status !== 'pending';
 }
 
+/**
+ * A "stale" download entry is one missing the basic fields needed to display or
+ * finalize it (modelId / fileName / combinedTotalBytes) — orphaned rows from an
+ * interrupted or malformed download that Storage Settings offers to clear. Single
+ * source of truth: the screen renders + clears from this, and it is unit-tested here,
+ * so the predicate can't drift between the UI and its coverage.
+ */
+export function isStaleDownload(entry: DownloadEntry): boolean {
+  return !entry.modelId || !entry.fileName || !entry.combinedTotalBytes;
+}
+
+/** All stale entries in a downloads map (the set Storage Settings' "Clear All" acts on). */
+export function selectStaleDownloads(
+  downloads: Record<ModelKey, DownloadEntry>,
+): DownloadEntry[] {
+  return Object.values(downloads).filter(isStaleDownload);
+}
+
 interface DownloadStoreState {
   downloads: Record<ModelKey, DownloadEntry>
   downloadIdIndex: Record<string, ModelKey>


### PR DESCRIPTION
## Why
StorageSettingsScreen computed 'stale download' inline (`!modelId || !fileName || !combinedTotalBytes`) and looped it for Clear All. The hardening test had **re-implemented that predicate locally** — a false-green (a reviewer flagged it): if the screen's rule drifted, the test stayed green because it tested its own copy.

## Change
- Extract `isStaleDownload` + `selectStaleDownloads` into `downloadStore`, alongside the sibling classifiers (`isActiveStatus`/`isQueuedStatus`/`isDownloadingStatus`). **Single source of truth.**
- Screen imports + uses them (no inline predicate).
- Rewrote the batch8 test to drive the **real** exported predicate + the **real** `useDownloadStore.remove` — deleting the predicate or `remove` fails it. RNTL screen test keeps the real pure predicates via `requireActual`.

## Tests
74 passed (batch8 + downloadStore + StorageSettingsScreen), tsc clean.

## Self-audit
- **Single-source SOLID:** the stale rule is defined once and consumed by both the screen and its tests; no drift possible.
- **No false-green:** replaces a re-implemented-predicate test with one driving real code.
- **Standards:** no UI/copy change (behavior identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storage settings now identify incomplete downloads more reliably and include a clearer “Clear All” behavior for stale items.

* **Bug Fixes**
  * Improved handling of partially saved downloads so only valid entries remain after cleanup.
  * Prevented the stale-download list from showing items that should not be flagged.
  * Ensured cleanup is safe to run even when there are no stale downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->