### PR TITLE
fix(image): stop offering SDXL on iOS — it jetsams even a 12 GB iPhone 17 Pro Max

### DIFF
--- a/__tests__/unit/services/hardware.test.ts
+++ b/__tests__/unit/services/hardware.test.ts
@@ -902,7 +902,8 @@ describe('HardwareService', () => {
     });
 
     describe('iOS recommendations', () => {
-      it('recommends SDXL for high-end devices (A17Pro+, 6GB+)', async () => {
+      it('recommends SD 2.1 Palettized (NOT SDXL) for high-end devices (A17Pro+, 6GB+)', async () => {
+        // SDXL jetsams even top-tier iOS devices (~7 GB dirty Core ML) → never recommended/offered.
         await setupDevice({
           totalGB: 8,
           platform: 'ios',
@@ -911,9 +912,11 @@ describe('HardwareService', () => {
         const rec = await hardwareService.getImageModelRecommendation();
         expect(rec.recommendedBackend).toBe('coreml');
         expect(rec.recommendedModels).toEqual(
-          expect.arrayContaining(['sdxl', 'xl-base']),
+          expect.arrayContaining(['2-1-base-palettized', 'v1-5-palettized']),
         );
-        expect(rec.bannerText).toContain('SDXL');
+        expect(rec.recommendedModels).not.toContain('sdxl');
+        expect(rec.recommendedModels).not.toContain('xl-base');
+        expect(rec.bannerText).not.toContain('SDXL');
       });
 
       it('recommends SD 1.5/2.1 palettized for mid-range (A15/A16, 6GB+)', async () => {

--- a/__tests__/unit/services/imageModelRecommendation.test.ts
+++ b/__tests__/unit/services/imageModelRecommendation.test.ts
@@ -47,12 +47,6 @@ const COREML_MODELS: TestImageModel[] = [
     backend: 'coreml',
   },
   {
-    id: 'coreml_apple_coreml-stable-diffusion-xl-base-ios',
-    name: 'SDXL (iOS)',
-    repo: 'apple/coreml-stable-diffusion-xl-base-ios',
-    backend: 'coreml',
-  },
-  {
     id: 'coreml_apple_coreml-stable-diffusion-v1-5',
     name: 'SD 1.5',
     repo: 'apple/coreml-stable-diffusion-v1-5',
@@ -90,36 +84,11 @@ describe('isRecommendedModel', () => {
   // ========================================================================
   // iOS Core ML recommendations
   // ========================================================================
-  describe('iOS Core ML — high-end (SDXL)', () => {
-    const rec: ImageModelRecommendation = {
-      recommendedBackend: 'coreml',
-      recommendedModels: ['sdxl', 'xl-base'],
-      bannerText: 'All models supported — SDXL for best quality',
-      compatibleBackends: ['coreml'],
-    };
+  // SDXL is no longer offered or recommended on iOS (its ~7 GB dirty Core ML footprint jetsams even
+  // a 12 GB device). High-end devices now get SD 2.1 Palettized as the top pick — covered by the
+  // mid-range/palettized block below and by hardware.test.ts's getImageModelRecommendation tiers.
 
-    it('matches SDXL model via repo (xl-base)', () => {
-      const sdxl = findModel(COREML_MODELS, 'xl-base');
-      expect(isRecommendedModel(sdxl, rec)).toBe(true);
-    });
-
-    it('does not match SD 1.5 Palettized', () => {
-      const sd15p = findModel(COREML_MODELS, 'v1-5-palettized');
-      expect(isRecommendedModel(sd15p, rec)).toBe(false);
-    });
-
-    it('does not match SD 2.1 Palettized', () => {
-      const sd21p = findModel(COREML_MODELS, '2-1-base-palettized');
-      expect(isRecommendedModel(sd21p, rec)).toBe(false);
-    });
-
-    it('does not match full-precision SD 1.5', () => {
-      const sd15 = COREML_MODELS.find(m => m.id === 'coreml_apple_coreml-stable-diffusion-v1-5')!;
-      expect(isRecommendedModel(sd15, rec)).toBe(false);
-    });
-  });
-
-  describe('iOS Core ML — mid-range (SD 1.5/2.1 Palettized)', () => {
+  describe('iOS Core ML — high-end + mid-range (SD 2.1 / 1.5 Palettized)', () => {
     const rec: ImageModelRecommendation = {
       recommendedBackend: 'coreml',
       recommendedModels: ['v1-5-palettized', '2-1-base-palettized'],
@@ -135,11 +104,6 @@ describe('isRecommendedModel', () => {
     it('matches SD 2.1 Palettized', () => {
       const sd21p = findModel(COREML_MODELS, '2-1-base-palettized');
       expect(isRecommendedModel(sd21p, rec)).toBe(true);
-    });
-
-    it('does not match SDXL', () => {
-      const sdxl = findModel(COREML_MODELS, 'xl-base');
-      expect(isRecommendedModel(sdxl, rec)).toBe(false);
     });
 
     it('does not match full-precision SD 1.5 (no "palettized" in repo)', () => {
@@ -164,11 +128,6 @@ describe('isRecommendedModel', () => {
     it('does not match SD 2.1 Palettized', () => {
       const sd21p = findModel(COREML_MODELS, '2-1-base-palettized');
       expect(isRecommendedModel(sd21p, rec)).toBe(false);
-    });
-
-    it('does not match SDXL', () => {
-      const sdxl = findModel(COREML_MODELS, 'xl-base');
-      expect(isRecommendedModel(sdxl, rec)).toBe(false);
     });
   });
 

--- a/__tests__/unit/utils/unsupportedJetsamImageModel.test.ts
+++ b/__tests__/unit/utils/unsupportedJetsamImageModel.test.ts
@@ -1,0 +1,54 @@
+/**
+ * SDXL (apple/coreml-stable-diffusion-xl-base-ios) is unsupported on iOS — its ~7 GB dirty Core ML
+ * footprint jetsams even a 12 GB iPhone 17 Pro Max. It's been removed from the download catalog, but
+ * a copy downloaded before that must never be OFFERED as selectable (tapping it = guaranteed jetsam).
+ * isUnsupportedJetsamImageModel is the guard the model selectors filter on.
+ */
+import { isUnsupportedJetsamImageModel } from '../../../src/utils/modelSelectorFilters';
+import { ONNXImageModel } from '../../../src/types';
+
+const model = (over: Partial<ONNXImageModel>): ONNXImageModel => ({
+  id: 'coreml_apple_coreml-stable-diffusion-2-1-base-palettized',
+  name: 'SD 2.1 Palettized',
+  description: '',
+  modelPath: '/models/sd21',
+  downloadedAt: '2026-07-25T00:00:00Z',
+  size: 1_000_000,
+  backend: 'coreml',
+  ...over,
+});
+
+describe('isUnsupportedJetsamImageModel', () => {
+  it('hides the SDXL iOS Core ML model matched by its id slug', () => {
+    expect(
+      isUnsupportedJetsamImageModel(
+        model({ id: 'coreml_apple_coreml-stable-diffusion-xl-base-ios', name: 'SDXL (iOS)' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('hides it even if the id was recorded oddly but the modelPath carries the repo slug', () => {
+    expect(
+      isUnsupportedJetsamImageModel(
+        model({ id: 'recovered_sdxl_123', modelPath: '/models/apple_coreml-stable-diffusion-xl-base-ios' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT hide the supported palettized models (SD 2.1 / 1.5)', () => {
+    expect(isUnsupportedJetsamImageModel(model({}))).toBe(false);
+    expect(
+      isUnsupportedJetsamImageModel(
+        model({ id: 'coreml_apple_coreml-stable-diffusion-v1-5-palettized', name: 'SD 1.5 Palettized' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('does NOT hide non-XL full-precision SD (substring must be the XL repo, not just "xl")', () => {
+    expect(
+      isUnsupportedJetsamImageModel(
+        model({ id: 'coreml_apple_coreml-stable-diffusion-v1-5', modelPath: '/models/sd15-relaxl' }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/components/ModelSelectorModal/index.tsx
+++ b/src/components/ModelSelectorModal/index.tsx
@@ -20,6 +20,7 @@ import { ImageTab } from './ImageTab';
 import {
   isSuspiciousRecoveredImageModel,
   isSuspiciousRecoveredTextModel,
+  isUnsupportedJetsamImageModel,
 } from '../../utils/modelSelectorFilters';
 import logger from '../../utils/logger';
 
@@ -95,7 +96,7 @@ export const ModelSelectorModal: React.FC<ModelSelectorModalProps> = ({
     [downloadedModels],
   );
   const filteredDownloadedImageModels = useMemo(
-    () => downloadedImageModels.filter(model => !isSuspiciousRecoveredImageModel(model)),
+    () => downloadedImageModels.filter(model => !isSuspiciousRecoveredImageModel(model) && !isUnsupportedJetsamImageModel(model)),
     [downloadedImageModels],
   );
 

--- a/src/screens/ChatScreen/useChatScreen.ts
+++ b/src/screens/ChatScreen/useChatScreen.ts
@@ -24,6 +24,7 @@ import { needsVisionRepair } from '../../utils/visionRepair';
 import {
   isSuspiciousRecoveredImageModel,
   isSuspiciousRecoveredTextModel,
+  isUnsupportedJetsamImageModel,
 } from '../../utils/modelSelectorFilters';
 
 export type { AlertState };
@@ -205,7 +206,7 @@ export const useChatScreen = () => {
     [downloadedModels],
   );
   const availableDownloadedImageModels = useMemo(
-    () => downloadedImageModels.filter(model => !isSuspiciousRecoveredImageModel(model)),
+    () => downloadedImageModels.filter(model => !isSuspiciousRecoveredImageModel(model) && !isUnsupportedJetsamImageModel(model)),
     [downloadedImageModels],
   );
   const hasAvailableModels =

--- a/src/services/coreMLModelBrowser.ts
+++ b/src/services/coreMLModelBrowser.ts
@@ -31,7 +31,9 @@ interface HFTreeEntry {
 // All Apple Core ML Stable Diffusion repos.
 // Palettized = 6-bit quantized, ~50% smaller, have ZIP downloads.
 // Full precision = larger but higher quality, multi-file download required.
-// SDXL iOS = 4-bit mixed-bit palettized, 768×768, ANE-optimized.
+// NOTE: SDXL (apple/coreml-stable-diffusion-xl-base-ios) is intentionally NOT offered on iOS.
+// Its Core ML runtime footprint is ~7 GB of DIRTY (un-pageable) memory, which jetsams even a
+// 12 GB iPhone 17 Pro Max mid-load. The 512×512 palettized SD models are the ceiling we ship.
 interface RepoEntry {
   repo: string;
   name: string;
@@ -62,11 +64,6 @@ const REPOS: RepoEntry[] = [
     name: 'SD 2.1 Palettized (Low RAM)',
     description: '6-bit quantized, 512×512, CPU/GPU — fits ≤4 GB devices',
     variant: 'original',
-  },
-  {
-    repo: 'apple/coreml-stable-diffusion-xl-base-ios',
-    name: 'SDXL (iOS)',
-    description: '4-bit quantized, 768×768, ANE-optimized',
   },
   {
     repo: 'apple/coreml-stable-diffusion-v1-5',

--- a/src/services/hardware.ts
+++ b/src/services/hardware.ts
@@ -370,7 +370,10 @@ class HardwareService {
   private getIosImageRec(chip: SoCInfo['appleChip'], ramGB: number): ImageModelRecommendation {
     const coreml = 'coreml';
     if ((chip === 'A17Pro' || chip === 'A18') && ramGB >= 6)
-      return { recommendedBackend: coreml, recommendedModels: ['sdxl', 'xl-base'], bannerText: 'All models supported \u2014 SDXL for best quality', compatibleBackends: [coreml] };
+      // SDXL is NOT recommended (nor offered) on iOS \u2014 its ~7 GB dirty Core ML footprint jetsams
+      // even top-tier devices (see coreMLModelBrowser). SD 2.1 Palettized (6-bit, ANE) is the
+      // best-quality model that loads safely, so big devices get it as the top pick.
+      return { recommendedBackend: coreml, recommendedModels: ['2-1-base-palettized', 'v1-5-palettized'], bannerText: 'SD 2.1 Palettized recommended \u2014 best quality for your device', compatibleBackends: [coreml] };
     if ((chip === 'A15' || chip === 'A16') && ramGB >= 6)
       return { recommendedBackend: coreml, recommendedModels: ['v1-5-palettized', '2-1-base-palettized'], bannerText: 'SD 1.5 or SD 2.1 Palettized recommended', compatibleBackends: [coreml] };
     if (ramGB < 4)

--- a/src/utils/modelSelectorFilters.ts
+++ b/src/utils/modelSelectorFilters.ts
@@ -13,3 +13,18 @@ export function isSuspiciousRecoveredTextModel(model: DownloadedModel): boolean 
 export function isSuspiciousRecoveredImageModel(model: ONNXImageModel): boolean {
   return model.id.startsWith('recovered_');
 }
+
+/**
+ * SDXL (apple/coreml-stable-diffusion-xl-base-ios) is unsupported on iOS: its Core ML runtime
+ * footprint is ~7 GB of DIRTY (un-pageable) memory, which jetsams even a 12 GB iPhone 17 Pro Max
+ * mid-load. It's been removed from the download catalog (coreMLModelBrowser), but a copy downloaded
+ * before that must never be OFFERED as selectable either — otherwise tapping it is a guaranteed
+ * jetsam. Match by its repo slug so it's hidden regardless of how the id/name was recorded.
+ * (It stays in the store so it remains deletable from the Download Manager to reclaim space.)
+ */
+export function isUnsupportedJetsamImageModel(model: ONNXImageModel): boolean {
+  const id = model.id.toLowerCase();
+  const path = model.modelPath.toLowerCase();
+  return id.includes('coreml-stable-diffusion-xl-base-ios') ||
+    path.includes('coreml-stable-diffusion-xl-base-ios');
+}


### PR DESCRIPTION
## Problem

SDXL (`apple/coreml-stable-diffusion-xl-base-ios`) is **not safely usable on iOS**. Its Core ML runtime footprint is ~7 GB of **dirty** (un-pageable) memory — verified on-device this session: **7.11 GB RAM, against a 4855 MB budget** — which jetsams even a top-tier **iPhone 17 Pro Max** mid-load. Offering or recommending it is a guaranteed crash.

## Fix — gone from every surface

1. **Catalog** (`coreMLModelBrowser.ts`) — removed the SDXL `RepoEntry` so it's no longer offered for download.
2. **Recommendation** (`hardware.ts` `getIosImageRec`) — the top tier (A17Pro/A18, ≥6 GB) no longer suggests SDXL. It now recommends **SD 2.1 Palettized** (6-bit, ANE) — the best-quality model that loads safely — with a "best quality for your device" banner.
3. **Selector guard** (`isUnsupportedJetsamImageModel`) — filters an **already-downloaded** SDXL out of both model selectors (`ModelSelectorModal` + `useChatScreen`), so a copy pulled before this change can't be tapped into a jetsam. It stays in the store so it remains **deletable** from the Download Manager to reclaim space.

## Verified on a real iPhone 17 Pro Max

With a previously-downloaded SDXL on disk, on the fresh bundle:
- The image model selector now shows **"No Image Models"** — SDXL is filtered out of the selectable list.
- The guard predicate matches the device's **actual** record id (`coreml_apple_coreml-stable-diffusion-xl-base-ios`, pulled from the device log), and `ImageTab` renders the filtered prop (wiring verified).

## Tests + hygiene

- New predicate test (`unsupportedJetsamImageModel.test.ts`) + updated recommendation/hardware tier tests — all green.
- eslint / tsc / depcruise clean; pre-push gate passed.

Android is unaffected — SDXL is Core ML (iOS-only) and never existed there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unsupported SDXL image models from iOS model discovery, selection, and chat downloads.
  * Updated iOS recommendations to prioritize SD 2.1 and SD 1.5 Palettized models.
  * Improved filtering for models that may cause memory-related app interruptions on iOS.
* **Tests**
  * Added coverage confirming unsupported SDXL models are excluded while supported Palettized models remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->