### PR TITLE
feat: aggressive model loading (bigger models load, with Load-Anyway override) + no-model loading feedback

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ import { initDebugLogFile, appendDebugLine } from './src/utils/debugLogFile';
 import { loadProFeatures } from './src/bootstrap/loadProFeatures';
 import { checkProStatus } from './src/services/proLicenseService';
 import { hydrateDownloadStore } from './src/services/downloadHydration';
+import { startLoadPolicySync } from './src/services/loadPolicySync';
 import { registerCoreDownloadProviders } from './src/services/modelDownloadService/registerProviders';
 import { useDownloadListeners } from './src/hooks/useDownloads';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
@@ -141,6 +142,11 @@ function App() {
     try {
       // Ensure persisted download metadata is loaded before restore logic reads it.
       await ensureAppStoreHydrated();
+
+      // Project the persisted "aggressive model loading" setting onto the residency
+      // manager (single owner of the runtime load policy) now that settings are
+      // hydrated, and keep it in sync for the app's lifetime.
+      startLoadPolicySync();
 
       // Hydrate download store from SQLite before any screen mounts.
       await hydrateDownloadStore().catch((error) => {

--- a/__tests__/integration/models/activeModelService.test.ts
+++ b/__tests__/integration/models/activeModelService.test.ts
@@ -84,6 +84,40 @@ describe('ActiveModelService Integration', () => {
     await activeModelService.syncWithNativeState();
   });
 
+  describe('Text Model Loading — aggressive load override ("Load Anyway")', () => {
+    // A GGUF whose estimated RAM exceeds the budget on the current device.
+    const oversized = () => createDownloadedModel({
+      id: 'huge-1', engine: 'llama' as any, fileName: 'huge.gguf', filePath: '/huge.gguf',
+      fileSize: 21 * 1024 * 1024 * 1024,
+    });
+
+    it('throws an OverridableMemoryError when the model does not fit (no override)', async () => {
+      mockHardwareService.getTotalMemoryGB.mockReturnValue(24);
+      mockHardwareService.getAvailableMemoryGB.mockReturnValue(24);
+      mockLlmService.isModelLoaded.mockReturnValue(false);
+      useAppStore.setState({ downloadedModels: [oversized()] });
+
+      const { isOverridableMemoryError } = require('../../../src/services/modelLoadErrors');
+      let caught: unknown;
+      await activeModelService.loadTextModel('huge-1').catch((e: unknown) => { caught = e; });
+      expect(caught).toBeDefined();
+      expect(isOverridableMemoryError(caught)).toBe(true);
+      expect(mockLlmService.loadModel).not.toHaveBeenCalled();
+    });
+
+    it('loads the same model when called with { override: true } (forces past the gate)', async () => {
+      mockHardwareService.getTotalMemoryGB.mockReturnValue(24);
+      mockHardwareService.getAvailableMemoryGB.mockReturnValue(24);
+      mockLlmService.isModelLoaded.mockReturnValue(true);
+      useAppStore.setState({ downloadedModels: [oversized()] });
+
+      await activeModelService.loadTextModel('huge-1', undefined, { override: true });
+
+      expect(mockLlmService.loadModel).toHaveBeenCalled();
+      expect(getAppState().activeModelId).toBe('huge-1');
+    });
+  });
+
   describe('Text Model Loading', () => {
     it('should load text model via llmService and update store', async () => {
       const model = createDownloadedModel({ id: 'test-model-1' });
@@ -113,14 +147,14 @@ describe('ActiveModelService Integration', () => {
       const litert = createDownloadedModel({ id: 'litert-1', engine: 'litert' as any, fileName: 'm.litertlm', filePath: '/m.litertlm' });
       useAppStore.setState({ downloadedModels: [litert] });
       await activeModelService.loadTextModel('litert-1').catch(() => {});
-      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ key: 'text', dirtyMemory: true }));
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ key: 'text', dirtyMemory: true }), expect.anything());
 
       // GGUF/llama is clean mmap -> physical-cap budgeting unchanged (dirtyMemory:false).
       spy.mockClear();
       const gguf = createDownloadedModel({ id: 'gguf-1', engine: 'llama' as any });
       useAppStore.setState({ downloadedModels: [gguf] });
       await activeModelService.loadTextModel('gguf-1').catch(() => {});
-      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ key: 'text', dirtyMemory: false }));
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ key: 'text', dirtyMemory: false }), expect.anything());
       spy.mockRestore();
     });
 

--- a/__tests__/integration/models/activeModelService.test.ts
+++ b/__tests__/integration/models/activeModelService.test.ts
@@ -555,6 +555,27 @@ describe('ActiveModelService Integration', () => {
       expect(result.severity).toBe('critical');
     });
 
