### PR TITLE
fix(release): release-sign the GitHub-release APK (was debug-signed)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,28 +99,27 @@ jobs:
 
           cat release-notes.md
 
-      # Decode signing material BEFORE building the APK so the GitHub-release APK is
-      # RELEASE-signed, not debug-signed. build.gradle gates release signing on
-      # project.hasProperty('OFFGRID_UPLOAD_STORE_FILE'), so the props are exported to
-      # $GITHUB_ENV as ORG_GRADLE_PROJECT_* (Gradle project properties) and are visible to
-      # every later gradle/fastlane step (APK + AAB). Skipped when secrets are absent, so
-      # the APK falls back to debug signing and the GitHub Release path still works.
-      - name: Decode signing secrets
-        if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' && env.PLAY_STORE_JSON_KEY != '' }}
+      # Decode the keystore BEFORE building the APK so the GitHub-release APK is RELEASE-signed,
+      # not debug-signed. Gated on the KEYSTORE ALONE (not the Play key) — APK signing only needs
+      # the keystore; coupling it to PLAY_STORE_JSON_KEY would debug-sign the APK in keystore-only
+      # setups. Only the keystore FILE PATH goes into $GITHUB_ENV (a path, so newline-safe); the
+      # secret-derived props are passed as static step env below (no env-file parsing). build.gradle
+      # gates release signing on project.hasProperty('OFFGRID_UPLOAD_STORE_FILE'), so when the
+      # keystore is absent the prop is unset and the build falls back to debug signing.
+      - name: Decode keystore
+        if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' }}
         run: |
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.keystore"
-          # PLAY_STORE_JSON_KEY may be stored raw-JSON or base64 — handle both (matches uat-dev.yml).
-          echo "$PLAY_STORE_JSON_KEY" | base64 --decode > "$RUNNER_TEMP/play-key.json" \
-            || printf '%s' "$PLAY_STORE_JSON_KEY" > "$RUNNER_TEMP/play-key.json"
-          echo "PLAY_UPLOAD=1" >> $GITHUB_ENV
-          {
-            echo "ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_STORE_FILE=$RUNNER_TEMP/release.keystore"
-            echo "ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_STORE_PASSWORD=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
-            echo "ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}"
-            echo "ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}"
-          } >> $GITHUB_ENV
+          echo "ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_STORE_FILE=$RUNNER_TEMP/release.keystore" >> "$GITHUB_ENV"
 
       - name: Build Android Release APK
+        env:
+          # Secret-derived signing props: static step env (never $GITHUB_ENV) so a newline in a
+          # secret can't corrupt the env file. build.gradle only reads these inside the
+          # hasProperty(STORE_FILE) block, so when the keystore is absent they're simply unused.
+          ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
           cd android
           ./gradlew assembleRelease
@@ -148,12 +147,24 @@ jobs:
           if-no-files-found: error
 
       # ── Play Store upload (in addition to the GitHub Release above) ──────────
-      # Builds the signed AAB and uploads it to the Play production track as a DRAFT (a
-      # human confirms rollout in the Play Console). The signing props + play-key were set
-      # up by the "Decode signing secrets" step above (ORG_GRADLE_PROJECT_* in $GITHUB_ENV),
-      # so this reuses them. Skipped when the secrets are absent (PLAY_UPLOAD unset).
+      # Decodes the Play service-account key, then builds the signed AAB and uploads it to the
+      # Play production track as a DRAFT (a human confirms rollout in the Play Console). Needs
+      # BOTH the keystore (decoded above → STORE_FILE prop) and the Play key, so it's gated on
+      # both; skipped when either is absent, and the GitHub Release path above still works.
+      - name: Decode Play service-account key
+        if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' && env.PLAY_STORE_JSON_KEY != '' }}
+        run: |
+          # PLAY_STORE_JSON_KEY may be stored raw-JSON or base64 — handle both (matches uat-dev.yml).
+          echo "$PLAY_STORE_JSON_KEY" | base64 --decode > "$RUNNER_TEMP/play-key.json" \
+            || printf '%s' "$PLAY_STORE_JSON_KEY" > "$RUNNER_TEMP/play-key.json"
+          echo "PLAY_UPLOAD=1" >> "$GITHUB_ENV"
+
       - name: Build signed AAB + upload to Play (draft)
         if: ${{ env.PLAY_UPLOAD == '1' }}
         env:
           PLAY_STORE_JSON_KEY_PATH: ${{ runner.temp }}/play-key.json
+          # Same static signing props as the APK build (STORE_FILE comes from $GITHUB_ENV).
+          ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: bundle exec fastlane android release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,27 @@ jobs:
 
           cat release-notes.md
 
