### PR TITLE
chore: post-0.0.103 cleanup — SonarCloud reliability + promote-as-draft fix

### DIFF
--- a/__tests__/unit/services/modelManager.test.ts
+++ b/__tests__/unit/services/modelManager.test.ts
@@ -474,7 +474,7 @@ describe('ModelManager', () => {
         .mockResolvedValueOnce(true);  // mmProjExists (no mmproj)
 
       mockedBackgroundDownloadService.startDownload.mockResolvedValue({
-        downloadId: 42,
+        downloadId: '42',
         fileName: 'bg-model.gguf',
         modelId: 'test/model',
         status: 'pending',
@@ -486,7 +486,7 @@ describe('ModelManager', () => {
       const result = await modelManager.downloadModelBackground('test/model', file);
 
       expect(mockedBackgroundDownloadService.startDownload).toHaveBeenCalled();
-      expect(result.downloadId).toBe(42);
+      expect(result.downloadId).toBe('42');
     });
 
     it('sets up progress listener during start and complete/error via watchDownload', async () => {
@@ -498,7 +498,7 @@ describe('ModelManager', () => {
         .mockResolvedValueOnce(true);
 
       mockedBackgroundDownloadService.startDownload.mockResolvedValue({
-        downloadId: 42,
+        downloadId: '42',
         fileName: 'bg-model.gguf',
         modelId: 'test/model',
         status: 'pending',
@@ -510,9 +510,9 @@ describe('ModelManager', () => {
       const info = await modelManager.downloadModelBackground('test/model', file);
       modelManager.watchDownload(info.downloadId, jest.fn(), jest.fn());
 
-      expect(mockedBackgroundDownloadService.onProgress).toHaveBeenCalledWith(42, expect.any(Function));
-      expect(mockedBackgroundDownloadService.onComplete).toHaveBeenCalledWith(42, expect.any(Function));
-      expect(mockedBackgroundDownloadService.onError).toHaveBeenCalledWith(42, expect.any(Function));
+      expect(mockedBackgroundDownloadService.onProgress).toHaveBeenCalledWith('42', expect.any(Function));
+      expect(mockedBackgroundDownloadService.onComplete).toHaveBeenCalledWith('42', expect.any(Function));
+      expect(mockedBackgroundDownloadService.onError).toHaveBeenCalledWith('42', expect.any(Function));
     });
 
     it('calls metadata callback with download info', async () => {
@@ -524,7 +524,7 @@ describe('ModelManager', () => {
         .mockResolvedValueOnce(true);
 
       mockedBackgroundDownloadService.startDownload.mockResolvedValue({
-        downloadId: 42,
+        downloadId: '42',
         fileName: 'bg-model.gguf',
         modelId: 'test/model',
         status: 'pending',
@@ -538,7 +538,7 @@ describe('ModelManager', () => {
 
       await modelManager.downloadModelBackground('test/model', file);
 
-      expect(metadataCallback).toHaveBeenCalledWith(42, expect.objectContaining({
+      expect(metadataCallback).toHaveBeenCalledWith('42', expect.objectContaining({
         modelId: 'test/model',
         fileName: 'bg-model.gguf',
       }));
@@ -562,7 +562,7 @@ describe('ModelManager', () => {
 
       mockedBackgroundDownloadService.startDownload
         .mockResolvedValueOnce({
-          downloadId: 42,
+          downloadId: '42',
           fileName: 'vision.gguf',
           modelId: 'test/model',
           status: 'pending',
@@ -1674,7 +1674,7 @@ describe('ModelManager', () => {
 
       mockedBackgroundDownloadService.startDownload
         .mockResolvedValueOnce({
-          downloadId: 42,
+          downloadId: '42',
           fileName: 'bg-vision.gguf',
           modelId: 'test/model',
           status: 'pending',

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import android.os.Environment
+import android.util.Log
 import android.os.PowerManager
 import android.provider.Settings
 import androidx.lifecycle.Observer
@@ -162,7 +163,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
                     if (download != null) {
                         downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, DownloadReason.USER_CANCELLED)
                         val file = File(download.destination)
-                        if (file.exists()) file.delete()
+                        if (file.exists() && !file.delete()) Log.w("DownloadManagerModule", "Failed to delete cancelled download file: ${file.path}")
                     }
                 }
                 WorkerDownload.cancel(reactApplicationContext, downloadId)

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -163,7 +163,7 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
                     if (download != null) {
                         downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, DownloadReason.USER_CANCELLED)
                         val file = File(download.destination)
-                        if (file.exists() && !file.delete()) Log.w("DownloadManagerModule", "Failed to delete cancelled download file: ${file.path}")
+                        if (file.exists() && !file.delete()) Log.w(NAME, "Failed to delete cancelled download file: ${file.path}")
                     }
                 }
                 WorkerDownload.cancel(reactApplicationContext, downloadId)

--- a/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/WorkerDownload.kt
@@ -275,7 +275,7 @@ class WorkerDownload(
         val current = downloadDao.getDownload(downloadId) ?: download
         return if (current.status == DownloadStatus.CANCELLED) {
             val partialFile = File(current.destination)
-            if (partialFile.exists()) partialFile.delete()
+            if (partialFile.exists() && !partialFile.delete()) Log.w(TAG, "Failed to delete partial file on cancel: ${partialFile.path}")
             Result.failure()
         } else {
             // System stopped the worker — retry silently, no JS state change.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -253,7 +253,11 @@ platform :android do
       skip_upload_changelogs: true,
       skip_upload_images: true,
       skip_upload_screenshots: true,
-      release_status: "draft" # human confirms rollout in Play Console
+      # A track PROMOTION reads track_promote_release_status, NOT release_status — the latter only
+      # applies to a fresh upload. Without this it defaulted to "completed", so the promotion went
+      # straight to review/100% rollout instead of parking as a draft (device 2026-07-16, 0.0.103).
+      release_status: "draft",
+      track_promote_release_status: "draft" # human confirms rollout in Play Console
     )
     UI.success("Promoted internal build (versionCode #{version_code}) to Play production (draft - confirm rollout in console)")
   end

--- a/src/screens/DownloadManagerScreen/useVoiceDownloadItems.ts
+++ b/src/screens/DownloadManagerScreen/useVoiceDownloadItems.ts
@@ -85,8 +85,9 @@ async function deleteItem(item: DownloadItem): Promise<void> {
     // Models screen keep showing the deleted model as present/active.
     await useWhisperStore.getState().deleteModelById(item.modelId);
   } else {
-    const pending = callHook<Promise<void>>(HOOKS.downloadsDeleteVoiceModel, item.modelId);
-    if (pending) await pending.catch(() => {});
+    // callHook returns undefined when the hook isn't registered (free build); await the promise
+    // only when it exists. `?.` keeps a Promise out of a boolean condition (SonarJS).
+    await callHook<Promise<void>>(HOOKS.downloadsDeleteVoiceModel, item.modelId)?.catch(() => {});
   }
 }
 

--- a/src/services/activeDownloadPersistence.ts
+++ b/src/services/activeDownloadPersistence.ts
@@ -64,7 +64,7 @@ export function initActiveDownloadPersistence(): void {
   subscribed = true;
   useDownloadStore.subscribe((state) => {
     const active = serializeActiveDownloads(state.downloads);
-    const signature = active.map((e) => `${e.modelKey}:${e.status}`).sort().join('|');
+    const signature = active.map((e) => `${e.modelKey}:${e.status}`).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)).join('|');
     if (signature === lastSignature) return;
     lastSignature = signature;
     saveActiveDownloads(active).catch(() => { /* saveActiveDownloads already logs; never throws */ });

--- a/src/services/modelPreloader.ts
+++ b/src/services/modelPreloader.ts
@@ -56,8 +56,9 @@ async function preloadText(): Promise<void> {
 async function preloadTts(): Promise<void> {
   // Pro implements the audio.preload hook (fits-gated + registers the engine);
   // no-op in free builds.
-  const pending = callHook<Promise<void>>(HOOKS.audioPreload);
-  if (pending) await pending;
+  // callHook returns undefined in free builds (no audio.preload hook); awaiting undefined is a
+  // no-op, so this needs no Promise-in-condition check (SonarJS).
+  await callHook<Promise<void>>(HOOKS.audioPreload);
 }
 
 async function preloadStt(): Promise<void> {


### PR DESCRIPTION
Follow-up to the 0.0.103 release. Two concerns, both concrete and testable:

## 1. SonarCloud reliability (the quality gate that failed at merge — `new_reliability_rating=D`)
Resolves the core-repo new-code bugs:
- **activeDownloadPersistence** — `.sort()` given an explicit string comparator (deterministic signature).
- **useVoiceDownloadItems / modelPreloader** — `callHook` returns `R | undefined`, so no Promise actually reached a boolean condition; rewritten as `await …?.catch()` / `await callHook(...)` so SonarJS `no-misused-promises` is satisfied. Behaviour-neutral.
- **modelManager.test** — `downloadId` is typed `string`; the mock returned a number and assertions compared to `42`. Aligned every `downloadId` to `'42'` so runtime + type + assertions match.
- **Android `delete()`** — the ignored `Boolean` return is now logged on a failed best-effort cleanup (DownloadManagerModule + WorkerDownload), matching the existing pattern in WorkerDownload.

## 2. promote.sh lands Play production as a DRAFT
The android promote lane set `release_status: 'draft'`, but a track **promotion** reads `track_promote_release_status` — which defaulted to `completed`, so `promote.sh` sent 0.0.103 straight to Play review/100% rollout instead of pausing as a draft. Added `track_promote_release_status: 'draft'`.

## Deliberately NOT in this PR
- **iOS tap-to-edit / keyboard flicker** — pre-existing (repros on the live TestFlight build), never root-caused; needs on-device iteration. A guessed fix with no red-verify would violate the testing bar. Separate branch.
- **Fit-chip UX** — a feature (build + wire + design), not cleanup. Separate PR.
- **SonarCloud #2 (McpServerModal)** — lives in the `pro/` submodule → separate pro-repo PR.

Gates: tsc / eslint / knip / depcruise clean; affected jest suites green (the one pre-push failure was a known heavy-memory flake — passes in isolation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when cancelling downloads, with warnings if partial files can’t be deleted.
  * Hardened voice-model deletion when optional audio features are unavailable.
  * Made background download identifiers handled consistently across the download flow.
  * Improved reliability of persisted in-progress download updates.
  * Ensured boot-time TTS preload always completes safely.
  * Corrected Android promotion to remain in draft track status.
* **Tests**
  * Updated unit tests to treat background download IDs as strings for accurate callback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->