### PR TITLE
fix(B5/G1): a transient FS error must not drop a valid model from the registry

### DIFF
--- a/__tests__/unit/services/modelManager/storageTransientFsG1.test.ts
+++ b/__tests__/unit/services/modelManager/storageTransientFsG1.test.ts
@@ -1,0 +1,70 @@
+/**
+ * B5 / G1 — a transient filesystem error must NEVER unlink a valid, fully-downloaded model.
+ *
+ * loadDownloadedModels() prunes any model whose file it can't find, then PERSISTS the pruned
+ * registry (saveModelsList). The regression: the existence probe (RNFS.exists) treated a
+ * transient rejection (I/O blip, container not yet mounted) the same as "file absent", so a
+ * momentary FS hiccup silently dropped the user's multi-GB model from storage — permanent loss.
+ *
+ * These tests drive the REAL seam (the actual loadDownloadedModels + validateAndResolveModels
+ * code) and only fault the third-party FS boundary (RNFS), which is the only way to reproduce a
+ * transient FS error deterministically. We assert OUR behaviour: the model survives and the
+ * registry is not rewritten to exclude it — while a PROVABLY absent file is still pruned.
+ */
+import RNFS from 'react-native-fs';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { loadDownloadedModels } from '../../../../src/services/modelManager/storage';
+
+const mockedRNFS = RNFS as jest.Mocked<typeof RNFS>;
+const mockedAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+const MODELS_DIR = '/data/models';
+const VALID_MODEL = {
+  id: 'unsloth/gemma-4-E2B-it-GGUF/gemma-4-E2B-it-Q4_K_M.gguf',
+  fileName: 'gemma-4-E2B-it-Q4_K_M.gguf',
+  filePath: `${MODELS_DIR}/gemma-4-E2B-it-Q4_K_M.gguf`,
+  engine: 'llama',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedAsyncStorage.getItem.mockResolvedValue(JSON.stringify([VALID_MODEL]));
+  mockedAsyncStorage.setItem.mockResolvedValue(undefined as any);
+});
+
+describe('loadDownloadedModels — transient FS error (B5/G1)', () => {
+  it('KEEPS a valid model when the existence check throws (transient), and does not rewrite the registry', async () => {
+    // RNFS.exists rejects — a transient I/O error, NOT proof the file is gone.
+    mockedRNFS.exists.mockRejectedValue(new Error('EIO: i/o error, stat'));
+
+    const models = await loadDownloadedModels(MODELS_DIR);
+
+    // The model is retained — no silent data loss.
+    expect(models).toHaveLength(1);
+    expect(models[0].filePath).toBe(VALID_MODEL.filePath);
+    // And the stored registry is NOT rewritten to a pruned list (nothing was provably removed).
+    expect(mockedAsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('still PRUNES and persists when the file is provably absent (exists cleanly resolves false)', async () => {
+    // Clean "false" everywhere — the file is genuinely gone; registry cleanup must still happen.
+    mockedRNFS.exists.mockResolvedValue(false);
+
+    const models = await loadDownloadedModels(MODELS_DIR);
+
+    expect(models).toHaveLength(0);
+    // The pruned (empty) registry is persisted — real orphan cleanup is preserved.
+    expect(mockedAsyncStorage.setItem).toHaveBeenCalledTimes(1);
+    const [, persisted] = mockedAsyncStorage.setItem.mock.calls[0];
+    expect(JSON.parse(persisted as string)).toHaveLength(0);
+  });
+
+  it('KEEPS a present model untouched (exists resolves true — no rewrite)', async () => {
+    mockedRNFS.exists.mockResolvedValue(true);
+
+    const models = await loadDownloadedModels(MODELS_DIR);
+
+    expect(models).toHaveLength(1);
+    expect(mockedAsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/modelManager/storage.ts
+++ b/src/services/modelManager/storage.ts
@@ -64,18 +64,36 @@ export async function saveImageModelsList(models: ONNXImageModel[]): Promise<voi
   await AsyncStorage.setItem(IMAGE_MODELS_STORAGE_KEY, JSON.stringify(models));
 }
 
+/**
+ * Existence probe that NEVER conflates a transient filesystem error with "file absent".
+ *
+ * `RNFS.exists` can reject on a transient FS hiccup (I/O error, container not yet mounted,
+ * momentary permission blip). If we read that rejection as "the file is gone", the caller
+ * prunes the model from the registry and persists the pruned list — silently unlinking a
+ * valid, fully-downloaded multi-GB model (G1 data loss). `verifiable: false` marks "we
+ * could not tell", which callers MUST treat as keep-the-model, not drop-it.
+ */
+async function probeExists(path: string): Promise<{ exists: boolean; verifiable: boolean }> {
+  try {
+    return { exists: await RNFS.exists(path), verifiable: true };
+  } catch (e) {
+    logger.warn(`[ModelManagerStorage] existence check could not be verified for ${path} — keeping model (transient)`, e);
+    return { exists: false, verifiable: false };
+  }
+}
+
 async function tryResolveTextModelPath(
   model: DownloadedModel,
   modelsDir: string,
-): Promise<{ exists: boolean; updated: boolean }> {
+): Promise<{ exists: boolean; updated: boolean; verifiable: boolean }> {
   const resolved = resolveStoredPath(model.filePath, modelsDir);
-  if (!resolved || resolved === model.filePath) return { exists: false, updated: false };
-  const exists = await RNFS.exists(resolved);
+  if (!resolved || resolved === model.filePath) return { exists: false, updated: false, verifiable: true };
+  const { exists, verifiable } = await probeExists(resolved);
   if (exists) {
     model.filePath = resolved;
-    return { exists: true, updated: true };
+    return { exists: true, updated: true, verifiable };
   }
-  return { exists: false, updated: false };
+  return { exists: false, updated: false, verifiable };
 }
 
 async function tryResolveMmProjPath(
@@ -103,12 +121,12 @@ async function validateAndResolveModels(
   let pathsUpdated = false;
 
   const existenceChecks = await Promise.all(
-    models.map(m => RNFS.exists(m.filePath))
+    models.map(m => probeExists(m.filePath))
   );
 
   const modelsToResolve: Array<{ model: DownloadedModel; idx: number }> = [];
   for (let i = 0; i < models.length; i++) {
-    if (!existenceChecks[i]) {
+    if (!existenceChecks[i].exists) {
       modelsToResolve.push({ model: models[i], idx: i });
     }
   }
@@ -124,7 +142,7 @@ async function validateAndResolveModels(
 
   const modelsToCheckMmProj: Array<{ model: DownloadedModel; idx: number }> = [];
   for (let i = 0; i < models.length; i++) {
-    const mainExists = existenceChecks[i];
+    const mainExists = existenceChecks[i].exists;
     if (!mainExists) {
       const idx = modelsToResolve.findIndex(m => m.idx === i);
       if (idx >= 0 && resolutionResults[idx].exists) {
@@ -144,15 +162,22 @@ async function validateAndResolveModels(
   }
 
   for (let i = 0; i < models.length; i++) {
-    const mainExists = existenceChecks[i];
+    const { exists: mainExists, verifiable: mainVerifiable } = existenceChecks[i];
     let exists = mainExists;
+    // The model is confirmably gone only when EVERY probe cleanly resolved "absent".
+    // If any probe couldn't be verified (RNFS threw), we don't know — and must not drop it.
+    let verifiable = mainVerifiable;
     if (!mainExists) {
       const idx = modelsToResolve.findIndex(m => m.idx === i);
       if (idx >= 0) {
         exists = resolutionResults[idx].exists;
+        verifiable = verifiable && resolutionResults[idx].verifiable;
       }
     }
-    if (exists) {
+    // Keep the model if it exists OR if we couldn't verify its absence. Pruning (and the
+    // saveModelsList persist that follows) is reserved for files PROVABLY gone — a transient
+    // filesystem error must never silently unlink a valid, fully-downloaded model (G1).
+    if (exists || !verifiable) {
       validModels.push(models[i]);
     }
   }


### PR DESCRIPTION
## What & why

`loadDownloadedModels()` prunes any model whose file it can't find, then **persists** the pruned registry (`saveModelsList`). Its existence probe was a bare `RNFS.exists`, which **rejects on a transient FS hiccup** (I/O blip, app-container path not yet mounted). That rejection either aborted the whole load (the models list blanks until relaunch) or — via the resolve fallback — could read as "file absent" and drop the row, so a filesystem hiccup made a user's fully-downloaded multi-GB model disappear.

**Fix:** `probeExists()` distinguishes *provably absent* (RNFS resolved `false`) from *couldn't verify* (RNFS threw). `validateAndResolveModels` keeps a model when it exists **or** when its absence couldn't be verified; only a **provably-gone** file is pruned + persisted. Real orphan cleanup (clean `false`) is unchanged. No file is ever unlinked in this path.

## Honest scoping note

This is **not** a port of the known-good B5 fix (the `corrupt`-flag change in `76669003`), and it's **not** the original G1 bug. The original mechanism — `validateModelFile`'s `RNFS.stat` throwing → `valid:false` → `RNFS.unlink()` the file — **no longer exists on `main`**: that path was refactored into the current `exists`-based *registry* prune (no file deletion). This PR closes the residual transient-FS gap in that current implementation. B5's original data-loss vector is already resolved on main; the backlog entry should be updated to reflect that.

## Test

Drives the **real** `loadDownloadedModels` / `validateAndResolveModels` code and faults only the third-party FS boundary (the sole deterministic way to reproduce a transient FS error):
- a valid model **survives** a throwing existence check, **registry untouched**;
- a **provably absent** model is still pruned + persisted (orphan cleanup preserved);
- a present model is left alone.

208 modelManager unit tests pass (incl. the 3 new); lint clean; `tsc` clean for the changed files (the whole-project `tsc` errors that pre-exist in the working tree are from an unrelated `pro` submodule WIP + an untracked SDXL test, and CI typechecks against the committed `pro`).

## Merge gate

Src change → per repo policy needs an on-device sanity check (normal model loads still work on iOS + Android) before merge. The transient-error branch itself can't be forced on a real device deterministically — that's what the boundary test covers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented downloaded models from being removed when a temporary filesystem error prevents verifying their files.
  * Confirmed model entries are pruned only when their files are verified as missing.
  * Added coverage for preserving valid models and correctly updating stored model records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->