### PR TITLE
chore(release): announce beta + prod releases in Slack from the release scripts

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -126,6 +126,14 @@ gh release create "v${NEW_VERSION}" \
   --title "Off Grid v${NEW_VERSION}" \
   --notes-file "$NOTES_FILE"
 
+# Announce the release in Slack — fail-soft, a chat message must never fail a published release.
+# Webhook comes from .env.keygen locally (mirrors the SLACK_WEBHOOK_URL repo secret the CI release
+# workflows use); notify-slack-release.mjs no-ops if it is unset.
+SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL:-$(sed -n 's/^SLACK_WEBHOOK_URL=//p' "$ROOT_DIR/.env.keygen" 2>/dev/null)}" \
+  PRODUCT="Off Grid AI Mobile" VERSION="$NEW_VERSION" \
+  RELEASE_URL="$(gh release view "v${NEW_VERSION}" --json url -q .url 2>/dev/null)" NOTES_FILE="$NOTES_FILE" \
+  node "$ROOT_DIR/scripts/notify-slack-release.mjs" || true
+
 # Clean up temp file
 rm -f "$NOTES_FILE"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -130,7 +130,7 @@ gh release create "v${NEW_VERSION}" \
 # Webhook comes from .env.keygen locally (mirrors the SLACK_WEBHOOK_URL repo secret the CI release
 # workflows use); notify-slack-release.mjs no-ops if it is unset.
 SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL:-$(sed -n 's/^SLACK_WEBHOOK_URL=//p' "$ROOT_DIR/.env.keygen" 2>/dev/null)}" \
-  PRODUCT="Off Grid AI Mobile" VERSION="$NEW_VERSION" \
+  PRODUCT="Off Grid AI Mobile" VERSION="$NEW_VERSION" CHANNEL_LABEL="stable" \
   RELEASE_URL="$(gh release view "v${NEW_VERSION}" --json url -q .url 2>/dev/null)" NOTES_FILE="$NOTES_FILE" \
   node "$ROOT_DIR/scripts/notify-slack-release.mjs" || true
 

--- a/scripts/uat.sh
+++ b/scripts/uat.sh
@@ -184,6 +184,14 @@ fi
 printf '\n\n%s\n' "$BUILD_LINE" >> "$NOTES_FILE"
 gh release create "$TAG" "${GH_ARGS[@]}" --prerelease --title "Off Grid ${BETA_VERSION} (beta)" --notes-file "$NOTES_FILE"
 
+# Announce the beta in Slack — fail-soft, a chat message must never fail a shipped build. Webhook comes
+# from .env.keygen locally (mirrors the SLACK_WEBHOOK_URL repo secret the release workflows use);
+# notify-slack-release.mjs no-ops if it is unset.
+SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL:-$(sed -n 's/^SLACK_WEBHOOK_URL=//p' "$ROOT_DIR/.env.keygen" 2>/dev/null)}" \
+  PRODUCT="Off Grid AI Mobile" VERSION="$BETA_VERSION" CHANNEL_LABEL="beta" \
+  RELEASE_URL="$(gh release view "$TAG" --json url -q .url 2>/dev/null)" NOTES_FILE="$NOTES_FILE" \
+  node "$ROOT_DIR/scripts/notify-slack-release.mjs" || true
+
 rm -f "$NOTES_FILE" "${ANDROID_CHANGELOG:-}" "$APK_DST" "$AAB_DST"
 echo ""
 info "${BOLD}Beta ${BETA_VERSION} shipped.${NC}"


### PR DESCRIPTION
## What

Both release scripts now announce the release in Slack after the GitHub release is cut:

- **`scripts/uat.sh`** (beta → TestFlight + Play internal) — posts after `gh release create`, before the notes tempfile is removed.
- **`scripts/release.sh`** (production/local) — same step added before its `rm -f "$NOTES_FILE"`.

Both call the existing `scripts/notify-slack-release.mjs` and are **fail-soft** (`|| true`) — a chat post can never fail an already-shipped build.

## Why

The Slack announcer only fired from CI (`release-ios.yml` on `workflow_run`). Releases cut locally via `uat.sh` / `release.sh` posted nothing, so beta ships (which are cut on this machine) never announced. This wires the same notifier into the local path.

## Secret handling

The webhook is read from the **gitignored `.env.keygen`** — the local secret store that already holds the RevenueCat / Resend / Keygen / Cloudflare tokens — mirroring the `SLACK_WEBHOOK_URL` repo secret the CI workflows use. It is extracted with a scoped `sed` for that one key (not a full `source`), so the other secrets in `.env.keygen` never enter the script environment. `notify-slack-release.mjs` no-ops when the webhook is unset, so this is a no-op on any machine without it.

No secrets are committed — `.env.keygen`, `fastlane/.env`, and `.env*` are all confirmed gitignored.

## Verification

- `notify-slack-release.mjs` posted the 0.0.103-beta.3 announcement successfully via this webhook during the live release.
- No native/deps/config changes; scripts-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Slack notifications when GitHub releases and beta prereleases are published.
  * Notifications include the product, version, release link, and beta status where applicable.

* **Reliability**
  * Release and beta build processes continue successfully even if Slack notification delivery fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->