### PR TITLE
fix(core): re-export AlertButton + Chunk for pro + pin bump

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,7 +11,7 @@ export { GenerationSettingsModal } from './GenerationSettingsModal';
 export { Toast, showToast, hideToast } from './Toast';
 export type { ToastOptions } from './Toast';
 export { CustomAlert, showAlert, hideAlert, initialAlertState } from './CustomAlert';
-export type { AlertState } from './CustomAlert';
+export type { AlertState, AlertButton } from './CustomAlert';
 export { CenteredAlert } from './CenteredAlert';
 ;
 export { ModelFailureCard } from './ModelFailureCard';

--- a/src/services/rag/index.ts
+++ b/src/services/rag/index.ts
@@ -9,6 +9,7 @@ import logger from '../../utils/logger';
 export type { RagDocument, RagSearchResult } from './database';
 ;
 export { chunkDocument } from './chunking';
+export type { Chunk } from './chunking';
 export { retrievalService } from './retrieval';
 ;
 


### PR DESCRIPTION
Small follow-up to #562: re-export `AlertButton` and `Chunk` from the core barrels (pro's locket code imports them; dev's knip sweep had de-exported them), and bump the pro submodule pin to the current `feat/locket` tip. Needed so the pro CI (which typechecks pro against `feat/locket-pro`) is green. tsc + lint clean.