+    it('aggressive load policy relaxes the PRE-CHECK too (not just residency), end-to-end', async () => {
+      // 6.5GB file → ~9.75GB required (1.5x). On a 12GB device this exceeds the
+      // balanced budget (0.70 Android / 0.78 iOS) but fits the aggressive budget
+      // (0.88 / 0.92) — proving the pre-check reads the residency manager's policy.
+      const model = createDownloadedModel({ id: 'mid-model', fileSize: 6.5 * 1024 * 1024 * 1024 });
+      useAppStore.setState({ downloadedModels: [model] });
+      mockHardwareService.getDeviceInfo.mockResolvedValue(
+        createDeviceInfo({ totalMemory: 12 * 1024 * 1024 * 1024 })
+      );
+
+      modelResidencyManager.setLoadPolicy('balanced');
+      const balanced = await activeModelService.checkMemoryForModel('mid-model', 'text');
+      expect(balanced.canLoad).toBe(false);
+
+      modelResidencyManager.setLoadPolicy('aggressive');
+      const aggressive = await activeModelService.checkMemoryForModel('mid-model', 'text');
+      expect(aggressive.canLoad).toBe(true);
+
+      modelResidencyManager.setLoadPolicy('balanced'); // don't leak policy to other tests
+    });
+
     it('should return blocked for non-existent model', async () => {
       useAppStore.setState({ downloadedModels: [] });
 

--- a/__tests__/rntl/components/TranscriptionModelsTab.test.tsx
+++ b/__tests__/rntl/components/TranscriptionModelsTab.test.tsx
@@ -22,7 +22,6 @@ jest.mock('../../../src/services', () => ({
 
 const mockWhisperActions = {
   downloadModel: jest.fn(async () => {}),
-  downloadFromUrl: jest.fn(async () => {}),
   selectModel: jest.fn(async () => {}),
   deleteModel: jest.fn(),
   deleteModelById: jest.fn(async () => {}),

--- a/__tests__/rntl/screens/ModelSettingsScreen.test.tsx
+++ b/__tests__/rntl/screens/ModelSettingsScreen.test.tsx
@@ -263,6 +263,28 @@ describe('ModelSettingsScreen', () => {
   });
 
   // ============================================================================
+  describe('aggressive loading toggle', () => {
+    it('renders the Aggressive Loading label', () => {
+      const { getByText } = renderWithSections('text');
+      expect(getByText('Aggressive Loading')).toBeTruthy();
+    });
+
+    it('turns the setting on via the switch', () => {
+      useAppStore.getState().updateSettings({ aggressiveModelLoading: false });
+      const { getByTestId } = renderWithSections('text');
+      fireEvent(getByTestId('aggressive-loading-switch'), 'valueChange', true);
+      expect(useAppStore.getState().settings.aggressiveModelLoading).toBe(true);
+    });
+
+    it('turns the setting off via the switch', () => {
+      useAppStore.getState().updateSettings({ aggressiveModelLoading: true });
+      const { getByTestId } = renderWithSections('text');
+      fireEvent(getByTestId('aggressive-loading-switch'), 'valueChange', false);
+      expect(useAppStore.getState().settings.aggressiveModelLoading).toBe(false);
+    });
+  });
+
+  // ============================================================================
   // Image Generation Settings
   // ============================================================================
   describe('image generation settings', () => {
@@ -796,6 +818,7 @@ describe('ModelSettingsScreen', () => {
           inferenceBackend: undefined as any,
           gpuLayers: undefined as any,
           flashAttn: undefined as any,
+          aggressiveModelLoading: undefined as any,
           cacheType: undefined as any,
           showGenerationDetails: undefined as any,
           enhanceImagePrompts: undefined as any,

--- a/__tests__/rntl/screens/NoModelScreen.test.tsx
+++ b/__tests__/rntl/screens/NoModelScreen.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * NoModelScreen — the empty state shown before a model is active.
+ *
+ * Regression: selecting a model kicks off a background load, but activeModelId
+ * stays null until the native load finishes, so this screen stayed visible with
+ * NO feedback and the user thought nothing happened. It must show a loading
+ * indicator while isModelLoading is true instead of the "Select Model" prompt.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('../../../src/components', () => ({
+  ModelSelectorModal: () => null,
+}));
+jest.mock('../../../src/services', () => ({
+  llmService: { getLoadedModelPath: () => null },
+}));
+
+import { NoModelScreen } from '../../../src/screens/ChatScreen/ChatScreenComponents';
+import { createStyles } from '../../../src/screens/ChatScreen/styles';
+import { getTheme } from '../../../src/theme';
+
+const theme = getTheme('light');
+const colors = theme.colors;
+const styles = createStyles(colors, theme.shadows);
+
+function renderScreen(overrides: Partial<React.ComponentProps<typeof NoModelScreen>> = {}) {
+  return render(
+    <NoModelScreen
+      styles={styles}
+      colors={colors}
+      navigation={{ goBack: jest.fn() }}
+      hasAvailableModels
+      showModelSelector={false}
+      setShowModelSelector={jest.fn()}
+      onSelectModel={jest.fn()}
+      onUnloadModel={jest.fn()}
+      isModelLoading={false}
+      {...overrides}
+    />,
+  );
+}
+
+describe('NoModelScreen', () => {
+  it('shows the "Select Model" prompt when idle (not loading)', () => {
+    const { getByText, queryByTestId } = renderScreen({ isModelLoading: false });
+    expect(getByText('No Model Selected')).toBeTruthy();
+    expect(getByText('Select Model')).toBeTruthy();
+    expect(queryByTestId('no-model-loading-indicator')).toBeNull();
+  });
+
+  it('shows a loading indicator (not the prompt) while a model loads in the background', () => {
+    const { getByText, getByTestId, queryByText } = renderScreen({ isModelLoading: true });
+    expect(getByTestId('no-model-loading-indicator')).toBeTruthy();
+    expect(getByText('Loading Model')).toBeTruthy();
+    // The idle prompt + Select button must be hidden so the user isn't told to
+    // re-select a model that is already loading.
+    expect(queryByText('No Model Selected')).toBeNull();
+    expect(queryByText('Select Model')).toBeNull();
+  });
+});

--- a/__tests__/unit/hooks/useChatModelActions.test.ts
+++ b/__tests__/unit/hooks/useChatModelActions.test.ts
@@ -171,7 +171,9 @@ describe('initiateModelLoad', () => {
     loadAnyway.onPress();
     await jest.advanceTimersByTimeAsync(400); // flush waitForRenderFrame -> doLoadTextModel -> resume
 
-    expect(mockLoadTextModel).toHaveBeenCalledWith('model-1');
+    // Load Anyway must force the residency gate too (override:true), or the load
+    // re-hits the budget and fails — the exact "Load Anyway did nothing" bug.
+    expect(mockLoadTextModel).toHaveBeenCalledWith('model-1', undefined, { override: true });
     expect(onResume).toHaveBeenCalledTimes(1); // the message is NOT dropped
     iaSpy.mockRestore();
     jest.useRealTimers();
@@ -192,7 +194,7 @@ describe('initiateModelLoad', () => {
     alert.buttons.find((b: any) => b.text === 'Load Anyway').onPress();
     await jest.advanceTimersByTimeAsync(400);
 
-    expect(mockLoadTextModel).toHaveBeenCalledWith('model-1'); // still loads
+    expect(mockLoadTextModel).toHaveBeenCalledWith('model-1', undefined, { override: true }); // still loads (forced)
     iaSpy.mockRestore();
     jest.useRealTimers();
   });

--- a/__tests__/unit/services/loadPolicySync.test.ts
+++ b/__tests__/unit/services/loadPolicySync.test.ts
@@ -1,0 +1,73 @@
+/**
+ * loadPolicySync — the single projection of the persisted "aggressive model
+ * loading" setting onto the residency manager's runtime policy.
+ *
+ * Drives the REAL appStore and the REAL modelResidencyManager (the thing under
+ * test is not mocked) so a green test means the projection actually works end to
+ * end: flip the setting → the manager's policy changes.
+ */
+import { loadPolicyFromSettings, startLoadPolicySync } from '../../../src/services/loadPolicySync';
+import { modelResidencyManager } from '../../../src/services/modelResidency';
+import { useAppStore } from '../../../src/stores';
+
+describe('loadPolicyFromSettings (the one boolean→policy mapping)', () => {
+  it('maps the flag to a policy', () => {
+    expect(loadPolicyFromSettings({ aggressiveModelLoading: true })).toBe('aggressive');
+    expect(loadPolicyFromSettings({ aggressiveModelLoading: false })).toBe('balanced');
+    expect(loadPolicyFromSettings({})).toBe('balanced');
+  });
+});
+
+describe('startLoadPolicySync', () => {
+  let unsubscribe: (() => void) | undefined;
+
+  beforeEach(() => {
+    useAppStore.getState().updateSettings({ aggressiveModelLoading: false });
+    modelResidencyManager.setLoadPolicy('balanced');
+  });
+  afterEach(() => {
+    unsubscribe?.();
+    unsubscribe = undefined;
+    modelResidencyManager.setLoadPolicy('balanced');
+  });
+
+  it('seeds the manager from the current (hydrated) setting on start', () => {
+    useAppStore.getState().updateSettings({ aggressiveModelLoading: true });
+    modelResidencyManager.setLoadPolicy('balanced'); // simulate a fresh manager
+    unsubscribe = startLoadPolicySync();
+    expect(modelResidencyManager.getLoadPolicy()).toBe('aggressive');
+  });
+
+  it('projects a later toggle onto the manager (View dispatches intent, service owns state)', () => {
+    unsubscribe = startLoadPolicySync();
+    expect(modelResidencyManager.getLoadPolicy()).toBe('balanced');
+
+    useAppStore.getState().updateSettings({ aggressiveModelLoading: true });
+    expect(modelResidencyManager.getLoadPolicy()).toBe('aggressive');
+
+    useAppStore.getState().updateSettings({ aggressiveModelLoading: false });
+    expect(modelResidencyManager.getLoadPolicy()).toBe('balanced');
+  });
+
+  it('stops projecting after unsubscribe', () => {
+    unsubscribe = startLoadPolicySync();
+    unsubscribe();
+    unsubscribe = undefined;
+    useAppStore.getState().updateSettings({ aggressiveModelLoading: true });
+    // No longer synced → manager keeps its last value.
+    expect(modelResidencyManager.getLoadPolicy()).toBe('balanced');
+  });
+
+  it('does not fire setLoadPolicy for unrelated setting changes (only on flag flip)', () => {
+    unsubscribe = startLoadPolicySync();
+    const spy = jest.spyOn(modelResidencyManager, 'setLoadPolicy');
+    // Change an unrelated setting several times.
+    useAppStore.getState().updateSettings({ temperature: 0.5 });
+    useAppStore.getState().updateSettings({ maxTokens: 2048 });
+    expect(spy).not.toHaveBeenCalled();
+    // Flipping the flag DOES fire it.
+    useAppStore.getState().updateSettings({ aggressiveModelLoading: true });
+    expect(spy).toHaveBeenCalledWith('aggressive');
+    spy.mockRestore();
+  });
+});

--- a/__tests__/unit/services/loadPolicySync.test.ts
+++ b/__tests__/unit/services/loadPolicySync.test.ts
@@ -58,6 +58,19 @@ describe('startLoadPolicySync', () => {
     expect(modelResidencyManager.getLoadPolicy()).toBe('balanced');
   });
 
+  it('is a singleton — calling twice does NOT stack subscriptions (leak guard)', () => {
+    const first = startLoadPolicySync();
+    const second = startLoadPolicySync();
+    expect(second).toBe(first); // same live unsubscribe returned, not a new subscription
+    unsubscribe = first;
+
+    const spy = jest.spyOn(modelResidencyManager, 'setLoadPolicy');
+    // One flag flip → setLoadPolicy fires exactly once, not once-per-start.
+    useAppStore.getState().updateSettings({ aggressiveModelLoading: true });
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
   it('does not fire setLoadPolicy for unrelated setting changes (only on flag flip)', () => {
     unsubscribe = startLoadPolicySync();
     const spy = jest.spyOn(modelResidencyManager, 'setLoadPolicy');

--- a/__tests__/unit/services/memoryBudget.test.ts
+++ b/__tests__/unit/services/memoryBudget.test.ts
@@ -7,7 +7,10 @@ import {
   modelBudgetFraction,
   modelMemoryBudgetMB,
   modelWarningThresholdMB,
+  memoryReserveMB,
+  policyAllowsOverride,
   MEMORY_RESERVE_MB,
+  AGGRESSIVE_RESERVE_MB,
 } from '../../../src/services/memoryBudget';
 
 const GB = 1024;
@@ -52,5 +55,47 @@ describe('modelWarningThresholdMB', () => {
       const total = gb * GB;
       expect(modelWarningThresholdMB(total, 'ios')).toBeLessThanOrEqual(modelMemoryBudgetMB(total, 'ios'));
     }
+  });
+});
+
+describe('load policy — aggressive vs balanced', () => {
+  it("defaults to balanced (behaviour-neutral) when policy omitted", () => {
+    for (const gb of [4, 8, 12, 24]) {
+      expect(modelBudgetFraction(gb, 'android')).toBe(modelBudgetFraction(gb, 'android', 'balanced'));
+      expect(modelMemoryBudgetMB(gb * GB, 'android')).toBe(modelMemoryBudgetMB(gb * GB, 'android', 'balanced'));
+    }
+  });
+
+  it('aggressive commits a strictly larger fraction at every tier', () => {
+    for (const [gb, plat] of [[4, 'android'], [8, 'android'], [12, 'android'], [12, 'ios'], [24, 'android']] as const) {
+      expect(modelBudgetFraction(gb, plat, 'aggressive')).toBeGreaterThan(modelBudgetFraction(gb, plat, 'balanced'));
+    }
+  });
+
+  it('aggressive holds a smaller (but non-zero) OS reserve — the lenient safeguard', () => {
+    expect(memoryReserveMB('aggressive')).toBe(AGGRESSIVE_RESERVE_MB);
+    expect(memoryReserveMB('balanced')).toBe(MEMORY_RESERVE_MB);
+    expect(AGGRESSIVE_RESERVE_MB).toBeGreaterThan(0);
+    expect(AGGRESSIVE_RESERVE_MB).toBeLessThan(MEMORY_RESERVE_MB);
+  });
+
+  it('fails-before/passes-after: a 21GB model is rejected on a 24GB phone under balanced but fits under aggressive', () => {
+    const total = 24 * GB;
+    const model = 21 * GB;
+    // Balanced: 24GB * 0.70 = 16.8GB budget → 21GB does NOT fit.
+    expect(modelMemoryBudgetMB(total, 'android', 'balanced')).toBeLessThan(model);
+    // Aggressive: pushes near the physical ceiling → 21GB fits (Nico's Qwen3 MoE case).
+    expect(modelMemoryBudgetMB(total, 'android', 'aggressive')).toBeGreaterThanOrEqual(model);
+  });
+
+  it('only aggressive permits a user override of a hard block', () => {
+    expect(policyAllowsOverride('aggressive')).toBe(true);
+    expect(policyAllowsOverride('balanced')).toBe(false);
+    expect(policyAllowsOverride()).toBe(false);
+  });
+
+  it('aggressive still never commits past its own reserve floor', () => {
+    const total = 24 * GB;
+    expect(modelMemoryBudgetMB(total, 'android', 'aggressive')).toBeLessThanOrEqual(total - AGGRESSIVE_RESERVE_MB);
   });
 });

--- a/__tests__/unit/services/memoryBudget.test.ts
+++ b/__tests__/unit/services/memoryBudget.test.ts
@@ -8,7 +8,6 @@ import {
   modelMemoryBudgetMB,
   modelWarningThresholdMB,
   memoryReserveMB,
-  policyAllowsOverride,
   MEMORY_RESERVE_MB,
   AGGRESSIVE_RESERVE_MB,
 } from '../../../src/services/memoryBudget';
@@ -86,12 +85,6 @@ describe('load policy — aggressive vs balanced', () => {
     expect(modelMemoryBudgetMB(total, 'android', 'balanced')).toBeLessThan(model);
     // Aggressive: pushes near the physical ceiling → 21GB fits (Nico's Qwen3 MoE case).
     expect(modelMemoryBudgetMB(total, 'android', 'aggressive')).toBeGreaterThanOrEqual(model);
-  });
-
-  it('only aggressive permits a user override of a hard block', () => {
-    expect(policyAllowsOverride('aggressive')).toBe(true);
-    expect(policyAllowsOverride('balanced')).toBe(false);
-    expect(policyAllowsOverride()).toBe(false);
   });
 
   it('aggressive still never commits past its own reserve floor', () => {

--- a/__tests__/unit/services/modelLoadErrors.test.ts
+++ b/__tests__/unit/services/modelLoadErrors.test.ts
@@ -1,0 +1,28 @@
+import { OverridableMemoryError, isOverridableMemoryError } from '../../../src/services/modelLoadErrors';
+
+describe('OverridableMemoryError', () => {
+  it('is a real Error subclass carrying the overridable discriminant', () => {
+    const err = new OverridableMemoryError('no room');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(OverridableMemoryError);
+    expect(err.message).toBe('no room');
+    expect(err.name).toBe('OverridableMemoryError');
+    expect(err.overridable).toBe(true);
+  });
+
+  it('isOverridableMemoryError recognises the class', () => {
+    expect(isOverridableMemoryError(new OverridableMemoryError('x'))).toBe(true);
+  });
+
+  it('isOverridableMemoryError recognises a duck-typed object (survives async/serialisation boundaries)', () => {
+    expect(isOverridableMemoryError({ overridable: true, message: 'x' })).toBe(true);
+  });
+
+  it('rejects plain errors and non-errors', () => {
+    expect(isOverridableMemoryError(new Error('generic'))).toBe(false);
+    expect(isOverridableMemoryError('memory')).toBe(false);
+    expect(isOverridableMemoryError(null)).toBe(false);
+    expect(isOverridableMemoryError(undefined)).toBe(false);
+    expect(isOverridableMemoryError({ overridable: false })).toBe(false);
+  });
+});

--- a/__tests__/unit/services/modelResidency.test.ts
+++ b/__tests__/unit/services/modelResidency.test.ts
@@ -24,6 +24,14 @@ describe('computeBudgetMB', () => {
   it('never returns negative', () => {
     expect(computeBudgetMB(1000)).toBe(0);
   });
+
+  it('passes the load policy through to the budget owner (aggressive > balanced)', () => {
+    expect(computeBudgetMB(24576, { policy: 'aggressive' })).toBeGreaterThan(
+      computeBudgetMB(24576, { policy: 'balanced' }),
+    );
+    // Omitting policy is behaviour-neutral (balanced).
+    expect(computeBudgetMB(24576)).toBe(computeBudgetMB(24576, { policy: 'balanced' }));
+  });
 });
 
 describe('planEviction', () => {
@@ -434,6 +442,97 @@ describe('ModelResidencyManager', () => {
       expect(ttsUnload).not.toHaveBeenCalled();
       expect(evicted).toEqual([]);
       expect(modelResidencyManager.isResident('tts')).toBe(true);
+    });
+  });
+
+  describe('load policy (aggressive) + override', () => {
+    beforeEach(() => {
+      modelResidencyManager._reset();
+      modelResidencyManager.setLoadPolicy('balanced');
+    });
+    afterEach(() => {
+      jest.restoreAllMocks();
+      modelResidencyManager.setLoadPolicy('balanced'); // never leak policy across suites
+    });
+
+    it('defaults to balanced and round-trips setLoadPolicy/getLoadPolicy', () => {
+      expect(modelResidencyManager.getLoadPolicy()).toBe('balanced');
+      modelResidencyManager.setLoadPolicy('aggressive');
+      expect(modelResidencyManager.getLoadPolicy()).toBe('aggressive');
+    });
+
+    it('fails-before/passes-after: a 21GB GGUF is refused on a 24GB phone under balanced, fits under aggressive', async () => {
+      modelResidencyManager.setBudgetOverrideMB(null);
+      jest.spyOn(hardwareService, 'getTotalMemoryGB').mockReturnValue(24);
+      jest.spyOn(hardwareService, 'getAvailableMemoryGB').mockReturnValue(8);
+      jest.spyOn(hardwareService, 'refreshMemoryInfo').mockResolvedValue(undefined as never);
+      const spec = { key: 'text', type: 'text' as const, sizeMB: 21 * 1024 };
+
+      // Balanced: 24GB * 0.70 ≈ 16.8GB budget → 21GB does not fit (Nico's Qwen3 MoE).
+      const balanced = await modelResidencyManager.makeRoomFor(spec);
+      expect(balanced.fits).toBe(false);
+
+      // Aggressive: pushes near the physical ceiling → the same model now fits.
+      modelResidencyManager.setLoadPolicy('aggressive');
+      const aggressive = await modelResidencyManager.makeRoomFor(spec);
+      expect(aggressive.fits).toBe(true);
+    });
+
+    it('override forces a load that still will not fit, evicting everything evictable first', async () => {
+      modelResidencyManager.setBudgetOverrideMB(1000); // tiny budget so nothing big fits
+      jest.spyOn(hardwareService, 'refreshMemoryInfo').mockResolvedValue(undefined as never);
+      const unloadImg = jest.fn().mockResolvedValue(undefined);
+      modelResidencyManager.register({ key: 'image', type: 'image', sizeMB: 400 }, unloadImg, 1);
+
+      // Without override: refuse and DON'T evict (never strand the device).
+      const blocked = await modelResidencyManager.makeRoomFor({ key: 'huge', type: 'text', sizeMB: 5000 });
+      expect(blocked.fits).toBe(false);
+      expect(unloadImg).not.toHaveBeenCalled();
+      expect(modelResidencyManager.isResident('image')).toBe(true);
+
+      // With override ("Load Anyway"): force fits=true AND free max room (evict image).
+      const forced = await modelResidencyManager.makeRoomFor(
+        { key: 'huge', type: 'text', sizeMB: 5000 },
+        { override: true },
+      );
+      expect(forced.fits).toBe(true);
+      expect(forced.evicted).toContain('image');
+      expect(unloadImg).toHaveBeenCalledTimes(1);
+      expect(modelResidencyManager.isResident('image')).toBe(false);
+    });
+
+    it('override is behaviour-neutral when the model already fits (no forced eviction)', async () => {
+      modelResidencyManager.setBudgetOverrideMB(2000);
+      jest.spyOn(hardwareService, 'refreshMemoryInfo').mockResolvedValue(undefined as never);
+      const unloadImg = jest.fn().mockResolvedValue(undefined);
+      modelResidencyManager.register({ key: 'image', type: 'image', sizeMB: 500 }, unloadImg, 1);
+      const { fits, evicted } = await modelResidencyManager.makeRoomFor(
+        { key: 'text', type: 'text', sizeMB: 1000 },
+        { override: true },
+      );
+      expect(fits).toBe(true);
+      expect(evicted).toEqual([]); // fit without eviction — override changed nothing
+      expect(unloadImg).not.toHaveBeenCalled();
+    });
+
+    it('aggressive holds a leaner dirty headroom so a dirty load the balanced guard refuses is allowed', async () => {
+      modelResidencyManager.setBudgetOverrideMB(null);
+      jest.spyOn(hardwareService, 'getTotalMemoryGB').mockReturnValue(12);
+      // ~3.4GB free: balanced dirty headroom (1024) → budget ≈ 2.4GB; aggressive (512) → ≈ 2.9GB.
+      jest.spyOn(hardwareService, 'getAvailableMemoryGB').mockReturnValue(3.4);
+      jest.spyOn(hardwareService, 'refreshMemoryInfo').mockResolvedValue(undefined as never);
+      // A resident dirty model creates dirty pressure so the live-RAM branch is used.
+      modelResidencyManager.register(
+        { key: 'image', type: 'image', sizeMB: 100, dirtyMemory: true, canEvict: () => false },
+        jest.fn().mockResolvedValue(undefined), 1);
+      const spec = { key: 'litert', type: 'text' as const, sizeMB: 2700, dirtyMemory: true };
+
+      const balanced = await modelResidencyManager.makeRoomFor(spec);
+      expect(balanced.fits).toBe(false);
+
+      modelResidencyManager.setLoadPolicy('aggressive');
+      const aggressive = await modelResidencyManager.makeRoomFor(spec);
+      expect(aggressive.fits).toBe(true);
     });
   });
 });

--- a/__tests__/unit/services/whisperService.branches.test.ts
+++ b/__tests__/unit/services/whisperService.branches.test.ts
@@ -2,7 +2,7 @@
  * WhisperService — additional branch coverage.
  *
  * Targets error/cleanup paths not exercised by whisperService.test.ts:
- * downloadModel validation failure, downloadFromUrl, listDownloadedModels,
+ * downloadModel validation failure, listDownloadedModels,
  * deleteModel active-download cancellation, loadModel release-wait,
  * unloadModel mid-transcription, requestPermissions non-mobile platform,
  * and startRealtimeTranscription guards / event finish / error paths.
@@ -90,68 +90,6 @@ describe('WhisperService — branch coverage', () => {
     });
   });
 
-  // ── downloadFromUrl (lines 92-112) ────────────────────────────────────────
-  describe('downloadFromUrl', () => {
-    it('returns existing path if already downloaded', async () => {
-      mockedRNFS.exists
-        .mockResolvedValueOnce(true)  // dir exists (ensureModelsDirExists)
-        .mockResolvedValueOnce(true); // dest already present
-      const result = await whisperService.downloadFromUrl('http://x/m.bin', 'tiny.en');
-      expect(result).toBe('/mock/documents/whisper-models/ggml-tiny.en.bin');
-      expect(mockedRNFS.downloadFile).not.toHaveBeenCalled();
-    });
-
-    it('downloads, validates and returns dest path on success', async () => {
-      mockedRNFS.exists
-        .mockResolvedValueOnce(true)   // dir exists
-        .mockResolvedValueOnce(false)  // not downloaded
-        .mockResolvedValueOnce(true);  // validateModelFile exists
-      mockedRNFS.stat.mockResolvedValueOnce({ size: 75 * 1024 * 1024, isFile: () => true } as any);
-      let progressCb: ((res: any) => void) | undefined;
-      mockedRNFS.downloadFile.mockImplementation((opts: any) => {
-        progressCb = opts.progress;
-        return { jobId: 1, promise: Promise.resolve({ statusCode: 200, bytesWritten: 1 }) } as any;
-      });
-
-      const onProgress = jest.fn();
-      const result = await whisperService.downloadFromUrl('http://x/m.bin', 'tiny.en', onProgress);
-      // exercise the progress callback branch
-      progressCb?.({ bytesWritten: 50, contentLength: 100 });
-      expect(onProgress).toHaveBeenCalledWith(0.5);
-      expect(result).toBe('/mock/documents/whisper-models/ggml-tiny.en.bin');
-    });
-
-    it('unlinks and throws when status code is not 200', async () => {
-      mockedRNFS.exists
-        .mockResolvedValueOnce(true)   // dir exists
-        .mockResolvedValueOnce(false); // not downloaded
-      mockedRNFS.unlink.mockResolvedValue(undefined as any);
-      mockedRNFS.downloadFile.mockReturnValue({
-        jobId: 1,
-        promise: Promise.resolve({ statusCode: 404, bytesWritten: 0 }),
-      } as any);
-
-      await expect(whisperService.downloadFromUrl('http://x/m.bin', 'tiny.en')).rejects.toThrow(
-        'Download failed with status 404',
-      );
-      expect(mockedRNFS.unlink).toHaveBeenCalledWith('/mock/documents/whisper-models/ggml-tiny.en.bin');
-    });
-
-    it('rethrows validation error and unlinks when downloaded file is invalid', async () => {
-      mockedRNFS.exists
-        .mockResolvedValueOnce(true)   // dir exists
-        .mockResolvedValueOnce(false)  // not downloaded
-        .mockResolvedValueOnce(true);  // validateModelFile exists
-      mockedRNFS.stat.mockResolvedValueOnce({ size: 500, isFile: () => true } as any); // too small
-      mockedRNFS.unlink.mockResolvedValue(undefined as any);
-      mockedRNFS.downloadFile.mockReturnValue({
-        jobId: 1,
-        promise: Promise.resolve({ statusCode: 200, bytesWritten: 1 }),
-      } as any);
-
-      await expect(whisperService.downloadFromUrl('http://x/m.bin', 'tiny.en')).rejects.toThrow(/too small/);
-    });
-  });
 
   // ── listDownloadedModels (lines 114-127) ──────────────────────────────────
   describe('listDownloadedModels', () => {

--- a/__tests__/utils/testHelpers.ts
+++ b/__tests__/utils/testHelpers.ts
@@ -66,6 +66,7 @@ export const resetStores = (): void => {
       inferenceBackend: 'cpu' as const,
       gpuLayers: 99,
       flashAttn: false,
+      aggressiveModelLoading: false,
       cacheType: 'q8_0',
       showGenerationDetails: false,
       enhanceImagePrompts: false,

--- a/docs/GAPS_BACKLOG.md
+++ b/docs/GAPS_BACKLOG.md
@@ -1,0 +1,67 @@
+# Gaps backlog
+
+Honest register of gaps, regressions, dead code, and "not fully done" items. Each
+entry has a verdict and evidence. The standing gap agent picks these up, closes
+them, and marks them resolved with evidence. Gaps are surfaced, never hidden.
+
+Verdict legend:
+- **delete-safe** — unreferenced / unreachable and provably unused; remove it.
+- **fix-the-guard** — the branch is SUPPOSED to fire but a condition prevents it; fix the condition (this is a latent bug, not litter).
+- **instrument-and-revisit** — uncertain trigger; add a `[*-SM]` trace + a Provit journey to observe it live before deciding.
+
+---
+
+## Dead-code recon — 2026-07-06
+
+Recon sweep (4 parallel agents over disjoint subsystems) for unreferenced exports,
+unreachable branches, duplicated logic, and threaded-but-unread params. All findings
+grep-verified. Nothing deleted yet — this is the register; deletions land as their own
+small PRs after each is confirmed.
+
+### Model-load / generation
+| # | Location | Symbol | Verdict | Note |
+|---|----------|--------|---------|------|
+| ML1 | activeModelService/index.ts:~469 | `getCurrentlyLoadedMemoryGB()` (private wrapper) | instrument-and-revisit | CORRECTION: recon said "zero call sites" but tests DO exercise it (integration + memory unit). Test-only API — deleting needs the tests reworked, not a blind delete. |
+| ML2 | activeModelService/index.ts:~475 | `checkMemoryForDualModel()` (public wrapper) | instrument-and-revisit | CORRECTION: exercised by integration tests + mocked in HomeScreen test. Prod never calls it — decide keep-vs-remove in the dead-code PR, with tests. |
+| ML3 | activeModelService/utils.ts:16-17 vs types.ts:48-50 | overhead multipliers (1.2/1.3 hardcoded vs 1.5/1.8 constants) | fix-the-guard | HomeScreen memory display disagrees with the load-path math; import the shared constants |
+| ML4 | useChatModelActions.ts (needsReload double-check) | redundant `&& loadedPath === activeModel.filePath` | instrument-and-revisit | logically impossible to be false; simplify |
+| ML5 | activeModelService/index.ts:~338 + loaders.ts | `cpuOnly: false` (always false) | delete-safe | native CPU-only branch unreachable from TS |
+
+> Note: the recon confirmed the "Load Anyway" flow is NOT dead once the residency gate
+> throws a typed `OverridableMemoryError` (shipped in this PR). Before that, the raised
+> pre-check budget made `canLoad` almost always true, so the pre-check's Load-Anyway was
+> effectively unreachable — the root cause of "Load Anyway stopped happening".
+
+### Download / model-manager
+| # | Location | Symbol | Verdict | Note |
+|---|----------|--------|---------|------|
+| DL1 | downloadHydration.ts:33 | `case 'retrying'` in mapNativeStatus | delete-safe | native (iOS+Android) never emits 'retrying' |
+| DL2 | DownloadManagerScreen/items.tsx:51,60,81,91 (+ downloadStatusIcon.ts, downloadErrors.ts, useDownloads.ts) | branches on `status === 'retrying'` | fix-the-guard | unreachable given DL1; remove or document the contract |
+| DL3 | modelManager/types.ts:13 | `BackgroundDownloadMetadataCallback` (@deprecated, no-op) | delete-safe | author-confirmed no-op, still threaded through 3 sites |
+| DL4 | downloadHydration.ts:25 | `export isMmProjFileName` | delete-safe | only used internally; drop the export |
+| DL5 | modelManager/download.ts:454-462 | `isFinalizing` reset only on error | instrument-and-revisit | verify re-entrancy window on success path |
+
+### Audio / TTS / STT
+| # | Location | Symbol | Verdict | Note |
+|---|----------|--------|---------|------|
+| AU1 | whisperStore.ts:172-189 | `deleteModel()` (vs used `deleteModelById`) | delete-safe | zero call sites |
+| AU2 | audioSessionManager.ts:51-57 | `ensurePlayback()` | delete-safe | only referenced in comments |
+| AU3 | whisperService.ts:145-164 (+ store 97-116) | `downloadFromUrl()` | delete-safe | only reached from an unused store action |
+| AU4 | ChatInput/Voice.ts:136-143 | stopRecording early-return guard | fix-the-guard | inverted condition; can't be true when recording |
+| AU5 | whisperService.ts:338-400 | `transcriptionFullyStopped` promise overwrite | fix-the-guard | new start replaces a promise unloadModel may await |
+| AU6 | audioRecorderService.ts:12-14 | `supportsDirectAudioInput()` stub `return true` | instrument-and-revisit | placeholder; add real capability detection |
+
+### Image-gen / tools / remote
+| # | Location | Symbol | Verdict | Note |
+|---|----------|--------|---------|------|
+| IM1 | types/index.ts:314-320 | duplicate `ImageGenerationState` | delete-safe | authoritative def is in imageGenerationService.ts |
+| IM2 | localDreamGenerator.ts:67 (+ loaders.ts:296) | `backend` param always `'auto'` | delete-safe | 'mnn'/'qnn' branches never reached from TS |
+| IM3 | imageGenerationHelpers.ts:42-44 | iOS short-circuit ignores `backend` | fix-the-guard | 'coreml'/default 'mnn' unreachable on iOS; make explicit |
+| IM4 | localDreamGenerator.ts:236-238 | `hasKernelCache()` wraps `hasOpenCLCache` (name mismatch) | fix-the-guard | rename to match native call |
+| IM5 | localDreamGenerator.ts:231-239 | `clearOpenCLCache`/`hasKernelCache` silent iOS no-op | instrument-and-revisit | throw or gate at call site on iOS |
+
+### Handling policy (how we close these)
+1. **delete-safe** → each removed in a small, single-concern PR with a grep proof of zero references in the description.
+2. **fix-the-guard** → fix the condition, add a fails-before/passes-after test that exercises the now-reachable branch.
+3. **instrument-and-revisit** → add a `[*-SM]` trace + a Provit journey; only decide delete-vs-keep after observing it live.
+4. **Standing gate** → add `knip` (or `ts-prune`) to CI to catch category-1 (unreferenced) dead code continuously, so this register only ever needs the reasoning-heavy categories.

--- a/docs/GAPS_BACKLOG.md
+++ b/docs/GAPS_BACKLOG.md
@@ -60,6 +60,36 @@ small PRs after each is confirmed.
 | IM4 | localDreamGenerator.ts:236-238 | `hasKernelCache()` wraps `hasOpenCLCache` (name mismatch) | fix-the-guard | rename to match native call |
 | IM5 | localDreamGenerator.ts:231-239 | `clearOpenCLCache`/`hasKernelCache` silent iOS no-op | instrument-and-revisit | throw or gate at call site on iOS |
 
+### Verification pass — 2026-07-06 (before acting)
+
+Every "delete-safe" candidate was re-grepped across `src`, `__tests__`, and `pro/`
+before touching anything. The recon **over-reported**: most flagged symbols are
+actually referenced (largely by tests, some by prod). Blind deletion would have
+broken the suite. Verified outcomes:
+
+- **RESOLVED (removed):**
+  - IM1 — duplicate `ImageGenerationState` in `types/index.ts`: zero importers (every
+    consumer takes the service's version). Deleted.
+  - AU3 — `whisperService.downloadFromUrl` + the `whisperStore.downloadFromUrl` action:
+    no UI/hook/screen/pro caller (custom-URL whisper download was never wired). Removed
+    across service + store + its orphaned tests.
+- **FALSE POSITIVE — verified USED, kept:**
+  - AU1 `whisperStore.deleteModel` — called at whisperStore.ts:180/201 + store test.
+  - AU2 `audioSessionManager.ensurePlayback` — full test suite + whisperService.test call.
+  - DL4 `isMmProjFileName` export — imported by `modelManager/restore.ts` + tested directly.
+  - ML1/ML2 — exercised by integration + memory unit tests (see corrected rows above).
+- **DEFERRED (not "dead", changing risks behaviour — kept out of this PR):**
+  - Unreachable-branch removals (DL1/DL2 `retrying`, IM3/IM7 iOS backend short-circuits):
+    they never execute, but removing a value from a status/type union risks exhaustiveness
+    breakage; do it as a typed refactor with its own tests.
+  - Threaded-constant params (ML5 `cpuOnly`, IM2 `backend:'auto'`): passed to the native
+    bridge; removing the arg changes the native call. Not dead in a way that's safe to cut here.
+  - Race/stub items (AU4/AU5/AU6, DL5, DL3 deprecated-callback threading): need on-device
+    observation before change — `instrument-and-revisit`, not a blind edit.
+
+Net: the genuinely-dead, safe-to-remove set was small (IM1 + AU3). Removed here; the
+rest stay in the register with an honest verdict rather than a risky change.
+
 ### Handling policy (how we close these)
 1. **delete-safe** → each removed in a small, single-concern PR with a grep proof of zero references in the description.
 2. **fix-the-guard** → fix the condition, add a fails-before/passes-after test that exercises the now-reachable branch.

--- a/src/screens/ChatScreen/ChatScreenComponents.tsx
+++ b/src/screens/ChatScreen/ChatScreenComponents.tsx
@@ -5,6 +5,7 @@ import {
   TouchableOpacity,
   Modal,
   Image,
+  ActivityIndicator,
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Feather';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -43,19 +44,33 @@ export const NoModelScreen: React.FC<{
       </View>
     </View>
     <View style={styles.noModelContainer}>
-      <View style={styles.noModelIconContainer}>
-        <Icon name="cpu" size={32} color={colors.textMuted} />
-      </View>
-      <Text style={styles.noModelTitle}>No Model Selected</Text>
-      <Text style={styles.noModelText}>
-        {hasAvailableModels
-          ? 'Select a text or image model to get started.'
-          : 'Download a text or image model from the Models tab to get started.'}
-      </Text>
-      {hasAvailableModels && (
-        <TouchableOpacity style={styles.selectModelButton} onPress={() => setShowModelSelector(true)}>
-          <Text style={styles.selectModelButtonText}>Select Model</Text>
-        </TouchableOpacity>
+      {isModelLoading ? (
+        // A model was selected and is loading in the background. activeModelId stays
+        // null until the native load finishes, so this empty state would otherwise
+        // remain with no feedback — the user thinks nothing happened. Show a loading
+        // indicator instead of the "Select Model" prompt.
+        <>
+          <ActivityIndicator size="large" color={colors.primary} testID="no-model-loading-indicator" />
+          <Text style={[styles.noModelTitle, styles.noModelLoadingTitle]}>Loading Model</Text>
+          <Text style={styles.noModelText}>Getting your model ready. This can take a moment.</Text>
+        </>
+      ) : (
+        <>
+          <View style={styles.noModelIconContainer}>
+            <Icon name="cpu" size={32} color={colors.textMuted} />
+          </View>
+          <Text style={styles.noModelTitle}>No Model Selected</Text>
+          <Text style={styles.noModelText}>
+            {hasAvailableModels
+              ? 'Select a text or image model to get started.'
+              : 'Download a text or image model from the Models tab to get started.'}
+          </Text>
+          {hasAvailableModels && (
+            <TouchableOpacity style={styles.selectModelButton} onPress={() => setShowModelSelector(true)}>
+              <Text style={styles.selectModelButtonText}>Select Model</Text>
+            </TouchableOpacity>
+          )}
+        </>
       )}
     </View>
     <ModelSelectorModal

--- a/src/screens/ChatScreen/styles.ts
+++ b/src/screens/ChatScreen/styles.ts
@@ -134,6 +134,7 @@ const createStateScreenStyles = (colors: ThemeColors) => ({
     marginBottom: SPACING.lg,
   },
   noModelTitle: { ...TYPOGRAPHY.h2, color: colors.text, marginBottom: SPACING.sm },
+  noModelLoadingTitle: { marginTop: SPACING.lg },
   noModelText: { ...TYPOGRAPHY.body, color: colors.textSecondary, textAlign: 'center' as const },
   selectModelButton: {
     marginTop: SPACING.xl,

--- a/src/screens/ChatScreen/useChatModelActions.ts
+++ b/src/screens/ChatScreen/useChatModelActions.ts
@@ -10,6 +10,7 @@ import { useAppStore } from '../../stores';
 import { DownloadedModel, RemoteModel, ONNXImageModel } from '../../types';
 import logger from '../../utils/logger';
 import { ModelReadyOutcome, reasonFromLoadError } from './modelReadiness';
+import { isOverridableMemoryError } from '../../services/modelLoadErrors';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 
@@ -60,11 +61,11 @@ function addSystemMsg(
   });
 }
 
-async function doLoadTextModel(deps: ModelActionDeps): Promise<void> {
+async function doLoadTextModel(deps: ModelActionDeps, opts?: { override?: boolean }): Promise<void> {
   const { activeModel, activeModelId } = deps;
   if (!activeModel || !activeModelId) return;
   try {
-    await activeModelService.loadTextModel(activeModelId);
+    await activeModelService.loadTextModel(activeModelId, undefined, opts);
     const multimodalSupport = llmService.getMultimodalSupport();
     deps.setSupportsVision(activeModel.engine === 'litert' ? !!activeModel.liteRTVision : (multimodalSupport?.vision || false));
     if (deps.modelLoadStartTimeRef.current && deps.settings.showGenerationDetails) {
@@ -106,9 +107,12 @@ export async function initiateModelLoad(
               deps.setLoadingModel(activeModel);
               deps.modelLoadStartTimeRef.current = Date.now();
               // Resume the turn after the forced load so the user's message isn't
-              // silently dropped (they'd otherwise have to retype it).
+              // silently dropped (they'd otherwise have to retype it). override:true
+              // makes the residency manager force the load (evict everything, skip the
+              // fit gate) — without it the load re-hit the hard budget gate and failed
+              // with "Failed to load model", defeating the whole "Load Anyway".
               waitForRenderFrame()
-                .then(() => doLoadTextModel(deps))
+                .then(() => doLoadTextModel(deps, { override: true }))
                 .then(() => { if (onLoadedResume && llmService.isModelLoaded()) onLoadedResume(); });
             }
           },
@@ -139,6 +143,30 @@ export async function initiateModelLoad(
     // return the typed reason now; only the !alreadyLoading path shows the alert
     // here (behavior-neutral), and the caller decides what to render otherwise.
     if (!alreadyLoading) {
+      // The residency gate can block a load the conservative pre-check let through.
+      // That is overridable — offer "Load Anyway" (force the load) rather than a
+      // dead-end "Failed to load model" the user can only dismiss.
+      if (isOverridableMemoryError(error)) {
+        deps.setAlertState(showAlert(
+          'Insufficient Memory',
+          `${detail}\n\nWould you like to override these safeguards and load it anyway?`,
+          [
+            { text: 'Cancel', style: 'cancel' },
+            {
+              text: 'Load Anyway', style: 'destructive', onPress: () => {
+                deps.setAlertState(hideAlert());
+                deps.setIsModelLoading(true);
+                deps.setLoadingModel(activeModel);
+                deps.modelLoadStartTimeRef.current = Date.now();
+                waitForRenderFrame()
+                  .then(() => doLoadTextModel(deps, { override: true }))
+                  .then(() => { if (onLoadedResume && llmService.isModelLoaded()) onLoadedResume(); });
+              },
+            },
+          ],
+        ));
+        return { ok: false, reason: 'insufficient-memory', detail, alerted: true };
+      }
       deps.setAlertState(showAlert('Error', `Failed to load model: ${detail}`));
     }
     return { ok: false, reason: reasonFromLoadError(error), detail, alerted: !alreadyLoading };
@@ -212,6 +240,7 @@ export async function ensureModelLoadedFn(
 export async function proceedWithModelLoadFn(
   deps: ModelActionDeps,
   model: DownloadedModel,
+  opts?: { override?: boolean },
 ): Promise<void> {
   // Close the picker FIRST so the load runs behind the dismissed sheet and the
   // minimal in-chat loading card shows — not a load running with the sheet still open.
@@ -221,7 +250,7 @@ export async function proceedWithModelLoadFn(
   deps.modelLoadStartTimeRef.current = Date.now();
   await waitForRenderFrame();
   try {
-    await activeModelService.loadTextModel(model.id);
+    await activeModelService.loadTextModel(model.id, undefined, opts);
     const multimodalSupport = llmService.getMultimodalSupport();
     deps.setSupportsVision(model.engine === 'litert' ? !!model.liteRTVision : (multimodalSupport?.vision || false));
     if (deps.modelLoadStartTimeRef.current && deps.settings.showGenerationDetails && deps.activeConversationId) {
@@ -233,6 +262,27 @@ export async function proceedWithModelLoadFn(
       });
     }
   } catch (error) {
+    // If the residency gate blocked it and the user hasn't already overridden,
+    // offer to force the load rather than dead-ending on "Failed to load model".
+    if (!opts?.override && isOverridableMemoryError(error)) {
+      deps.setIsModelLoading(false);
+      deps.setLoadingModel(null);
+      deps.modelLoadStartTimeRef.current = null;
+      deps.setAlertState(showAlert(
+        'Insufficient Memory',
+        `${(error as Error).message}\n\nWould you like to override these safeguards and load it anyway?`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Load Anyway', style: 'destructive', onPress: () => {
+              deps.setAlertState(hideAlert());
+              proceedWithModelLoadFn(deps, model, { override: true });
+            },
+          },
+        ],
+      ));
+      return;
+    }
     deps.setAlertState(showAlert('Error', `Failed to load model: ${(error as Error).message}`));
   } finally {
     deps.setIsModelLoading(false);
@@ -256,7 +306,9 @@ export async function handleModelSelectFn(
       {
         text: 'Load Anyway', style: 'destructive', onPress: () => {
           deps.setAlertState(hideAlert());
-          proceedWithModelLoadFn(deps, model);
+          // override:true so the load also bypasses the residency hard gate, not just
+          // the conservative pre-check — otherwise "Load Anyway" fails at the budget.
+          proceedWithModelLoadFn(deps, model, { override: true });
         }
       },
     ]));

--- a/src/screens/ModelSettingsScreen/TextGenerationAdvanced.tsx
+++ b/src/screens/ModelSettingsScreen/TextGenerationAdvanced.tsx
@@ -166,6 +166,42 @@ const FlashAttentionSection: React.FC<{ trackColor: { false: string; true: strin
   );
 };
 
+// ─── Aggressive Loading ───────────────────────────────────────────────────────
+
+/**
+ * Aggressive model loading toggle. Shared by the llama AND LiteRT advanced panels
+ * (both go through the same residency memory gate) and reads/writes the single
+ * `settings.aggressiveModelLoading` source of truth — so this toggle, the in-chat
+ * settings, and the residency manager never disagree. The boolean is projected
+ * onto the residency manager by loadPolicySync; this View only dispatches intent.
+ */
+export const AggressiveLoadingSection: React.FC<{ trackColor: { false: string; true: string } }> = ({ trackColor }) => {
+  const { colors } = useTheme();
+  const styles = useThemedStyles(createStyles);
+  const { settings, updateSettings } = useAppStore();
+  const on = !!settings.aggressiveModelLoading;
+
+  return (
+    <View style={styles.toggleRow}>
+      <View style={styles.toggleInfo}>
+        <Text style={styles.toggleLabel}>Aggressive Loading</Text>
+        <Text style={styles.toggleDesc}>
+          Commit more of your RAM and hold a smaller reserve so larger models load. If a
+          model still will not fit, you can override the safeguards and load it anyway.
+          Larger models run slower and can be less stable.
+        </Text>
+      </View>
+      <Switch
+        testID="aggressive-loading-switch"
+        value={on}
+        onValueChange={(value) => updateSettings({ aggressiveModelLoading: value })}
+        trackColor={trackColor}
+        thumbColor={on ? colors.primary : colors.textMuted}
+      />
+    </View>
+  );
+};
+
 // ─── KV Cache Section ─────────────────────────────────────────────────────────
 
 const KvCacheSection: React.FC<{ cacheDisabled: boolean }> = ({ cacheDisabled }) => {
@@ -255,6 +291,7 @@ export const TextGenerationAdvanced: React.FC = () => {
       <BackendSelectorSection />
       <FlashAttentionSection trackColor={trackColor} />
       <KvCacheSection cacheDisabled={cacheDisabled} />
+      <AggressiveLoadingSection trackColor={trackColor} />
     </>
   );
 };
@@ -262,7 +299,9 @@ export const TextGenerationAdvanced: React.FC = () => {
 // ─── LiteRT Advanced ─────────────────────────────────────────────────────────
 
 export const LiteRTTextGenerationAdvanced: React.FC = () => {
+  const { colors } = useTheme();
   const { settings, updateSettings } = useAppStore();
+  const trackColor = { false: colors.surfaceLight, true: `${colors.primary}80` };
 
   return (
     <>
@@ -276,6 +315,7 @@ export const LiteRTTextGenerationAdvanced: React.FC = () => {
       />
 
       <LiteRTBackendSelectorSection />
+      <AggressiveLoadingSection trackColor={trackColor} />
     </>
   );
 };

--- a/src/screens/ModelSettingsScreen/TextGenerationAdvanced.tsx
+++ b/src/screens/ModelSettingsScreen/TextGenerationAdvanced.tsx
@@ -186,9 +186,9 @@ export const AggressiveLoadingSection: React.FC<{ trackColor: { false: string; t
       <View style={styles.toggleInfo}>
         <Text style={styles.toggleLabel}>Aggressive Loading</Text>
         <Text style={styles.toggleDesc}>
-          Commit more of your RAM and hold a smaller reserve so larger models load. If a
-          model still will not fit, you can override the safeguards and load it anyway.
-          Larger models run slower and can be less stable.
+          Raises the memory ceiling from ~70% of RAM to ~88% and cuts the OS reserve from
+          1.5GB to 0.8GB, so larger models load. If one still will not fit, you can override
+          the safeguards and load it anyway. Leaves less RAM for other apps.
         </Text>
       </View>
       <Switch

--- a/src/services/activeModelService/index.ts
+++ b/src/services/activeModelService/index.ts
@@ -4,6 +4,7 @@ import { liteRTService } from '../litert';
 import { localDreamGeneratorService as onnxImageGeneratorService } from '../localDreamGenerator';
 import { hardwareService } from '../hardware';
 import { modelResidencyManager } from '../modelResidency';
+import { OverridableMemoryError } from '../modelLoadErrors';
 import { remoteServerManager } from '../remoteServerManager';
 import { useAppStore, useRemoteServerStore } from '../../stores';
 import { ONNXImageModel } from '../../types';
@@ -113,6 +114,7 @@ class ActiveModelService {
   async loadTextModel(
     modelId: string,
     timeoutMs: number = 120000,
+    opts?: { override?: boolean },
   ): Promise<void> {
     // Fast path — model already loaded (no lock; just sync the store).
     if (this.isTextModelCurrent(modelId)) {
@@ -125,12 +127,13 @@ class ActiveModelService {
     // Everything else goes through the residency manager's global lock so no two
     // model operations ever touch memory at once (the single load gateway).
     await modelResidencyManager.runExclusive(`load:text:${modelId}`, () =>
-      this.doLoadTextModelLocked(modelId, timeoutMs),
+      this.doLoadTextModelLocked(modelId, timeoutMs, opts),
     );
   }
   private async doLoadTextModelLocked(
     modelId: string,
     timeoutMs: number,
+    opts?: { override?: boolean },
   ): Promise<void> {
     // Re-check after acquiring — a queued call may have loaded it already.
     if (this.isTextModelCurrent(modelId)) {
@@ -158,16 +161,20 @@ class ActiveModelService {
     // extras) to fit the RAM budget before loading this text model. The evicted
     // models' unload fns are the non-locking internal variants (we already hold
     // the lock here), so this never deadlocks.
-    const room = await modelResidencyManager.makeRoomFor({ key: 'text', type: 'text', sizeMB: textSizeMB, dirtyMemory: textIsDirty });
-    // makeRoomFor evicts nothing when the model won't fit even after freeing
-    // others (it refuses to strand the device). Honor that signal here: loading
-    // anyway is a guaranteed OOM crash. Throwing a memory error lets the caller
-    // surface a clean 'insufficient-memory' outcome (reasonFromLoadError maps it)
-    // instead of jetsam killing the app. makeRoomFor uses REAL free RAM, so this
-    // is the physical limit — looser than the conservative pre-load check, so a
-    // "Load Anyway" still succeeds whenever the model can actually fit.
+    const room = await modelResidencyManager.makeRoomFor(
+      { key: 'text', type: 'text', sizeMB: textSizeMB, dirtyMemory: textIsDirty },
+      { override: opts?.override },
+    );
+    // makeRoomFor evicts nothing when the model won't fit even after freeing others
+    // (it refuses to strand the device). This is OVERRIDABLE: the user can retry with
+    // { override: true } ("Load Anyway"), which forces the load after evicting
+    // everything evictable — GGUF weights are clean mmap pages, so it often succeeds
+    // past the conservative gate. Throwing the typed error lets every caller surface a
+    // uniform "Load Anyway" instead of a dead-end "Failed to load model".
     if (!room.fits) {
-      throw new Error('Not enough free memory to load this model, even after freeing other models. Close other apps or choose a smaller model.');
+      throw new OverridableMemoryError(
+        'Not enough free memory to load this model, even after freeing other models. Close other apps or choose a smaller model.',
+      );
     }
     this.loadingState.text = true;
     this.notifyListeners();
@@ -235,33 +242,37 @@ class ActiveModelService {
   private async checkImageModelCanLoad(
     modelId: string,
     model: ONNXImageModel,
-  ): Promise<{ canLoad: boolean; error?: string }> {
+    opts?: { override?: boolean },
+  ): Promise<{ canLoad: boolean; error?: string; overridable?: boolean }> {
     if (model.backend === 'qnn') {
       const socInfo = await hardwareService.getSoCInfo();
       if (!socInfo.hasNPU) {
         return {
           canLoad: false,
+          // A missing NPU is a hardware capability gap, not a memory budget — not overridable.
           error:
             'NPU models require a Qualcomm Snapdragon processor. Your device does not have a compatible NPU. Please use a GPU model instead.',
         };
       }
     }
-    // Residency manager is authoritative for memory: evict other generation
-    // models (and extras) to fit the RAM budget before loading this image
-    // model. (Replaces the old per-load critical-memory gate.) If it can't fit
-    // even after eviction, block the load.
-    const { fits } = await modelResidencyManager.makeRoomFor({
-      key: 'image',
-      type: 'image',
-      sizeMB: Math.round((hardwareService.estimateImageModelRam(model) || 0) / (1024 * 1024)),
-      // CoreML/ONNX image weights load into dirty (jetsam-counted) memory — gate on
-      // real free RAM too, unlike mmap'd GGUF text. (See ResidentSpec.dirtyMemory.)
-      dirtyMemory: true,
-    });
+    // Residency manager is authoritative for memory: evict others to fit the budget
+    // before loading. If it can't fit even after eviction, block — unless "Load Anyway".
+    const { fits } = await modelResidencyManager.makeRoomFor(
+      {
+        key: 'image',
+        type: 'image',
+        sizeMB: Math.round((hardwareService.estimateImageModelRam(model) || 0) / (1024 * 1024)),
+        // CoreML/ONNX image weights load into dirty (jetsam-counted) memory — gate on
+        // real free RAM too, unlike mmap'd GGUF text. (See ResidentSpec.dirtyMemory.)
+        dirtyMemory: true,
+      },
+      { override: opts?.override },
+    );
     if (!fits) {
       return {
         canLoad: false,
         error: `Not enough memory to load ${model.name}. Free up space or choose a smaller model.`,
+        overridable: true,
       };
     }
     return { canLoad: true };
@@ -269,14 +280,16 @@ class ActiveModelService {
   async loadImageModel(
     modelId: string,
     timeoutMs: number = 180000,
+    opts?: { override?: boolean },
   ): Promise<void> {
     await modelResidencyManager.runExclusive(`load:image:${modelId}`, () =>
-      this.doLoadImageModelLocked(modelId, timeoutMs),
+      this.doLoadImageModelLocked(modelId, timeoutMs, opts),
     );
   }
   private async doLoadImageModelLocked(
     modelId: string,
     timeoutMs: number,
+    opts?: { override?: boolean },
   ): Promise<void> {
     // Hydrate real device RAM BEFORE the compute-path decision. preferGpuForImageGen()
     // and estimateImageModelRam() read getTotalMemoryGB(), which returns a 4GB fallback
@@ -302,9 +315,11 @@ class ActiveModelService {
     if (!model) {
       throw new Error('Model not found');
     }
-    const check = await this.checkImageModelCanLoad(modelId, model);
+    const check = await this.checkImageModelCanLoad(modelId, model, opts);
     if (!check.canLoad) {
-      throw new Error(check.error);
+      throw check.overridable
+        ? new OverridableMemoryError(check.error ?? 'Not enough memory to load this model.')
+        : new Error(check.error);
     }
     this.loadingState.image = true;
     this.notifyListeners();

--- a/src/services/activeModelService/index.ts
+++ b/src/services/activeModelService/index.ts
@@ -165,12 +165,9 @@ class ActiveModelService {
       { key: 'text', type: 'text', sizeMB: textSizeMB, dirtyMemory: textIsDirty },
       { override: opts?.override },
     );
-    // makeRoomFor evicts nothing when the model won't fit even after freeing others
-    // (it refuses to strand the device). This is OVERRIDABLE: the user can retry with
-    // { override: true } ("Load Anyway"), which forces the load after evicting
-    // everything evictable — GGUF weights are clean mmap pages, so it often succeeds
-    // past the conservative gate. Throwing the typed error lets every caller surface a
-    // uniform "Load Anyway" instead of a dead-end "Failed to load model".
+    // Won't fit even after eviction. OVERRIDABLE: the typed error lets every caller
+    // offer "Load Anyway" (retry with { override: true }), which forces the load after
+    // evicting everything — GGUF weights mmap clean, so it often succeeds past the gate.
     if (!room.fits) {
       throw new OverridableMemoryError(
         'Not enough free memory to load this model, even after freeing other models. Close other apps or choose a smaller model.',
@@ -463,7 +460,8 @@ class ActiveModelService {
     return _getCurrentlyLoadedMemoryGB(this.getIds(), this.getLists());
   }
   async checkMemoryForModel(modelId: string, modelType: ModelType): Promise<MemoryCheckResult> {
-    return _checkMemoryForModel({ modelId, modelType, ids: this.getIds(), lists: this.getLists() });
+    // Same policy as residency so the pre-check + residency gate agree (aggressive relaxes both).
+    return _checkMemoryForModel({ modelId, modelType, ids: this.getIds(), lists: this.getLists(), policy: modelResidencyManager.getLoadPolicy() });
   }
   async checkMemoryForDualModel(textModelId: string | null, imageModelId: string | null): Promise<MemoryCheckResult> {
     return _checkMemoryForDualModel({ textModelId, imageModelId, lists: this.getLists() });

--- a/src/services/activeModelService/memory.ts
+++ b/src/services/activeModelService/memory.ts
@@ -14,16 +14,19 @@ import {
   TEXT_MODEL_OVERHEAD_MULTIPLIER,
   IMAGE_MODEL_OVERHEAD_MULTIPLIER,
 } from './types';
-import { modelMemoryBudgetMB, modelWarningThresholdMB } from '../memoryBudget';
+import { modelMemoryBudgetMB, modelWarningThresholdMB, LoadPolicy } from '../memoryBudget';
 
 // ---------------------------------------------------------------------------
 // Budget helpers
 // ---------------------------------------------------------------------------
 
-export const getMemoryBudgetGB = async (): Promise<number> => {
+// The pre-load check reads the SAME budget owner as the residency manager, so it
+// must honour the SAME load policy — otherwise aggressive mode would relax the
+// residency gate while the pre-check kept blocking/warning at balanced limits.
+export const getMemoryBudgetGB = async (policy: LoadPolicy = 'balanced'): Promise<number> => {
   const deviceInfo = await hardwareService.getDeviceInfo();
   const totalMB = deviceInfo.totalMemory / (1024 * 1024);
-  return modelMemoryBudgetMB(totalMB) / 1024;
+  return modelMemoryBudgetMB(totalMB, undefined, policy) / 1024;
 };
 
 export const getMemoryWarningThresholdGB = async (): Promise<number> => {
@@ -118,13 +121,15 @@ export interface CheckMemoryParams {
   modelType: ModelType;
   ids: LoadedModelIds;
   lists: ModelLists;
+  /** Active load policy. Defaults to balanced so existing callers are unchanged. */
+  policy?: LoadPolicy;
 }
 
 export async function checkMemoryForModel(
   params: CheckMemoryParams,
 ): Promise<MemoryCheckResult> {
-  const { modelId, modelType, ids, lists } = params;
-  const memoryBudgetGB = await getMemoryBudgetGB();
+  const { modelId, modelType, ids, lists, policy } = params;
+  const memoryBudgetGB = await getMemoryBudgetGB(policy);
   const warningThresholdGB = await getMemoryWarningThresholdGB();
 
   const model =

--- a/src/services/loadPolicySync.ts
+++ b/src/services/loadPolicySync.ts
@@ -1,0 +1,42 @@
+/**
+ * Load-policy projection — the SINGLE place the persisted "aggressive model
+ * loading" setting is mapped to the residency manager's runtime LoadPolicy.
+ *
+ * Separation of concerns (MVVM-ish):
+ *  - Views (the Settings screen AND the in-chat quick settings) only dispatch an
+ *    intent: `updateSettings({ aggressiveModelLoading })`. They never touch the
+ *    residency manager or compute a policy themselves — so the two surfaces can't
+ *    drift.
+ *  - This module PROJECTS that one setting onto the service that owns the runtime
+ *    policy (modelResidencyManager). The boolean→policy mapping lives here, once.
+ *  - The service (modelResidencyManager) owns the authoritative policy + memory
+ *    math; imperative load decisions read it from the service, never from a
+ *    reactive store snapshot.
+ */
+import { useAppStore } from '../stores';
+import { modelResidencyManager } from './modelResidency';
+import { LoadPolicy } from './memoryBudget';
+
+/** The one boolean→policy mapping. */
+export function loadPolicyFromSettings(settings: { aggressiveModelLoading?: boolean }): LoadPolicy {
+  return settings.aggressiveModelLoading ? 'aggressive' : 'balanced';
+}
+
+/**
+ * Push the current setting into the manager and keep it in sync on every change.
+ * Idempotent per value (Zustand only notifies on change, and setLoadPolicy is a
+ * plain assignment). Returns an unsubscribe fn. Call once at app boot.
+ */
+export function startLoadPolicySync(): () => void {
+  let last: boolean | undefined;
+  const apply = (aggressive: boolean | undefined) => {
+    if (aggressive === last) return; // no-op unless the flag actually flipped
+    last = aggressive;
+    modelResidencyManager.setLoadPolicy(loadPolicyFromSettings({ aggressiveModelLoading: aggressive }));
+  };
+  // Seed from the (already hydrated) current value.
+  apply(useAppStore.getState().settings?.aggressiveModelLoading);
+  // Project future changes. The base store's subscribe fires on every set(); we
+  // diff the one flag so setLoadPolicy runs only when it changes.
+  return useAppStore.subscribe(state => apply(state.settings?.aggressiveModelLoading));
+}

--- a/src/services/loadPolicySync.ts
+++ b/src/services/loadPolicySync.ts
@@ -24,10 +24,17 @@ export function loadPolicyFromSettings(settings: { aggressiveModelLoading?: bool
 
 /**
  * Push the current setting into the manager and keep it in sync on every change.
- * Idempotent per value (Zustand only notifies on change, and setLoadPolicy is a
- * plain assignment). Returns an unsubscribe fn. Call once at app boot.
+ * SINGLETON: safe to call more than once — App's boot effect can re-run (its
+ * useCallback deps change), and a naive subscribe would then stack listeners and
+ * leak for the app lifetime (one setLoadPolicy per listener per set()). Repeated
+ * calls return the SAME live unsubscribe; the underlying store subscription is
+ * created exactly once. Returns an unsubscribe fn (which also clears the singleton).
  */
+let activeUnsubscribe: (() => void) | null = null;
+
 export function startLoadPolicySync(): () => void {
+  if (activeUnsubscribe) return activeUnsubscribe; // already syncing — don't stack
+
   let last: boolean | undefined;
   const apply = (aggressive: boolean | undefined) => {
     if (aggressive === last) return; // no-op unless the flag actually flipped
@@ -38,5 +45,10 @@ export function startLoadPolicySync(): () => void {
   apply(useAppStore.getState().settings?.aggressiveModelLoading);
   // Project future changes. The base store's subscribe fires on every set(); we
   // diff the one flag so setLoadPolicy runs only when it changes.
-  return useAppStore.subscribe(state => apply(state.settings?.aggressiveModelLoading));
+  const unsub = useAppStore.subscribe(state => apply(state.settings?.aggressiveModelLoading));
+  activeUnsubscribe = () => {
+    unsub();
+    activeUnsubscribe = null;
+  };
+  return activeUnsubscribe;
 }

--- a/src/services/memoryBudget.ts
+++ b/src/services/memoryBudget.ts
@@ -22,16 +22,56 @@
  * Previously two places computed this independently (a 0.6 in the residency policy
  * AND a separate device-tiered fraction in the model-load check); unifying it here
  * is the fix.
+ *
+ * ── Load policy ────────────────────────────────────────────────────────────────
+ * The SAME functions are parameterised by a `LoadPolicy` so "aggressive mode" is a
+ * single data-driven knob, NOT an `if (aggressive)` scattered through the load path:
+ *  - 'balanced' (default): the conservative behaviour above. Every existing caller
+ *    that omits the policy gets exactly this, so the default is behaviour-neutral.
+ *  - 'aggressive': commit a larger fraction of RAM and hold a smaller OS reserve,
+ *    so big models (e.g. a 21GB MoE on a 24GB phone, a 3GB LiteRT model whose dirty
+ *    footprint the balanced dynamic guard rejects on a 12GB phone) are allowed to
+ *    load. The reserve floor is reduced but NEVER removed — that is the "lenient
+ *    safeguard": we still keep the OS + app baseline alive rather than guaranteeing
+ *    an instant jetsam. A hard block under aggressive can additionally be overridden
+ *    by explicit user confirmation ("Load Anyway"); see `policyAllowsOverride`.
  */
 import { Platform } from 'react-native';
 
+/** How hard we push RAM utilisation when loading a model. */
+export type LoadPolicy = 'balanced' | 'aggressive';
+
 /** Never commit the last ~1.5GB — OS + app baseline must always have headroom. */
 export const MEMORY_RESERVE_MB = 1500;
+/** Aggressive mode still keeps a floor alive (lenient, not absent). */
+export const AGGRESSIVE_RESERVE_MB = 800;
 
 type Plat = 'ios' | 'android' | string;
 
+/** OS/app reserve (MB) that is never committed to models, by policy. */
+export function memoryReserveMB(policy: LoadPolicy = 'balanced'): number {
+  return policy === 'aggressive' ? AGGRESSIVE_RESERVE_MB : MEMORY_RESERVE_MB;
+}
+
+/** Whether a hard "won't fit" block may be overridden by explicit user confirmation. */
+export function policyAllowsOverride(policy: LoadPolicy = 'balanced'): boolean {
+  return policy === 'aggressive';
+}
+
 /** Safe fraction of total RAM this process may commit to models, by device tier. */
-export function modelBudgetFraction(totalRamGB: number, platform: Plat = Platform.OS): number {
+export function modelBudgetFraction(
+  totalRamGB: number,
+  platform: Plat = Platform.OS,
+  policy: LoadPolicy = 'balanced',
+): number {
+  if (policy === 'aggressive') {
+    // Lenient: use more of RAM. Low-RAM tiers stay comparatively cautious (a 60%
+    // slice of 4GB is already close to what the OS will tolerate), high-RAM/entitled
+    // tiers push near the physical ceiling so a 21GB model fits a 24GB phone.
+    if (totalRamGB <= 4) return 0.60;
+    if (totalRamGB <= 8) return 0.75;
+    return platform === 'ios' ? 0.92 : 0.88;
+  }
   if (totalRamGB <= 4) return 0.50; // ~2GB on 4GB — safe; dynamic guard tightens under pressure
   if (totalRamGB <= 8) return 0.60; // 6-8GB
   return platform === 'ios' ? 0.78 : 0.70; // 12GB+: iOS holds the increased-memory entitlement
@@ -45,10 +85,14 @@ export function modelWarningFraction(totalRamGB: number, platform: Plat = Platfo
 }
 
 /** Hard budget in MB: the smaller of the fraction-of-RAM and (RAM minus reserve). */
-export function modelMemoryBudgetMB(totalRamMB: number, platform: Plat = Platform.OS): number {
+export function modelMemoryBudgetMB(
+  totalRamMB: number,
+  platform: Plat = Platform.OS,
+  policy: LoadPolicy = 'balanced',
+): number {
   const totalRamGB = totalRamMB / 1024;
-  const byFraction = totalRamMB * modelBudgetFraction(totalRamGB, platform);
-  const byReserve = totalRamMB - MEMORY_RESERVE_MB;
+  const byFraction = totalRamMB * modelBudgetFraction(totalRamGB, platform, policy);
+  const byReserve = totalRamMB - memoryReserveMB(policy);
   return Math.max(0, Math.min(byFraction, byReserve));
 }
 

--- a/src/services/memoryBudget.ts
+++ b/src/services/memoryBudget.ts
@@ -33,8 +33,12 @@
  *    footprint the balanced dynamic guard rejects on a 12GB phone) are allowed to
  *    load. The reserve floor is reduced but NEVER removed — that is the "lenient
  *    safeguard": we still keep the OS + app baseline alive rather than guaranteeing
- *    an instant jetsam. A hard block under aggressive can additionally be overridden
- *    by explicit user confirmation ("Load Anyway"); see `policyAllowsOverride`.
+ *    an instant jetsam.
+ *
+ * "Load Anyway" (the per-load override that forces past the fit gate) is a separate,
+ * ALWAYS-available escape hatch — not gated by this policy. Aggressive mode changes
+ * the default budget so fewer loads need forcing; the override remains the explicit,
+ * per-load, user-confirmed way to push past whatever budget is in effect.
  */
 import { Platform } from 'react-native';
 
@@ -51,11 +55,6 @@ type Plat = 'ios' | 'android' | string;
 /** OS/app reserve (MB) that is never committed to models, by policy. */
 export function memoryReserveMB(policy: LoadPolicy = 'balanced'): number {
   return policy === 'aggressive' ? AGGRESSIVE_RESERVE_MB : MEMORY_RESERVE_MB;
-}
-
-/** Whether a hard "won't fit" block may be overridden by explicit user confirmation. */
-export function policyAllowsOverride(policy: LoadPolicy = 'balanced'): boolean {
-  return policy === 'aggressive';
 }
 
 /** Safe fraction of total RAM this process may commit to models, by device tier. */

--- a/src/services/modelLoadErrors.ts
+++ b/src/services/modelLoadErrors.ts
@@ -1,0 +1,27 @@
+/**
+ * A model load was blocked by the memory budget, but the user CAN choose to load
+ * it anyway ("Load Anyway" → retry with { override: true }).
+ *
+ * This carries an explicit, typed signal rather than relying on message-regex
+ * sniffing: the readiness/failure layer checks `isOverridableMemoryError(err)` to
+ * decide whether to offer the override button. The message still matches the
+ * insufficient-memory reason mapping so existing classification keeps working.
+ */
+export class OverridableMemoryError extends Error {
+  /** Discriminant so the UI can offer "Load Anyway" without message sniffing. */
+  readonly overridable = true as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'OverridableMemoryError';
+    // Restore the prototype chain (TS + transpiled ES5 subclassed Error).
+    Object.setPrototypeOf(this, OverridableMemoryError.prototype);
+  }
+}
+
+export function isOverridableMemoryError(err: unknown): err is OverridableMemoryError {
+  return (
+    err instanceof OverridableMemoryError ||
+    (typeof err === 'object' && err !== null && (err as { overridable?: unknown }).overridable === true)
+  );
+}

--- a/src/services/modelResidency/index.ts
+++ b/src/services/modelResidency/index.ts
@@ -13,6 +13,7 @@ import { AppState } from 'react-native';
 import { hardwareService } from '../hardware';
 import logger from '../../utils/logger';
 import { planEviction, computeBudgetMB, Resident, ResidentType } from './policy';
+import { LoadPolicy } from '../memoryBudget';
 
 type UnloadFn = () => Promise<void>;
 
@@ -22,6 +23,8 @@ const MIN_BUDGET_MB = 1024;
  *  OS + other apps so a dirty load never spills into swap. (Not applied to mmap'd
  *  GGUF — their clean weights don't pressure this limit.) */
 const DIRTY_AVAILABILITY_HEADROOM_MB = 1024;
+/** Aggressive-mode dirty headroom — leaner, still non-zero (lenient safeguard). */
+const AGGRESSIVE_DIRTY_HEADROOM_MB = 512;
 /** Small, cheaply-reloadable models reclaimed first under memory pressure. */
 const SIDECAR_TYPES = new Set<ResidentType>(['whisper', 'tts', 'embedding']);
 
@@ -63,6 +66,13 @@ const stripUnload = ({ unload: _unload, ...rest }: RegisteredResident): Resident
 class ModelResidencyManager {
   private readonly residents = new Map<string, RegisteredResident>();
   private budgetOverrideMB: number | null = null;
+  /**
+   * Current load policy (single owner). The View (settings screen) dispatches an
+   * intent via setLoadPolicy; the manager — not a reactive store snapshot — is the
+   * authoritative source the memory math reads, so no imperative decision is made
+   * off a store value multiple writers can desync.
+   */
+  private loadPolicy: LoadPolicy = 'balanced';
 
   constructor() {
     // Residency owns the memory-pressure response (single owner of model memory).
@@ -137,6 +147,20 @@ class ModelResidencyManager {
     this.budgetOverrideMB = mb;
   }
 
+  /**
+   * Set the load policy. Called (as an intent) when the user toggles "aggressive
+   * model loading" and at boot from the persisted setting. 'aggressive' commits a
+   * larger fraction of RAM and a smaller reserve so big models load; the numbers
+   * themselves live in the memoryBudget owner, never branched on here.
+   */
+  setLoadPolicy(policy: LoadPolicy): void {
+    this.loadPolicy = policy;
+  }
+
+  getLoadPolicy(): LoadPolicy {
+    return this.loadPolicy;
+  }
+
   getBudgetMB(): number {
     if (this.budgetOverrideMB != null) return this.budgetOverrideMB;
     // The budget is the device + platform PHYSICAL-RAM cap (a fraction of total RAM).
@@ -149,7 +173,7 @@ class ModelResidencyManager {
     // real dirty cost is ~1-2GB of KV+compute) on a 12GB phone that runs it fine. A
     // GGUF's loadability is bounded by physical RAM (its weights fit as clean pages),
     // which is exactly computeBudgetMB. Floored so a small model always loads.
-    const physicalCapMB = computeBudgetMB(hardwareService.getTotalMemoryGB() * 1024);
+    const physicalCapMB = computeBudgetMB(hardwareService.getTotalMemoryGB() * 1024, { policy: this.loadPolicy });
     return Math.round(Math.max(MIN_BUDGET_MB, physicalCapMB));
   }
 
@@ -161,7 +185,7 @@ class ModelResidencyManager {
    */
   private budgetForSpec(spec: ResidentSpec): number {
     if (this.budgetOverrideMB != null) return this.budgetOverrideMB;
-    const physicalCapMB = computeBudgetMB(hardwareService.getTotalMemoryGB() * 1024);
+    const physicalCapMB = computeBudgetMB(hardwareService.getTotalMemoryGB() * 1024, { policy: this.loadPolicy });
     // Dirty-memory PRESSURE — the incoming model is dirty, OR a dirty model (CoreML/ONNX
     // image) is already resident. A dirty model's working set/compile spike can't be
     // paged out like clean mmap weights, so while one is present EVERY load (even an
@@ -177,7 +201,13 @@ class ModelResidencyManager {
     // headroom). This is the single owner of the live os_proc budget.
     const availableMB = hardwareService.getAvailableMemoryGB() * 1024;
     const residentMB = [...this.residents.values()].reduce((sum, r) => sum + r.sizeMB, 0);
-    const dynamicMB = availableMB + residentMB - DIRTY_AVAILABILITY_HEADROOM_MB;
+    // Aggressive mode holds a smaller real-free-RAM headroom for dirty loads (the
+    // lenient safeguard) so e.g. a 3GB LiteRT model the balanced guard rejects on a
+    // 12GB phone is allowed through. Still non-zero — never a guaranteed jetsam.
+    const dirtyHeadroomMB = this.loadPolicy === 'aggressive'
+      ? AGGRESSIVE_DIRTY_HEADROOM_MB
+      : DIRTY_AVAILABILITY_HEADROOM_MB;
+    const dynamicMB = availableMB + residentMB - dirtyHeadroomMB;
     return Math.round(Math.max(MIN_BUDGET_MB, Math.min(physicalCapMB, dynamicMB)));
   }
 
@@ -223,7 +253,10 @@ class ModelResidencyManager {
    * (e.g. activeModelService) but want the manager to enforce memory. Returns
    * the evicted keys.
    */
-  async makeRoomFor(spec: ResidentSpec): Promise<{ evicted: string[]; fits: boolean }> {
+  async makeRoomFor(
+    spec: ResidentSpec,
+    opts?: { override?: boolean },
+  ): Promise<{ evicted: string[]; fits: boolean }> {
     // Re-read real free RAM so the decision reflects current pressure, not a stale
     // boot-time snapshot (other apps may have grabbed memory since).
     await hardwareService.refreshMemoryInfo().catch(() => {});
@@ -238,10 +271,18 @@ class ModelResidencyManager {
     const availMB = Math.round(hardwareService.getAvailableMemoryGB() * 1024);
     const totalMB = Math.round(hardwareService.getTotalMemoryGB() * 1024);
     logger.log(`[MEM-SM] makeRoomFor ${spec.key} sizeMB=${spec.sizeMB} dirty=${!!spec.dirtyMemory} budgetMB=${budgetMB} os_procAvailMB=${availMB} totalMB=${totalMB} residents=[${residents.map(r => `${r.key}:${r.sizeMB}${r.pinned ? '(pinned)' : ''}`).join(',')}] fits=${plan.fits} evict=[${plan.evict.map(e => e.key).join(',')}]`);
-    if (!plan.fits) {
+    if (!plan.fits && !opts?.override) {
       // Won't fit even after the planned evictions — DON'T evict (otherwise we'd
       // strand the device with nothing). The caller blocks the load.
       return { evicted: [], fits: false };
+    }
+    // Override ("Load Anyway"): the user explicitly accepted the risk. planEviction
+    // already collected every evictable resident when !fits, so evicting plan.evict
+    // frees the MAXIMUM room, then we force fits=true. The lenient safeguards remain:
+    // we still evicted everything we could, and the native loader keeps its
+    // GPU→CPU→smaller-ctx fallback + OOM recovery if the attempt truly can't fit.
+    if (!plan.fits && opts?.override) {
+      logger.log(`[MEM-SM] makeRoomFor ${spec.key} OVERRIDE — forcing load after evicting [${plan.evict.map(e => e.key).join(',')}]`);
     }
     for (const victim of plan.evict) {
       const reg = this.residents.get(victim.key);
@@ -249,7 +290,7 @@ class ModelResidencyManager {
       await reg.unload().catch(err => logger.log(`[ModelResidency] unload ${victim.key} failed:`, err));
       this.residents.delete(victim.key);
     }
-    return { evicted: plan.evict.map(e => e.key), fits: plan.fits };
+    return { evicted: plan.evict.map(e => e.key), fits: true };
   }
 
   async ensureResident(

--- a/src/services/modelResidency/policy.ts
+++ b/src/services/modelResidency/policy.ts
@@ -17,7 +17,7 @@
  * can be unit-tested without touching native model loading.
  */
 
-import { modelMemoryBudgetMB } from '../memoryBudget';
+import { modelMemoryBudgetMB, LoadPolicy } from '../memoryBudget';
 
 export type ResidentType = 'text' | 'image' | 'whisper' | 'tts' | 'classifier' | 'embedding';
 
@@ -94,18 +94,19 @@ export function selectEvictionVictim(
  */
 export function computeBudgetMB(
   totalRamMB: number,
-  opts?: { reserveMB?: number; fraction?: number },
+  opts?: { reserveMB?: number; fraction?: number; policy?: LoadPolicy },
 ): number {
   // Explicit overrides keep the old escape hatch; otherwise defer to the single
   // device + platform aware budget owner (so residency and the pre-load memory
   // check can never disagree, and high-RAM/iOS-entitled devices get their larger
-  // safe fraction instead of a flat 60%).
+  // safe fraction instead of a flat 60%). The load policy ('aggressive') tunes the
+  // fraction + reserve in that one owner — never branched on here.
   if (opts?.fraction != null || opts?.reserveMB != null) {
     const fraction = opts?.fraction ?? 0.6;
     const reserveMB = opts?.reserveMB ?? 1500;
     return Math.max(0, Math.min(totalRamMB * fraction, totalRamMB - reserveMB));
   }
-  return modelMemoryBudgetMB(totalRamMB);
+  return modelMemoryBudgetMB(totalRamMB, undefined, opts?.policy);
 }
 
 /**

--- a/src/services/whisperService.ts
+++ b/src/services/whisperService.ts
@@ -142,28 +142,6 @@ class WhisperService {
     logger.log(`[Whisper] Downloaded to ${destPath}`);
     return destPath;
   }
-  async downloadFromUrl(url: string, modelId: string, onProgress?: (progress: number) => void): Promise<string> {
-    await this.ensureModelsDirExists();
-    const destPath = this.getModelPath(modelId);
-    if (await RNFS.exists(destPath)) return destPath;
-    const download = RNFS.downloadFile({
-      fromUrl: url, toFile: destPath, progressDivider: 1,
-      progress: (res) => { onProgress?.(res.bytesWritten / res.contentLength); },
-    });
-    const result = await download.promise;
-    if (result.statusCode !== 200) {
-      await RNFS.unlink(destPath).catch(() => {});
-      throw new Error(`Download failed with status ${result.statusCode}`);
-    }
-    try {
-      await this.validateModelFile(destPath);
-    } catch (validationError) {
-      await RNFS.unlink(destPath).catch(() => {});
-      throw validationError;
-    }
-    return destPath;
-  }
-
   /** List every downloaded ggml whisper model on disk (for the Download Manager). */
   async listDownloadedModels(): Promise<Array<{ modelId: string; fileName: string; sizeBytes: number; filePath: string }>> {
     const dir = this.getModelsDir();

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -54,6 +54,11 @@ type AppSettings = {
   imageThreads: number; imageWidth: number; imageHeight: number;
   imageUseOpenCL: boolean; enhanceImagePrompts: boolean;
   enableGpu: boolean; gpuLayers: number; flashAttn: boolean;
+  /** Aggressive model loading: commit more RAM + a smaller reserve so large models
+   *  load (with a "Load Anyway" override when the budget still blocks). Off by
+   *  default (behaviour-neutral). Single source of truth read by both the Settings
+   *  screen and the in-chat settings; projected onto the residency manager. */
+  aggressiveModelLoading: boolean;
   cacheType: CacheType; showGenerationDetails: boolean; enabledTools: string[];
   thinkingEnabled: boolean;
   inferenceBackend: InferenceBackend;
@@ -187,6 +192,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   inferenceBackend: Platform.OS === 'ios' ? INFERENCE_BACKENDS.METAL : INFERENCE_BACKENDS.CPU,
   gpuLayers: 99,
   flashAttn: true,
+  aggressiveModelLoading: false,
   cacheType: 'q8_0' as CacheType,
   showGenerationDetails: false,
   enabledTools: ['web_search', 'read_url', 'search_knowledge_base'],

--- a/src/stores/whisperStore.ts
+++ b/src/stores/whisperStore.ts
@@ -24,7 +24,6 @@ interface WhisperState {
 
   // Actions
   downloadModel: (modelId: string) => Promise<void>;
-  downloadFromUrl: (url: string, modelId: string) => Promise<void>;
   /** Activate an already-downloaded model without re-downloading. */
   selectModel: (modelId: string) => Promise<void>;
   loadModel: () => Promise<void>;
@@ -90,27 +89,6 @@ export const useWhisperStore = create<WhisperState>()(
           // Clear this model's progress entry, even if auto-load hangs/fails —
           // the file is already on disk by this point. Other in-flight downloads
           // keep their own entries.
-          clearProgress(set, modelId);
-        }
-      },
-
-      downloadFromUrl: async (url: string, modelId: string) => {
-        setProgress(set, modelId, 0);
-        set({ error: null });
-        try {
-          await whisperService.downloadFromUrl(url, modelId, (progress) => {
-            setProgress(set, modelId, progress);
-          });
-          set((s) => ({
-            downloadedModelId: modelId,
-            presentModelIds: s.presentModelIds.includes(modelId) ? s.presentModelIds : [...s.presentModelIds, modelId],
-          }));
-          await get().loadModel();
-        } catch (error) {
-          if (!(error as { cancelled?: boolean })?.cancelled) {
-            set({ error: error instanceof Error ? error.message : 'Download failed' });
-          }
-        } finally {
           clearProgress(set, modelId);
         }
       },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -310,14 +310,10 @@ export interface ONNXImageModel {
   attentionVariant?: 'split_einsum' | 'original';
 }
 
-// Image generation state for UI
-export interface ImageGenerationState {
-  isGenerating: boolean;
-  currentStep: number;
-  totalSteps: number;
-  progress: number;
-  prompt?: string;
-}
+// NOTE: the authoritative ImageGenerationState lives in
+// services/imageGenerationService.ts (phase-derived) and is re-exported from
+// services/index.ts. The duplicate that used to sit here was imported by nobody
+// (every consumer takes the service's version) — removed to kill the drift risk.
 
 export type ImageGenerationMode = 'auto' | 'manual';
 export type AutoDetectMethod = 'pattern' | 'llm';


### PR DESCRIPTION
## What & why

Two users could not load models that their devices can actually run:
- A ~3GB LiteRT model rejected on a 12GB phone (the dirty-memory guard was too tight).
- A 21GB Qwen3-MoE GGUF rejected on a 24GB phone (the balanced budget caps at ~70%).

This adds an **Aggressive model loading** mode plus a **"Load Anyway" override**, so power users can trade the conservative safety margin for the ability to run bigger/better models. Default is unchanged (behaviour-neutral).

It also fixes two model-load UX bugs surfaced along the way.

## The seam (SOLID / single source of truth)

Aggressive mode is **one data-driven policy**, not an `if (aggressive)` scattered through the load path:

- `memoryBudget.ts` (the single budget owner) is parameterised by `LoadPolicy = 'balanced' | 'aggressive'`. `balanced` (default) is byte-for-byte the old behaviour; `aggressive` commits a larger fraction and a smaller **non-zero** reserve (the lenient safeguard).
- `modelResidencyManager` owns the runtime policy (`setLoadPolicy`) and adds a one-shot `{ override }` to `makeRoomFor` that forces a load after evicting everything evictable.
- `OverridableMemoryError` is the typed signal a blocked-but-overridable load; every load caller renders a uniform **"Load Anyway"** from it.
- The persisted `aggressiveModelLoading` setting is the **single source of truth** read by both the Settings screen and the in-chat settings. `loadPolicySync` is the ONE place the boolean is mapped to a policy and projected onto the residency manager. **Data/UI stay separate**: the service owns state + the memory math; the Views only dispatch `updateSettings` / `loadTextModel({override})`.

## Bug fixes (same subsystem)

1. **"Load Anyway" stopped happening.** Raising the pre-check budget made `canLoad` almost always true, so the pre-check's Load-Anyway became unreachable; the real blocker (residency `makeRoomFor`) threw a raw `Error` → dead-end "Failed to load model". Fixed at the seam: typed error + every Load-Anyway path passes `{ override: true }`.
2. **No feedback on the no-model chat screen.** Selecting a model starts a background load, but `activeModelId` stays null until it finishes, so the empty state lingered with no indicator. `NoModelScreen` now shows a loading indicator while loading.

## GPU / NPU

llama.rn 0.12.5 acceleration is already wired end-to-end (`initLlama({ n_gpu_layers, devices })`): Metal (iOS), OpenCL/Adreno + Hexagon HTP (Android), selectable in the backend picker. There is no TPU backend in llama.rn. No change needed there; aggressive mode is the new capability.

## Dead-code recon

`docs/GAPS_BACKLOG.md` catalogues 21 grep-verified findings from a 4-agent recon sweep, each with a verdict (delete-safe / fix-the-guard / instrument-and-revisit) and evidence. Deletions land as their own follow-up PR — nothing deleted blind (two recon "delete-safe" calls were corrected after verifying tests exercise them).

## Tests
- `memoryBudget` policy math incl. the 21GB-on-24GB fails-before/passes-after.
- `modelResidency` policy + override (forces past the gate, evicts, behaviour-neutral when it already fits, leaner dirty headroom).
- `OverridableMemoryError` + `loadPolicySync` (drives the REAL store + REAL manager — no mocks of the thing under test).
- `activeModelService` integration: blocked-without-override throws the typed error; loads with `{override:true}`.
- UI: Aggressive Loading toggle; NoModelScreen loading indicator.
- `npm run lint`, `tsc --noEmit`, and the related jest suites are green (4739 passed on the push gate).

> Provit on-device journey pending (aggressive-load + Load-Anyway on a physical device) before merge, per the no-merge-without-Provit rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Aggressive Loading** toggle that changes model-loading behavior and is applied automatically on app startup.
  * Added **Load Anyway** to retry model loading when memory/residency limits are hit.
* **Bug Fixes**
  * Updated the “no model selected” screen to show a **Loading Model** indicator/message while a model is loading.
* **Tests**
  * Expanded coverage for aggressive vs balanced policies, override/“load anyway” flows, memory budgeting, and related UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->