### PR TITLE
fix(uat): unblock the release build (tag-fetch recursion + fastlane dirty-check)

### DIFF
--- a/scripts/uat.sh
+++ b/scripts/uat.sh
@@ -55,7 +55,11 @@ command -v bundle >/dev/null || error "bundler not installed (bundle install)"
 # A beta targets the NEXT version, not the live one (the live train is closed - see header).
 CURRENT_VERSION=$(node -p "require('./package.json').version")   # e.g. 0.0.102 (live)
 TARGET_VERSION=$(node -e "const [a,b,c]=require('./package.json').version.split('.').map(Number); console.log(a+'.'+b+'.'+(c+1))")   # 0.0.103
-git fetch --tags --quiet || error "Could not refresh tags. Refusing to pick a beta number from stale tag history (would risk reusing an already-published beta tag and failing the tag push after the store uploads)."
+# --no-recurse-submodules: this fetch only needs CORE tags to pick the next beta number. Recursing
+# into the pro submodule made it try to fetch pro commits referenced by old tag history that are no
+# longer on pro's remote (e.g. after a pro branch was deleted/rebased) → "not our ref" → the whole
+# tag refresh failed and blocked the build. The submodule is already checked out at the pinned commit.
+git fetch --tags --no-recurse-submodules --quiet || error "Could not refresh tags. Refusing to pick a beta number from stale tag history (would risk reusing an already-published beta tag and failing the tag push after the store uploads)."
 LAST_N=$(git tag -l "v${TARGET_VERSION}-beta.*" | sed -E "s/.*-beta\.([0-9]+)$/\1/" | sort -n | tail -1)
 N=$(( ${LAST_N:-0} + 1 ))
 BETA_VERSION="${TARGET_VERSION}-beta.${N}"

--- a/scripts/uat.sh
+++ b/scripts/uat.sh
@@ -47,7 +47,9 @@ command -v node   >/dev/null || error "node not installed"
 command -v gh     >/dev/null || error "gh CLI not installed"
 command -v bundle >/dev/null || error "bundler not installed (bundle install)"
 [ -f fastlane/Fastfile ]     || error "fastlane/Fastfile not found"
-[ -z "$(git status --porcelain)" ] || error "Working tree is dirty. Commit or stash first."
+# Ignore fastlane/README.md — fastlane regenerates it on every run, so it is dirty by the time a
+# second build starts (and after any prior run). It is not source we build from.
+[ -z "$(git status --porcelain | grep -vE 'fastlane/README\.md$' || true)" ] || error "Working tree is dirty. Commit or stash first."
 [ "$DO_ANDROID" = 0 ] || { [ -f android/gradlew ] || error "android/gradlew not found"; [ -n "${ANDROID_HOME:-}" ] || error "ANDROID_HOME not set"; }
 [ "$DO_IOS" = 0 ]     || command -v xcodebuild >/dev/null || error "xcodebuild not installed"
 


### PR DESCRIPTION
Two build-script fixes surfaced while cutting the UAT build after the #548/#23 merges. App code untouched.

- **Tag-refresh fetch recursed into the pro submodule** — `git fetch --tags` failed on a stale pro pointer (`d4ff8e48`) referenced by old core tag history but no longer on pro's remote (`not our ref`), aborting every build. The tag refresh only needs core tags to pick the beta number, so `--no-recurse-submodules`.
- **fastlane/README.md tripped the dirty-tree gate** — fastlane regenerates it on every run, so the tree is "dirty" on the next build and `uat.sh` refuses to start. Exclude it from the `git status --porcelain` gate (it is not build source).

With both, `uat.sh` proceeds past the gates and builds (verified: beta `0.0.103-beta.3`, Android AAB compiling).

## Post-merge review status (FYI)
All CodeRabbit + Gitar comments on #548/#23 were fixed pre-merge and both bots posted "Confirmed" replies — nothing outstanding. Pro #23's `ci` flaked on `managerSheetResidency` (a heavy core residency test that timed out at 10155ms vs the 10s `testTimeout`); it passed on #548's test job with the same config, so it's a one-off timeout flake, not a regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved beta release checks by ignoring expected generated changes to the Fastlane README.
  * Reduced release failures caused by stale submodule history when refreshing tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->