### PR TITLE
fix(B9/G4): don't double-count an already-resident model on reload

### DIFF
--- a/__tests__/unit/services/modelResidency.test.ts
+++ b/__tests__/unit/services/modelResidency.test.ts
@@ -728,6 +728,53 @@ describe('ModelResidencyManager', () => {
         expect(fits).toBe(false);
       });
     });
+
+    describe('already-resident reload must not double-count its dirty footprint (G4/B9)', () => {
+      // Reloading a model that is ALREADY resident (e.g. an image model re-selected after a thread
+      // change) must charge its dirty footprint ONCE, not twice: the incoming spec.sizeMB and the
+      // still-registered same-key resident are the SAME RAM. The old dirty-ceiling summed both and
+      // refused a model already sitting in memory. Size the model so 1x fits the balanced dirty
+      // ceiling but 2x (the double-count) exceeds it — pinning the bug precisely.
+      const TOTAL_GB = 12;
+      const ceilingMB = computeBudgetMB(TOTAL_GB * 1024, { policy: 'balanced' });
+      const sizeMB = Math.round(ceilingMB * 0.7); // 1x = 0.7*ceiling (fits), 2x = 1.4*ceiling (exceeds)
+      const origPlatform = Platform.OS;
+
+      beforeEach(() => {
+        Platform.OS = 'android';
+        modelResidencyManager._reset();
+        modelResidencyManager.setBudgetOverrideMB(null);
+        jest.spyOn(hardwareService, 'getTotalMemoryGB').mockReturnValue(TOTAL_GB);
+        jest.spyOn(hardwareService, 'getAvailableMemoryGB').mockReturnValue(TOTAL_GB); // healthy free RAM — isolate the dirty-ceiling path
+        jest.spyOn(hardwareService, 'refreshMemoryInfo').mockResolvedValue(undefined as never);
+      });
+      // Don't leak Platform.OS into sibling suites (the override-survival tests read the ambient
+      // platform for Android reclaim credit).
+      afterEach(() => { Platform.OS = origPlatform; });
+
+      it('KEEPS an already-resident dirty image model on reload (fits — footprint counted once)', async () => {
+        modelResidencyManager.register(
+          { key: 'image', type: 'image', modelId: 'sdxl', sizeMB, dirtyMemory: true },
+          jest.fn().mockResolvedValue(undefined),
+          1,
+        );
+        // Reload the SAME key: with the bug, dirtyFootprint = sizeMB + sizeMB = 1.4*ceiling → refused.
+        const { fits, evicted } = await modelResidencyManager.makeRoomFor({
+          key: 'image', type: 'image', modelId: 'sdxl', sizeMB, dirtyMemory: true,
+        });
+        expect(fits).toBe(true);       // fails-before: was false (double-counted to 2x the ceiling)
+        expect(evicted).toEqual([]);   // the resident it replaces is never evicted
+      });
+
+      it('still REFUSES a genuinely oversized dirty model (no over-correction)', async () => {
+        // A fresh dirty model whose OWN footprint exceeds the balanced ceiling must still be refused —
+        // proves the fix only drops the same-key double-count, not the real physics guard.
+        const { fits } = await modelResidencyManager.makeRoomFor({
+          key: 'image', type: 'image', modelId: 'huge', sizeMB: ceilingMB + 500, dirtyMemory: true,
+        });
+        expect(fits).toBe(false);
+      });
+    });
   });
 
   describe('override survival floor (never force a load into a jetsam SIGKILL)', () => {

--- a/src/services/modelResidency/index.ts
+++ b/src/services/modelResidency/index.ts
@@ -327,8 +327,13 @@ class ModelResidencyManager {
     // INDEPENDENT of the total-budget check above, so it never changes the clean+dirty swap cases
     // (a large image still evicts a resident text via the total budget).
     const dirtyCeilingMB = computeBudgetMB(totalMB, { policy: 'balanced' });
+    // Sum the dirty residents that STAY — excluding the incoming's own same-key entry. On a reload
+    // (e.g. an image model re-loaded after a thread change) the incoming REPLACES that resident, so
+    // spec.sizeMB below already accounts for its footprint; counting the resident too double-charges
+    // the model and wrongly refuses one already sitting in RAM (G4). Mirrors planEviction's
+    // alreadyResident rule, which likewise charges the incoming 0 when it's already resident.
     const keptDirtyMB = residents
-      .filter(r => r.dirtyMemory && !plan.evict.some(e => e.key === r.key))
+      .filter(r => r.dirtyMemory && r.key !== spec.key && !plan.evict.some(e => e.key === r.key))
       .reduce((sum, r) => sum + r.sizeMB, 0);
     const dirtyFootprintMB = (spec.dirtyMemory ? spec.sizeMB : 0) + keptDirtyMB;
     const dirtyCeilingExceeded = !!spec.dirtyMemory && dirtyFootprintMB > dirtyCeilingMB;


### PR DESCRIPTION
## Problem

`makeRoomFor`'s dirty-ceiling check summed every non-evicted dirty resident **and** added the incoming `spec.sizeMB` — but on a reload the incoming **replaces** its own same-key resident, so that entry is the **same RAM**. Reloading an already-resident dirty model (e.g. an image model re-selected after a thread change) therefore charged **2× its footprint** and was refused for memory even though it already occupied that RAM.

## Fix

`planEviction` already handles this (its `alreadyResident` rule charges the incoming 0 and never evicts the same-key resident). The separate dirty-ceiling check in `makeRoomFor` didn't mirror it — now it excludes the incoming's own same-key entry from `keptDirtyMB`, so the footprint is counted once. The real physics guard is untouched: a fresh dirty model whose **own** footprint exceeds the balanced ceiling is still refused.

```diff
- .filter(r => r.dirtyMemory && !plan.evict.some(e => e.key === r.key))
+ .filter(r => r.dirtyMemory && r.key !== spec.key && !plan.evict.some(e => e.key === r.key))
```

## Test — real manager, red→green

Drives the **real** `modelResidencyManager` (registers an already-resident dirty image model, reloads the same key), sized so 1× fits the balanced dirty ceiling but 2× (the double-count) exceeds it:
- reload **fits** — red before the fix (`fits:false`, double-counted; verified by reverting), green after;
- a genuinely-oversized dirty model is still **refused** (no over-correction).

66 residency + 126 adjacent memory tests pass; eslint/tsc/depcruise clean.

## On-device note (honest)

B9's precise fault — the double-count crossing the memory ceiling on reload — **can't be staged on a physical device**: it needs an image model that fits budget at 1× but double-counts past the ceiling. SDXL was the only candidate on the test iPhone, and it's **override-only** (7.3 GB > 4.9 GB budget, so it bypasses the dirty-ceiling check entirely) and has since been removed. The rigorous proof is the real-manager test above; there's no distinguishing device repro to run — same class as the B5/B8 memory-accounting fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model reload memory calculations so an already-resident model’s dirty memory is not counted twice.
  * Improved handling of dirty models near memory limits, allowing valid reloads while still rejecting genuinely oversized models.

* **Tests**
  * Added coverage for resident model reloads, oversized dirty models, and platform-state isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->