### PR TITLE
fix(hooks): package.json changes also trigger the iOS pre-push build (parity)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -44,7 +44,7 @@ PUSHED_KOTLIN=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.(kt|kts)$' || true)
 # native C++ builds). Run the full native builds LOCALLY on push when native / gradle / pods / deps
 # change. JS-only and docs-only pushes skip these (they stay fast).
 PUSHED_ANDROID_NATIVE=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.(kt|kts)$|^android/|^package(-lock)?\.json$' | grep -v '/build/' || true)
-PUSHED_IOS_NATIVE=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.swift$|^ios/|Podfile' | grep -v 'Pods/' | grep -v '/build/' || true)
+PUSHED_IOS_NATIVE=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.swift$|^ios/|Podfile|^package(-lock)?\.json$' | grep -v 'Pods/' | grep -v '/build/' || true)
 
 if [ -n "$PUSHED_JS" ]; then
   echo "▶ JS/TS lint (push range)..."


### PR DESCRIPTION
Follow-up to #608. The pre-push iOS-build trigger was missing `package*.json` (Android had it) — a native dep bump affects both platforms, so it should build both. Verified both hook commands compile locally: Android `assembleDebug assembleRelease` (both APKs) and iOS simulator build (OffgridMobile.app). Hooks-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-push checks so changes to package configuration also trigger the iOS native build validation.
  * Existing conditional build and test behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->