+      # Decode signing material BEFORE building the APK so the GitHub-release APK is
+      # RELEASE-signed, not debug-signed. build.gradle gates release signing on
+      # project.hasProperty('OFFGRID_UPLOAD_STORE_FILE'), so the props are exported to
+      # $GITHUB_ENV as ORG_GRADLE_PROJECT_* (Gradle project properties) and are visible to
+      # every later gradle/fastlane step (APK + AAB). Skipped when secrets are absent, so
+      # the APK falls back to debug signing and the GitHub Release path still works.
+      - name: Decode signing secrets
+        if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' && env.PLAY_STORE_JSON_KEY != '' }}
+        run: |
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.keystore"
+          # PLAY_STORE_JSON_KEY may be stored raw-JSON or base64 — handle both (matches uat-dev.yml).
+          echo "$PLAY_STORE_JSON_KEY" | base64 --decode > "$RUNNER_TEMP/play-key.json" \
+            || printf '%s' "$PLAY_STORE_JSON_KEY" > "$RUNNER_TEMP/play-key.json"
+          echo "PLAY_UPLOAD=1" >> $GITHUB_ENV
+          {
+            echo "ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_STORE_FILE=$RUNNER_TEMP/release.keystore"
+            echo "ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_STORE_PASSWORD=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
+            echo "ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}"
+            echo "ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}"
+          } >> $GITHUB_ENV
+
       - name: Build Android Release APK
         run: |
           cd android
@@ -127,28 +148,12 @@ jobs:
           if-no-files-found: error
 
       # ── Play Store upload (in addition to the GitHub Release above) ──────────
-      # Decodes the production keystore + Play service-account key from secrets, builds
-      # a signed AAB, and uploads to the Play production track as a DRAFT (a human
-      # confirms rollout in the Play Console). Skipped automatically if the secrets are
-      # absent, so the GitHub Release path still works without them.
-      - name: Decode signing secrets
-        if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' && env.PLAY_STORE_JSON_KEY != '' }}
-        run: |
-          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.keystore"
-          # PLAY_STORE_JSON_KEY may be stored raw-JSON or base64 — handle both (matches uat-dev.yml).
-          echo "$PLAY_STORE_JSON_KEY" | base64 --decode > "$RUNNER_TEMP/play-key.json" \
-            || printf '%s' "$PLAY_STORE_JSON_KEY" > "$RUNNER_TEMP/play-key.json"
-          echo "PLAY_UPLOAD=1" >> $GITHUB_ENV
-
+      # Builds the signed AAB and uploads it to the Play production track as a DRAFT (a
+      # human confirms rollout in the Play Console). The signing props + play-key were set
+      # up by the "Decode signing secrets" step above (ORG_GRADLE_PROJECT_* in $GITHUB_ENV),
+      # so this reuses them. Skipped when the secrets are absent (PLAY_UPLOAD unset).
       - name: Build signed AAB + upload to Play (draft)
         if: ${{ env.PLAY_UPLOAD == '1' }}
         env:
           PLAY_STORE_JSON_KEY_PATH: ${{ runner.temp }}/play-key.json
-          # build.gradle gates release signing on project.hasProperty(...), so these must be
-          # Gradle PROJECT properties (ORG_GRADLE_PROJECT_<name>), not plain env — otherwise
-          # the AAB falls back to debug signing and Play rejects it.
-          ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_STORE_FILE: ${{ runner.temp }}/release.keystore
-          ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ORG_GRADLE_PROJECT_OFFGRID_UPLOAD_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: bundle exec fastlane android release


### PR DESCRIPTION
## What

The production release workflow's `Build Android Release APK` step ran `assembleRelease` **before** the keystore was decoded and without signing props, so the APK attached to the production GitHub release was **debug-signed**.

## Fix

- Move the signing-secret decode ahead of the APK build.
- Export the signing values to `$GITHUB_ENV` as `ORG_GRADLE_PROJECT_*` (Gradle project properties, which `build.gradle`'s release `signingConfig` gates on via `hasProperty`), so **both** the APK and the AAB are release-signed with the same material.
- Remove the now-duplicate later decode step (props defined once).

Skipped cleanly when secrets are absent (open-core): APK falls back to debug signing and the GitHub Release path still works.

## Scope

CI-only, production `release.yml`. Follows up the item flagged during #503. No app/logic changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the Android release workflow by decoding and preparing signing credentials earlier to ensure build and packaging steps have consistent access.
  * Enhanced Play Store upload reliability by splitting credential decoding into dedicated steps (including Play service-account handling) and tightening when Draft uploads can run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->