### PR TITLE
fix: address review findings — whisper eviction safety, error messages, resort coverage

### DIFF
--- a/__tests__/unit/components/ensureWhisperForTranscription.test.ts
+++ b/__tests__/unit/components/ensureWhisperForTranscription.test.ts
@@ -1,0 +1,73 @@
+import { ensureWhisperForTranscription } from '../../../src/components/ChatInput/ensureWhisperForTranscription';
+
+/**
+ * Guards the 🟠 Major fix: transcription must free a blocking generation model ONLY
+ * when whisper was BLOCKED by the single-model rule — never on a hard whisper-load
+ * failure. Evicting the user's generation model for a whisper that can't load anyway
+ * would strand them with nothing loaded. The old code called unloadAllModels on ANY
+ * non-load, so the 'error' case below fails on it and passes with the fix.
+ */
+const makeDeps = (over: Partial<Parameters<typeof ensureWhisperForTranscription>[0]> = {}) => {
+  const freeGenerationModels = jest.fn(async () => {});
+  const loadWhisper = jest.fn(async () => 'loaded' as const);
+  const deps = {
+    isLoaded: () => false,
+    hasDownloadedModel: () => true,
+    loadWhisper,
+    freeGenerationModels,
+    ...over,
+  };
+  return { deps, freeGenerationModels, loadWhisper };
+};
+
+describe('ensureWhisperForTranscription', () => {
+  it('returns true immediately when whisper is already loaded (no load, no eviction)', async () => {
+    const { deps, freeGenerationModels, loadWhisper } = makeDeps({ isLoaded: () => true });
+    await expect(ensureWhisperForTranscription(deps)).resolves.toBe(true);
+    expect(loadWhisper).not.toHaveBeenCalled();
+    expect(freeGenerationModels).not.toHaveBeenCalled();
+  });
+
+  it('returns false when no model is downloaded (no eviction)', async () => {
+    const { deps, freeGenerationModels, loadWhisper } = makeDeps({ hasDownloadedModel: () => false });
+    await expect(ensureWhisperForTranscription(deps)).resolves.toBe(false);
+    expect(loadWhisper).not.toHaveBeenCalled();
+    expect(freeGenerationModels).not.toHaveBeenCalled();
+  });
+
+  it('loads normally when there is room — does NOT evict any generation model', async () => {
+    const { deps, freeGenerationModels } = makeDeps({ loadWhisper: jest.fn(async () => 'loaded' as const) });
+    await expect(ensureWhisperForTranscription(deps)).resolves.toBe(true);
+    expect(freeGenerationModels).not.toHaveBeenCalled();
+  });
+
+  it('does NOT evict the generation model on a hard whisper-load ERROR (the regression)', async () => {
+    const loadWhisper = jest.fn(async () => 'error' as const);
+    const { deps, freeGenerationModels } = makeDeps({ loadWhisper });
+    await expect(ensureWhisperForTranscription(deps)).resolves.toBe(false);
+    // The whole point: a corrupt/missing whisper won't load, so evicting the user's
+    // generation model would strand them. freeGenerationModels must NOT be called.
+    expect(freeGenerationModels).not.toHaveBeenCalled();
+    expect(loadWhisper).toHaveBeenCalledTimes(1); // no pointless retry either
+  });
+
+  it('frees the generation model and retries ONLY when blocked, then loads', async () => {
+    const loadWhisper = jest.fn()
+      .mockResolvedValueOnce('blocked')
+      .mockResolvedValueOnce('loaded');
+    const { deps, freeGenerationModels } = makeDeps({ loadWhisper });
+    await expect(ensureWhisperForTranscription(deps)).resolves.toBe(true);
+    expect(freeGenerationModels).toHaveBeenCalledTimes(1);
+    expect(loadWhisper).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns false when it is still blocked/failing after freeing (no infinite retry)', async () => {
+    const loadWhisper = jest.fn()
+      .mockResolvedValueOnce('blocked')
+      .mockResolvedValueOnce('error');
+    const { deps, freeGenerationModels } = makeDeps({ loadWhisper });
+    await expect(ensureWhisperForTranscription(deps)).resolves.toBe(false);
+    expect(freeGenerationModels).toHaveBeenCalledTimes(1);
+    expect(loadWhisper).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/unit/screens/ModelsScreen/useTextModels.handlers.test.ts
+++ b/__tests__/unit/screens/ModelsScreen/useTextModels.handlers.test.ts
@@ -18,6 +18,14 @@ jest.mock('@react-navigation/native', () => ({
   useFocusEffect: jest.fn((cb: () => () => void) => { cb(); }),
 }));
 
+// ── Acceleration predicate (deterministic per-id verdict for the resort test) ──
+// Keep the real module's other exports; only make modelSupportsNpuGpu controllable
+// so we can assert the "float accelerable models to the top" ordering deterministically.
+jest.mock('../../../../src/utils/acceleration', () => ({
+  ...jest.requireActual('../../../../src/utils/acceleration'),
+  modelSupportsNpuGpu: (m: { id?: string }) => ((m?.id?.charCodeAt(0) ?? 1) % 2 === 0),
+}));
+
 // ── App store ─────────────────────────────────────────────────────────
 const mockAddDownloadedModel = jest.fn();
 const mockRemoveDownloadedModel = jest.fn();
@@ -317,5 +325,44 @@ describe('isModelDownloaded / getDownloadedModel resolve by file, not composite 
     const resolved = result.current.getDownloadedModel(REPO, 'gemma-4-E2B-it-Q4_0.gguf');
     expect(resolved?.quantization).toBe('Q4_0');
     expect(resolved?.id).toBe('recovered_gemma-4-E2B-it-Q4_0.gguf_1783000000000');
+  });
+});
+
+// ── Recommended-list NPU/GPU prioritization (the resort at useTextModels.ts:329) ──
+// Guards the user-visible behavior CodeRabbit flagged: on the 'recommended' sort,
+// NPU/GPU-accelerable models float to the top; explicit sorts are honored (no resort).
+describe('recommendedAsModelInfo — NPU/GPU prioritization', () => {
+  const accel = (m: { id?: string }) => ((m?.id?.charCodeAt(0) ?? 1) % 2 === 0); // matches the mock
+
+  it("floats accelerable models ahead of non-accelerable ones on the 'recommended' sort", () => {
+    const { result } = renderHook(() => useTextModels(setAlertState));
+    const list = result.current.recommendedAsModelInfo;
+    expect(list.length).toBeGreaterThan(0);
+
+    // Partition invariant: once a non-accelerable model appears, no accelerable model
+    // may appear after it. Deleting the resort line lets a non-accelerable precede an
+    // accelerable one → this fails.
+    let sawNonAccel = false;
+    for (const m of list) {
+      if (!accel(m)) sawNonAccel = true;
+      else if (sawNonAccel) throw new Error(`accelerable model ${m.id} appears after a non-accelerable one`);
+    }
+    // And the resort must be meaningful for this dataset (both groups present),
+    // otherwise the invariant is vacuous.
+    expect(list.some(accel)).toBe(true);
+    expect(list.some(m => !accel(m))).toBe(true);
+  });
+
+  it("honors an explicit sort (size) — does NOT reprioritize by accelerability", () => {
+    const { result } = renderHook(() => useTextModels(setAlertState));
+    act(() => result.current.setSortOption('size'));
+
+    const list = result.current.recommendedAsModelInfo;
+    // 'size' sorts by paramCount ascending (applySort). The accel resort is skipped,
+    // so the list stays param-ordered rather than accelerable-first.
+    const params = list.map(m => m.paramCount ?? 0);
+    for (let i = 1; i < params.length; i++) {
+      expect(params[i]).toBeGreaterThanOrEqual(params[i - 1]);
+    }
   });
 });

--- a/__tests__/unit/stores/whisperStore.test.ts
+++ b/__tests__/unit/stores/whisperStore.test.ts
@@ -359,7 +359,7 @@ describe('whisperStore', () => {
         // A heavier model is resident: residency refuses without evicting it.
         mockResidency.makeRoomFor.mockResolvedValueOnce({ evicted: [], fits: false });
 
-        await getState().loadModel();
+        const result = await getState().loadModel();
 
         // The seam under test: the native load must be skipped when it won't fit.
         // Deleting the `if (!fits) return` guard in the store fails THIS line.
@@ -369,6 +369,9 @@ describe('whisperStore', () => {
         // Not an error state — STT just stays out and loads on the next record.
         expect(getState().error).toBeNull();
         expect(getState().isModelLoading).toBe(false);
+        // Reports 'blocked' (not 'error') so a caller can free the resident model and
+        // retry — vs 'error', where freeing wouldn't help.
+        expect(result).toBe('blocked');
       });
 
       it('loads and registers whisper when makeRoomFor reports it fits', async () => {
@@ -377,11 +380,26 @@ describe('whisperStore', () => {
         mockWhisperService.loadModel.mockResolvedValue(undefined);
         mockResidency.makeRoomFor.mockResolvedValueOnce({ evicted: [], fits: true });
 
-        await getState().loadModel();
+        const result = await getState().loadModel();
 
         expect(mockWhisperService.loadModel).toHaveBeenCalledWith('/models/ggml-tiny');
         expect(mockResidency.register).toHaveBeenCalled();
         expect(getState().isModelLoaded).toBe(true);
+        expect(result).toBe('loaded');
+      });
+
+      it("reports 'error' (not 'blocked') on a hard load failure — freeing models won't help", async () => {
+        useWhisperStore.setState({ downloadedModelId: 'ggml-tiny' });
+        mockWhisperService.getModelPath.mockReturnValue('/models/ggml-tiny');
+        mockResidency.makeRoomFor.mockResolvedValueOnce({ evicted: [], fits: true });
+        mockWhisperService.loadModel.mockRejectedValueOnce(new Error('model file corrupted'));
+
+        const result = await getState().loadModel();
+
+        // Distinguishing error from blocked is what stops the caller evicting the
+        // user's generation model for a whisper that can't load anyway.
+        expect(result).toBe('error');
+        expect(getState().isModelLoaded).toBe(false);
       });
     });
   });

--- a/src/components/ChatInput/Voice.ts
+++ b/src/components/ChatInput/Voice.ts
@@ -7,6 +7,7 @@ import { audioRecorderService } from '../../services/audioRecorderService';
 import { whisperService } from '../../services/whisperService';
 import { recordingController } from '../../services/recordingController';
 import { resolveTranscription } from './transcriptionOutcome';
+import { ensureWhisperForTranscription } from './ensureWhisperForTranscription';
 import logger from '../../utils/logger';
 
 interface UseVoiceInputParams {
@@ -53,28 +54,17 @@ export function useVoiceInput({ conversationId, onTranscript, onAudioAttachment,
   const shouldUseFilePath = (): boolean =>
     isInAudioInterfaceMode() && !!downloadedModelId && !supportsDirectAudio();
 
-  // Transcription is a PREREQUISITE of a voice turn — whisperService.transcribeFile
-  // throws "No Whisper model loaded" if the model isn't resident. The STT single-model
-  // rule keeps whisper OUT of RAM while a generation model is resident (a 142MB sidecar
-  // can't co-reside with an 8.5GB text model without OOM). So before transcribing we
-  // ensure whisper is loaded, and if a resident generation model is blocking it we free
-  // that model FIRST (keepSelection=true so routing reloads the right one after the
-  // transcript decides text-vs-image). Without this, a voice note recorded while a text
-  // model was resident transcribed to "" and misrouted ("draw a dog" → text model).
-  // One seam used by both the direct-audio and file transcription paths below.
-  const ensureWhisperForTranscription = async (): Promise<boolean> => {
-    if (whisperService.isModelLoaded()) return true;
-    if (!downloadedModelId) return false;
-    // Roomy device / nothing resident: a normal sidecar load fits.
-    await useWhisperStore.getState().loadModel();
-    if (whisperService.isModelLoaded()) return true;
-    // Blocked by a resident generation model (the sidecar rule correctly won't evict
-    // it, and there's no in-flight answer to protect during transcription). Free the
-    // generation model(s) via the owning service, then load whisper.
-    await activeModelService.unloadAllModels(true);
-    await useWhisperStore.getState().loadModel();
-    return whisperService.isModelLoaded();
-  };
+  // Ensure whisper is resident before transcribing (the decision lives in the pure
+  // ensureWhisperForTranscription — it frees a blocking generation model, but never
+  // evicts on a hard whisper-load failure). One seam for both paths below.
+  const ensureWhisper = (): Promise<boolean> => ensureWhisperForTranscription({
+    isLoaded: () => whisperService.isModelLoaded(),
+    hasDownloadedModel: () => !!downloadedModelId,
+    loadWhisper: () => useWhisperStore.getState().loadModel(),
+    // keepSelection=true so routing reloads the right generation model after the
+    // transcript decides text-vs-image.
+    freeGenerationModels: () => activeModelService.unloadAllModels(true).then(() => {}),
+  });
 
   const isTranscribing = isWhisperTranscribing || isTranscribingFile;
   const isRecording = isDirectRecording || isAudioModeRecording || isWhisperRecording;
@@ -142,7 +132,7 @@ export function useVoiceInput({ conversationId, onTranscript, onAudioAttachment,
                 // transcribeFile after a successful load is a transcription miss,
                 // not a load failure — leave whisperReady true so the user gets
                 // "couldn't hear that", not "couldn't load the voice model".
-                whisperReady = await ensureWhisperForTranscription();
+                whisperReady = await ensureWhisper();
                 if (whisperReady) transcript = await whisperService.transcribeFile(path);
               }
               catch (err) { logger.error('[Voice] transcription error:', err); }
@@ -180,7 +170,7 @@ export function useVoiceInput({ conversationId, onTranscript, onAudioAttachment,
         let whisperReady = false;
         let transcript = '';
         try {
-          whisperReady = await ensureWhisperForTranscription();
+          whisperReady = await ensureWhisper();
           if (whisperReady) transcript = await whisperService.transcribeFile(path);
         } catch (transcribeErr) {
           logger.error('[Voice] File transcription error:', transcribeErr);

--- a/src/components/ChatInput/ensureWhisperForTranscription.ts
+++ b/src/components/ChatInput/ensureWhisperForTranscription.ts
@@ -1,0 +1,36 @@
+import type { WhisperLoadResult } from '../../stores/whisperStore';
+
+/**
+ * Decide how to get whisper resident for a voice-turn transcription — pure so it's
+ * unit-testable and holds no View state. Transcription is a prerequisite of the turn
+ * (whisperService.transcribeFile throws without a resident model), and the STT
+ * single-model rule keeps whisper OUT of RAM while a heavier generation model is
+ * resident. So:
+ *
+ *  1. Already loaded → done.
+ *  2. No model downloaded → can't transcribe.
+ *  3. Try a normal load. 'loaded' → done.
+ *  4. ONLY when the load was 'blocked' by the single-model rule (a generation model
+ *     owns RAM) do we free that model and retry — there's no in-flight answer to
+ *     protect during transcription. A hard 'error' (corrupt/missing whisper file,
+ *     native failure) means whisper won't load regardless, so we must NOT evict the
+ *     user's generation model (that would strand them with nothing loaded).
+ */
+export interface WhisperReadinessDeps {
+  isLoaded: () => boolean;
+  hasDownloadedModel: () => boolean;
+  loadWhisper: () => Promise<WhisperLoadResult>;
+  freeGenerationModels: () => Promise<void>;
+}
+
+export async function ensureWhisperForTranscription(deps: WhisperReadinessDeps): Promise<boolean> {
+  if (deps.isLoaded()) return true;
+  if (!deps.hasDownloadedModel()) return false;
+
+  const first = await deps.loadWhisper();
+  if (first === 'loaded') return true;
+  if (first !== 'blocked') return false; // hard failure — don't evict anything
+
+  await deps.freeGenerationModels();
+  return (await deps.loadWhisper()) === 'loaded';
+}

--- a/src/services/loadModelWithOverride.ts
+++ b/src/services/loadModelWithOverride.ts
@@ -13,6 +13,10 @@
 import { AlertState, showAlert, hideAlert } from '../components/CustomAlert';
 import { isOverridableMemoryError } from './modelLoadErrors';
 
+/** Safe message extraction — a thrown value isn't guaranteed to be an Error, and
+ *  `(error as Error).message` renders "undefined" for a string/other throw. */
+const errorMessage = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
 export interface LoadWithOverrideDeps {
   setAlertState: (a: AlertState) => void;
   /** Ran on a successful load (initial OR after Load Anyway). e.g. navigate/close sheet. */
@@ -44,7 +48,7 @@ export async function loadModelWithOverride(
         deps.setAlertState(
           showAlert(
             'Insufficient Memory',
-            `${(error as Error).message}\n\nWould you like to override these safeguards and load it anyway?`,
+            `${errorMessage(error)}\n\nWould you like to override these safeguards and load it anyway?`,
             [
               { text: 'Cancel', style: 'cancel' },
               {
@@ -60,8 +64,8 @@ export async function loadModelWithOverride(
         );
         return;
       }
-      deps.setAlertState(showAlert('Error', `Failed to load model: ${(error as Error).message}`));
-      deps.onError?.(error as Error);
+      deps.setAlertState(showAlert('Error', `Failed to load model: ${errorMessage(error)}`));
+      deps.onError?.(error instanceof Error ? error : new Error(errorMessage(error)));
     } finally {
       deps.onAttemptEnd?.();
     }

--- a/src/stores/whisperStore.ts
+++ b/src/stores/whisperStore.ts
@@ -5,6 +5,16 @@ import { whisperService, WHISPER_MODELS } from '../services';
 import { modelResidencyManager } from '../services/modelResidency';
 import logger from '../utils/logger';
 
+/**
+ * Outcome of a whisper load, so callers can tell WHY it didn't load:
+ *  - 'loaded'  — resident and ready.
+ *  - 'blocked' — skipped by the single-model rule (a heavier generation model owns
+ *                RAM; the sidecar can't co-reside). Retryable by freeing that model.
+ *  - 'error'   — a real load failure (missing/corrupt file, native error) or nothing
+ *                downloaded. Freeing other models will NOT help — do not evict.
+ */
+export type WhisperLoadResult = 'loaded' | 'blocked' | 'error';
+
 interface WhisperState {
   // Active (selected) model ID
   downloadedModelId: string | null;
@@ -27,7 +37,7 @@ interface WhisperState {
   downloadModel: (modelId: string) => Promise<void>;
   /** Activate an already-downloaded model without re-downloading. */
   selectModel: (modelId: string) => Promise<void>;
-  loadModel: () => Promise<void>;
+  loadModel: () => Promise<WhisperLoadResult>;
   unloadModel: () => Promise<void>;
   deleteModel: () => Promise<void>;
   /** Delete a specific on-disk model (active or not). */
@@ -94,16 +104,16 @@ export const useWhisperStore = create<WhisperState>()(
         }
       },
 
-      loadModel: async () => {
+      loadModel: async (): Promise<WhisperLoadResult> => {
         const { downloadedModelId, isModelLoading } = get();
         if (!downloadedModelId) {
           set({ error: 'No model downloaded' });
-          return;
+          return 'error';
         }
 
         // Prevent multiple simultaneous load attempts
         if (isModelLoading) {
-          return;
+          return get().isModelLoaded ? 'loaded' : 'error';
         }
 
         set({ isModelLoading: true, error: null });
@@ -137,6 +147,9 @@ export const useWhisperStore = create<WhisperState>()(
             return true;
           });
           set({ isModelLoaded: loaded, isModelLoading: false, error: null });
+          // loaded=false means the single-model rule blocked it (not a failure) —
+          // report 'blocked' so a caller can free the resident model and retry.
+          return loaded ? 'loaded' : 'blocked';
         } catch (error) {
           const errorMsg = error instanceof Error ? error.message : 'Failed to load model';
           // If the model file is missing or corrupted, clear the downloaded state
@@ -148,6 +161,7 @@ export const useWhisperStore = create<WhisperState>()(
             downloadedModelId: isFileError ? null : downloadedModelId,
             error: errorMsg,
           });
+          return 'error';
         }
       },
 

--- a/src/stores/whisperStore.ts
+++ b/src/stores/whisperStore.ts
@@ -10,8 +10,12 @@ import logger from '../utils/logger';
  *  - 'loaded'  — resident and ready.
  *  - 'blocked' — skipped by the single-model rule (a heavier generation model owns
  *                RAM; the sidecar can't co-reside). Retryable by freeing that model.
- *  - 'error'   — a real load failure (missing/corrupt file, native error) or nothing
- *                downloaded. Freeing other models will NOT help — do not evict.
+ *  - 'error'   — a real load failure (missing/corrupt file, native error), nothing
+ *                downloaded, OR a concurrent load is already in flight (its outcome is
+ *                unknown here). Freeing other models will NOT help — do not evict. The
+ *                conservative choice: a caller treats 'error' as "don't touch other
+ *                models", which is safe for the in-flight case too (the running load
+ *                resolves on its own).
  */
 export type WhisperLoadResult = 'loaded' | 'blocked' | 'error';
 


### PR DESCRIPTION
Follow-up to #468, addressing CodeRabbit/Qodo review findings on the merged voice/settings work.

## Fixes
- **🟠 Major (functional):** `ensureWhisperForTranscription` no longer evicts the resident generation model on a *hard* whisper-load failure — only on a genuine single-model-rule *block*. A corrupt/missing whisper would otherwise strand the user with nothing loaded. `whisperStore.loadModel` now returns a discriminated `'loaded' | 'blocked' | 'error'`; the decision is extracted to a pure, tested `ensureWhisperForTranscription` (logic out of the View hook).
- **Minor:** `loadModelWithOverride` replaces `(error as Error).message` casts with a safe `errorMessage()` (a non-Error throw rendered "undefined").

## Tests (fails-before / passes-after)
- `ensureWhisperForTranscription`: 'error' must NOT free/evict (the exact regression); 'blocked' frees+retries; no infinite retry.
- `whisperStore.loadModel` returns loaded/blocked/error.
- Recommended-list NPU/GPU prioritization resort (the coverage CodeRabbit asked for): partition invariant on 'recommended', explicit 'size' sort honored.

Full core suite green (328 suites). Merge with a **merge commit** (never squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Whisper transcription now ensures the STT model is ready before sending or transcribing audio.
  * Model loading now reports explicit outcomes for success vs single-model capacity blocks vs errors.

* **Bug Fixes**
  * Prevented Whisper load failures from triggering unnecessary eviction or repeated retry loops.
  * Improved Whisper model load error text and ensured consistent error reporting.
  * Refined recommended model ordering to consistently prioritize accelerable models, while preserving manual sort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->