### PR TITLE
refactor: single source of truth for image-backend labels

### DIFF
--- a/__tests__/rntl/screens/StorageSettingsScreen.test.tsx
+++ b/__tests__/rntl/screens/StorageSettingsScreen.test.tsx
@@ -294,14 +294,17 @@ describe('StorageSettingsScreen', () => {
     expect(getByText('GPU')).toBeTruthy();
   });
 
-  it('renders image model with QNN backend as Qualcomm NPU', () => {
+  it('renders image model with QNN backend as NPU (single source of truth, no "Qualcomm NPU" drift)', () => {
     mockDownloadedImageModels = [
       { id: 'i1', name: 'QNN Model', description: '', modelPath: '/p', downloadedAt: '', size: 1024, style: 'artistic', backend: 'qnn' },
     ];
 
-    const { getByText } = render(<StorageSettingsScreen />);
+    const { getByText, queryByText } = render(<StorageSettingsScreen />);
     expect(getByText('QNN Model')).toBeTruthy();
-    expect(getByText(/Qualcomm NPU/)).toBeTruthy();
+    // Every surface now renders "NPU" via imageBackendLabel; Storage Settings used
+    // to drift to "Qualcomm NPU".
+    expect(getByText(/NPU/)).toBeTruthy();
+    expect(queryByText(/Qualcomm NPU/)).toBeNull();
   });
 
   // ---- Orphaned files section tests ----

--- a/__tests__/unit/utils/imageBackend.test.ts
+++ b/__tests__/unit/utils/imageBackend.test.ts
@@ -1,0 +1,29 @@
+import { imageBackendLabel } from '../../../src/utils/imageBackend';
+
+describe('imageBackendLabel', () => {
+  it('maps known backends to their canonical label', () => {
+    expect(imageBackendLabel('coreml')).toBe('Core ML');
+    expect(imageBackendLabel('qnn')).toBe('NPU');
+    expect(imageBackendLabel('mnn')).toBe('GPU');
+  });
+
+  it('returns the default fallback for unknown/absent backends', () => {
+    expect(imageBackendLabel(undefined)).toBe('GPU');
+    expect(imageBackendLabel(null)).toBe('GPU');
+    expect(imageBackendLabel('')).toBe('GPU');
+    expect(imageBackendLabel('something-new')).toBe('GPU');
+  });
+
+  it('honours a per-surface fallback for unknown/absent backends', () => {
+    expect(imageBackendLabel('all', 'Backend')).toBe('Backend');
+    expect(imageBackendLabel(undefined, 'Image Generation')).toBe('Image Generation');
+    // a known backend always wins over the fallback
+    expect(imageBackendLabel('qnn', 'Backend')).toBe('NPU');
+  });
+
+  it('normalises the qnn label so no surface can drift back to "Qualcomm NPU"', () => {
+    // Storage Settings previously showed "Qualcomm NPU" while every other surface
+    // showed "NPU"; the single source of truth prevents that divergence.
+    expect(imageBackendLabel('qnn', 'GPU')).toBe('NPU');
+  });
+});

--- a/src/screens/DownloadManagerScreen/useDownloadManager.ts
+++ b/src/screens/DownloadManagerScreen/useDownloadManager.ts
@@ -16,6 +16,7 @@ import { cancelSyntheticImageDownload } from '../ModelsScreen/imageDownloadActio
 import { parseEntryMetadata, retryImageDownload } from './retryHandlers';
 import { modelDownloadService } from '../../services/modelDownloadService';
 import { uniformDownloadId } from '../../services/modelDownloadService/uniformId';
+import { imageBackendLabel } from '../../utils/imageBackend';
 import { setImageDownloadOps } from '../../services/modelDownloadService/providers/imageProvider';
 import { useEffect } from 'react';
 
@@ -56,10 +57,7 @@ function getActiveItemFileName(
 }
 
 function getImageAuthor(backend?: string): string {
-  if (backend === 'coreml') return 'Core ML';
-  if (backend === 'qnn') return 'NPU';
-  if (backend === 'mnn') return 'GPU';
-  return 'Image Generation';
+  return imageBackendLabel(backend, 'Image Generation');
 }
 
 function getActiveItemAuthor(

--- a/src/screens/ModelsScreen/ImageFilterBar.tsx
+++ b/src/screens/ModelsScreen/ImageFilterBar.tsx
@@ -5,6 +5,7 @@ import { SPACING } from '../../constants';
 import { createStyles } from './styles';
 import { BackendFilter, ImageFilterDimension } from './types';
 import { BACKEND_OPTIONS, SD_VERSION_OPTIONS, STYLE_OPTIONS } from './constants';
+import { imageBackendLabel } from '../../utils/imageBackend';
 
 interface Props {
   backendFilter: BackendFilter;
@@ -21,10 +22,7 @@ interface Props {
 }
 
 function getBackendLabel(filter: BackendFilter): string {
-  if (filter === 'mnn') return 'GPU';
-  if (filter === 'qnn') return 'NPU';
-  if (filter === 'coreml') return 'Core ML';
-  return 'Backend';
+  return imageBackendLabel(filter, 'Backend');
 }
 
 function getSdLabel(filter: string): string {

--- a/src/screens/ModelsScreen/ImageModelsTab.tsx
+++ b/src/screens/ModelsScreen/ImageModelsTab.tsx
@@ -10,6 +10,7 @@ import { HFImageModel, getVariantLabel } from '../../services/huggingFaceModelBr
 import { ImageModelRecommendation } from '../../types';
 import { useDownloadStore, isActiveStatus, isQueuedStatus, isDownloadingStatus } from '../../stores/downloadStore';
 import { makeImageModelKey } from '../../utils/modelKey';
+import { imageBackendLabel } from '../../utils/imageBackend';
 import { createStyles } from './styles';
 import { ModelsScreenViewModel } from './useModelsScreen';
 import { ImageFilterBar } from './ImageFilterBar';
@@ -67,10 +68,7 @@ export const ImageModelCardItem: React.FC<ImageModelCardProps> = ({
   const isQueued = !!entry && isQueuedStatus(entry.status);
   const isDownloading = !!entry && isDownloadingStatus(entry.status);
   const progressValue = entry?.progress ?? 0;
-  let authorLabel: string;
-  if (model._coreml) authorLabel = 'Core ML';
-  else if (model.backend === 'qnn') authorLabel = 'NPU';
-  else authorLabel = 'GPU';
+  const authorLabel = model._coreml ? 'Core ML' : imageBackendLabel(model.backend);
   const variantSuffix = model.variant ? ` \u00B7 ${getVariantLabel(model.variant)}` : '';
   return (
     <View>

--- a/src/screens/ModelsScreen/utils.ts
+++ b/src/screens/ModelsScreen/utils.ts
@@ -2,6 +2,7 @@ import RNFS from 'react-native-fs';
 import { guessStyle, HFImageModel } from '../../services/huggingFaceModelBrowser';
 import { ModelInfo, ImageModelRecommendation, SoCInfo } from '../../types';
 import { ImageModelDescriptor, ModelTypeFilter } from './types';
+import { imageBackendLabel } from '../../utils/imageBackend';
 
 export function formatNumber(num: number): string {
   if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
@@ -146,8 +147,7 @@ export function hfModelToDescriptor(
     name: hfModel.displayName,
     description: (() => {
       if (hfModel._coreml) return `Core ML model from ${hfModel.repo}`;
-      const backendLabel = hfModel.backend === 'qnn' ? 'NPU' : 'GPU';
-      return `${backendLabel} model from ${hfModel.repo}`;
+      return `${imageBackendLabel(hfModel.backend, 'GPU')} model from ${hfModel.repo}`;
     })(),
     downloadUrl: hfModel.downloadUrl,
     size: hfModel.size,

--- a/src/screens/StorageSettingsScreen.tsx
+++ b/src/screens/StorageSettingsScreen.tsx
@@ -16,6 +16,7 @@ import { useAppStore, useChatStore } from '../stores';
 import { useDownloadStore } from '../stores/downloadStore';
 import { hardwareService, modelManager } from '../services';
 import { OrphanedFilesSection } from './OrphanedFilesSection';
+import { imageBackendLabel } from '../utils/imageBackend';
 import { createStyles } from './StorageSettingsScreen.styles';
 
 export const StorageSettingsScreen: React.FC = () => {
@@ -176,11 +177,7 @@ export const StorageSettingsScreen: React.FC = () => {
                 <View style={styles.modelInfo}>
                   <Text style={styles.modelName} numberOfLines={1}>{model.name}</Text>
                   <Text style={styles.modelMeta}>
-                    {(() => {
-                      if (model.backend === 'coreml') return 'Core ML';
-                      if (model.backend === 'qnn') return 'Qualcomm NPU';
-                      return 'GPU';
-                    })()}
+                    {imageBackendLabel(model.backend, 'GPU')}
                     {model.style ? ` • ${model.style}` : ''}
                   </Text>
                 </View>

--- a/src/utils/imageBackend.ts
+++ b/src/utils/imageBackend.ts
@@ -1,0 +1,27 @@
+/**
+ * Single source of truth for the human-readable label of an image-generation backend.
+ *
+ * The same coreml/qnn/mnn → "Core ML"/"NPU"/"GPU" mapping was duplicated across the
+ * Models tab, the image filter bar, the Download Manager, Storage Settings and the
+ * filter constants — and had already drifted (Storage Settings showed "Qualcomm NPU"
+ * while every other surface showed "NPU"). Define it once; every surface calls this so
+ * the label can't diverge again.
+ *
+ * `fallback` is the label for an unknown/absent backend — it differs by surface (a model
+ * author line wants "GPU", a filter chip wants "Backend"), so callers pass their own.
+ */
+export function imageBackendLabel(
+  backend: string | undefined | null,
+  fallback: string = 'GPU',
+): string {
+  switch (backend) {
+    case 'coreml':
+      return 'Core ML';
+    case 'qnn':
+      return 'NPU';
+    case 'mnn':
+      return 'GPU';
+    default:
+      return fallback;
+  }
+}


### PR DESCRIPTION
## What

The coreml/qnn/mnn → "Core ML"/"NPU"/"GPU" mapping for image-generation backends was duplicated across five surfaces (Models tab, image filter bar, Download Manager, Storage Settings, and the model-descriptor builder). It had already drifted: Storage Settings rendered **"Qualcomm NPU"** while every other surface rendered **"NPU"**.

This collapses the mapping into one function, `imageBackendLabel(backend, fallback)`, and routes every surface through it. The per-surface fallback (author line → "GPU", filter chip → "Backend", download row → "Image Generation") is passed in by the caller, so the label itself can no longer diverge.

## Why (SOLID)

Single source of truth / DRY: the backend→label rule is now defined once and reused, instead of the same `switch` copy-pasted into five callers where it had already gone out of sync.

## Tests
- New `__tests__/unit/utils/imageBackend.test.ts` drives the real function across all backends + fallbacks, and pins the qnn→"NPU" normalization (fails-before/passes-after for the drift).
- Updated `StorageSettingsScreen.test.tsx` to the corrected contract (qnn now renders "NPU", never "Qualcomm NPU").
- `npx tsc --noEmit` clean; related suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized image model backend labels across the app, including clearer labels like Core ML, NPU, and GPU.
  * Added fallback handling so unknown or missing backend values display a consistent label.

* **Bug Fixes**
  * Updated model and storage views to show the expected backend names instead of inconsistent or overly specific labels.
  * Improved label behavior for image generation and model filtering so the same backend is shown consistently everywhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->