### PR TITLE
chore: bump pro submodule to include #17 (TTS warm-no-evict)

### DIFF
--- a/__tests__/integration/stores/tts.test.ts
+++ b/__tests__/integration/stores/tts.test.ts
@@ -110,25 +110,60 @@ describe('TTS integration', () => {
   });
 
   // ── Voice sequencing ──────────────────────────────────────────────────
-  // TTS must load with single-model override so the finished text model is evicted for the
-  // voice model. This asserts the CONTRACT (override:true is requested); the real eviction
-  // behavior of override is proven in modelResidency.test.ts (real makeRoomFor → evicts).
-  describe('voice sequencing: loading TTS requests single-model eviction', () => {
-    it('initializeEngine calls makeRoomFor for tts with override:true', async () => {
+  // TTS eviction is requested ONLY for a real speak turn (the finished text model is
+  // evicted for the voice model) — NOT for warm/preload/mode-switch, which co-reside if
+  // there's room (those callers gate on canLoadWithoutEviction; evicting there would kill
+  // the user's text model mid-session). This asserts the CONTRACT (which override flag is
+  // requested); the real eviction behavior is proven in modelResidency.test.ts.
+  describe('voice sequencing: TTS load requests eviction only for a real turn', () => {
+    afterEach(() => { mockEngine.getPhase.mockReturnValue('ready'); });
+
+    it('a warm/preload initializeEngine() does NOT override (co-reside, honor fit)', async () => {
       const { modelResidencyManager } = require('@offgrid/core/services/modelResidency');
       const spy = jest.spyOn(modelResidencyManager, 'makeRoomFor')
-        .mockResolvedValue({ fits: true, evicted: ['text'] });
-      mockEngine.getPhase.mockReturnValue('idle');   // cold → initializeEngine runs makeRoomFor
+        .mockResolvedValue({ fits: true, evicted: [] });
+      mockEngine.getPhase.mockReturnValue('idle');
       mockEngine.isFullyDownloaded.mockReturnValue(true);
 
       await getState().initializeEngine();
 
       expect(spy).toHaveBeenCalledWith(
         expect.objectContaining({ key: 'tts', type: 'tts' }),
+        { override: false },
+      );
+      spy.mockRestore();
+    });
+
+    it('a speak turn forces override:true (evict the finished text model for the voice model)', async () => {
+      const { modelResidencyManager } = require('@offgrid/core/services/modelResidency');
+      const spy = jest.spyOn(modelResidencyManager, 'makeRoomFor')
+        .mockResolvedValue({ fits: true, evicted: ['text'] });
+      mockEngine.getPhase.mockReturnValue('idle');
+      mockEngine.isFullyDownloaded.mockReturnValue(true);
+
+      await getState().initializeEngine({ override: true });
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'tts', type: 'tts' }),
         { override: true },
       );
       spy.mockRestore();
-      mockEngine.getPhase.mockReturnValue('ready');
+    });
+
+    it('a warm load that does not fit skips quietly — no error, no eviction', async () => {
+      const { modelResidencyManager } = require('@offgrid/core/services/modelResidency');
+      const spy = jest.spyOn(modelResidencyManager, 'makeRoomFor')
+        .mockResolvedValue({ fits: false, evicted: [] });
+      mockEngine.getPhase.mockReturnValue('idle');
+      mockEngine.isFullyDownloaded.mockReturnValue(true);
+
+      await getState().initializeEngine(); // warm
+
+      // Not an error state (the speak turn will force-load later), and the engine
+      // was NOT initialized (no co-resident load forced).
+      expect(getState().error).toBeNull();
+      expect(mockEngine.initialize).not.toHaveBeenCalled();
+      spy.mockRestore();
     });
   });
 


### PR DESCRIPTION
Bumps the pro submodule to `59eaa243` (pro main, includes #16 + #17) so the release ships the TTS warm-no-evict fix, and moves the core-side TTS contract test to match #17's conditional-override behavior (warm=false, speak=true). Without both together, core main's suite asserts the old always-override contract and goes red.

Release prep for the next version. Merge with a **merge commit**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated TTS integration coverage to verify warm loads, speak-turn loads, and “doesn’t fit” scenarios behave correctly.
  * Added checks for the exact eviction/override behavior during engine initialization and ensured warm attempts don’t set errors or initialize the engine prematurely.

* **Chores**
  * Updated a tracked subproject reference to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->