### PR TITLE
hotfix(ci): make release + UAT manual-only (no auto-run on merge/push)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,9 @@ name: Build and Release Android
 # If you rename this workflow, update the workflow_run trigger in release-ios.yml.
 
 on:
-  push:
-    branches: [main]     # every merge to main cuts a release
-  workflow_dispatch: {}   # manual fallback
+  # Manual only. Releases are cut by hand (scripts/release.sh locally, or this dispatch) —
+  # merging to main must NOT auto-publish to the stores.
+  workflow_dispatch: {}
 
 permissions:
   contents: write

--- a/.github/workflows/uat-dev.yml
+++ b/.github/workflows/uat-dev.yml
@@ -19,8 +19,8 @@
 name: UAT build (dev → internal testers)
 
 on:
-  push:
-    branches: [dev]
+  # Manual only. Betas are cut by hand (scripts/uat.sh locally, or this dispatch) — pushing
+  # to dev must NOT auto-build/publish a beta.
   workflow_dispatch:
     inputs:
       platform:


### PR DESCRIPTION
## What

Removes the automatic `push` triggers from both release workflows:
- **release.yml** no longer runs on push to `main` (was auto-cutting a production release on every merge).
- **uat-dev.yml** no longer runs on push to `dev` (was auto-building/publishing a beta).

Both keep `workflow_dispatch`, so they can still be launched by hand from the Actions tab. Local scripts (`scripts/release.sh`, `scripts/uat.sh`) remain the primary paths.

## Why

Merging #503 to main auto-fired the production Android release ([failed run](https://github.com/off-grid-ai/off-grid-ai-mobile/actions/runs/28952455396)). Releases and betas should be cut manually, not on merge.

## Scope

Trigger-only change; no build/logic changes. Nothing auto-publishes to the stores anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release and beta pipelines now run manually instead of automatically on branch updates.
  * This helps prevent unintended app store publishing from routine merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->