### PR TITLE
docs(readme): fix stale repo slug + document acceleration, memory control, downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 **Chat. Generate images. Use tools. See. Listen. All on your phone or Mac. All offline. Zero data leaves your device.**
 
-[![GitHub stars](https://img.shields.io/github/stars/alichherawalla/off-grid-mobile?style=social)](https://github.com/alichherawalla/off-grid-mobile)
+[![GitHub stars](https://img.shields.io/github/stars/off-grid-ai/OGAM?style=social)](https://github.com/off-grid-ai/OGAM)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Google Play](https://img.shields.io/badge/Google%20Play-Download-brightgreen?logo=google-play)](https://play.google.com/store/apps/details?id=ai.offgridmobile)
 [![App Store](https://img.shields.io/badge/App%20Store-Download-blue?logo=apple)](https://apps.apple.com/us/app/off-grid-local-ai/id6759299882)
 [![Platform](https://img.shields.io/badge/Platform-Android%20%7C%20iOS%20%7C%20macOS-green.svg)](#install)
-[![codecov](https://codecov.io/gh/alichherawalla/off-grid-mobile/graph/badge.svg)](https://codecov.io/gh/alichherawalla/off-grid-mobile)
+[![codecov](https://codecov.io/gh/off-grid-ai/OGAM/graph/badge.svg)](https://codecov.io/gh/off-grid-ai/OGAM)
 [![Slack](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack)](https://join.slack.com/t/off-grid-mobile/shared_invite/zt-411pbtz7r-lcOK4YCeY40vh_~FUdcvLA)
 [![Pro](https://img.shields.io/badge/Off%20Grid%20Pro-%2469%20lifetime%20and%20%2449%20annual-000000?style=flat)](https://offgridmobileai.co/pay/)
 
@@ -125,15 +125,15 @@ Tested on Snapdragon 8 Gen 2/3, Apple A17 Pro. Results vary by model size and qu
 </tr></table>
 </div>
 
-Or grab the latest APK from [**GitHub Releases**](https://github.com/alichherawalla/off-grid-mobile/releases/latest).
+Or grab the latest APK from [**GitHub Releases**](https://github.com/off-grid-ai/OGAM/releases/latest).
 
 > **macOS**: The iOS App Store version runs natively on Apple Silicon Macs via Mac Catalyst / iPad compatibility.
 
 ### Build from source
 
 ```bash
-git clone https://github.com/alichherawalla/off-grid-mobile.git
-cd off-grid-mobile
+git clone https://github.com/off-grid-ai/OGAM.git
+cd OGAM
 npm install
 
 # Android
@@ -151,8 +151,8 @@ npm run ios
 
 ## Testing
 
-[![CI](https://github.com/alichherawalla/off-grid-mobile/actions/workflows/ci.yml/badge.svg)](https://github.com/alichherawalla/off-grid-mobile/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/alichherawalla/off-grid-mobile/graph/badge.svg)](https://codecov.io/gh/alichherawalla/off-grid-mobile)
+[![CI](https://github.com/off-grid-ai/OGAM/actions/workflows/ci.yml/badge.svg)](https://github.com/off-grid-ai/OGAM/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/off-grid-ai/OGAM/graph/badge.svg)](https://codecov.io/gh/off-grid-ai/OGAM)
 
 Tests run across three platforms on every PR:
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Most "local LLM" apps give you a text chatbot and call it a day. Off Grid AI is 
 
 **Text Generation** — Run Qwen 3, Llama 3.2, Gemma 3, Phi-4, and any GGUF model. Streaming responses, thinking mode, markdown rendering, 15-30 tok/s on flagship devices. Bring your own `.gguf` files too.
 
+**GPU & NPU Acceleration** — Your phone has silicon sitting idle. Off Grid uses it. Adreno GPUs via OpenCL run 20-40 tok/s on a Snapdragon 8 Gen 2+, against 15-30 on CPU; Apple Silicon uses Metal. The app detects what your device has and defaults to the fastest backend that works, and you can override it in Settings. The Hexagon NPU (Snapdragon) is there too, marked experimental because it is — it only accelerates `Q4_0` and `Q8_0` quants, a K-quant silently falls back to CPU, and some model architectures come out garbled on it. Models that can actually use the GPU or NPU are badged in the model list, so you pick the right quant before you download 4GB.
+
 **Remote LLM Servers** — Connect to any OpenAI-compatible server on your local network (Ollama, LM Studio, LocalAI). Discover models automatically, stream responses via SSE, store API keys securely in the system keychain. Switch seamlessly between local and remote models.
 
 **Tool Calling** — Models that support function calling can use built-in tools: web search, calculator, date/time, device info, and knowledge base search. Automatic tool loop with runaway prevention. Clickable links in search results.
@@ -99,13 +101,18 @@ Most "local LLM" apps give you a text chatbot and call it a day. Off Grid AI is 
 
 **AI Prompt Enhancement** — Simple prompt in, detailed Stable Diffusion prompt out. Your text model automatically enhances image generation prompts.
 
+**Memory You Can See and Control** — A phone has finite RAM, and a 4GB model does not politely share it. The model manager shows you what is resident right now and what each one is costing you in RAM, with a per-model eject. **Model Loading** picks the policy: *Lean* keeps one model in memory at a time, *Balanced* co-resides models that fit and swaps the ones that don't, *Aggressive* commits a larger share of RAM so bigger models load. If a load is refused, **Load Anyway** overrides it — your device, your call. When a model gets evicted mid-conversation, the chat says so and offers to bring it back rather than silently failing.
+
+**Download Manager** — Three downloads run at once, the rest FIFO-queue and show as *Queued* instead of quietly stalling. Pause, resume, retry, cancel. Downloads survive backgrounding the app.
+
 ---
 
 ## Performance
 
 | Task | Flagship | Mid-range |
 |------|----------|-----------|
-| Text generation | 15-30 tok/s | 5-15 tok/s |
+| Text generation (CPU) | 15-30 tok/s | 5-15 tok/s |
+| Text generation (GPU / OpenCL) | 20-40 tok/s | — |
 | Image gen (NPU) | 5-10s | — |
 | Image gen (CPU) | ~15s | ~30s |
 | Vision inference | ~7s | ~15s |


### PR DESCRIPTION
## Why

Two problems. The README still pointed at `alichherawalla/off-grid-mobile` in six places (the repo is `off-grid-ai/OGAM`), so the stars and Codecov badges resolved against a slug Codecov does not know about, and the clone instructions `cd` into a directory that never gets created. And three user-visible subsystems shipped since the last content pass with no write-up at all.

## What changed

**Commit 1 — stale slug.** Badges (stars, codecov ×2, CI), the Releases link, and the `git clone` / `cd` pair.

**Commit 2 — new features.**
- **GPU & NPU Acceleration** — backend auto-detection and override, OpenCL on Adreno, Metal on Apple Silicon, Hexagon HTP marked experimental with its real constraints stated (`Q4_0`/`Q8_0` only, silent CPU fallback on K-quants, garbled output on some architectures), per-model accelerability badging in the model list.
- **Memory You Can See and Control** — resident models with per-model RAM and eject, the Lean/Balanced/Aggressive `modelLoadingMode` policy, Load Anyway, and the evicted-mid-conversation recovery prompt.
- **Download Manager** — 3 concurrent, FIFO queue, *Queued* state, survives backgrounding.
- Performance table: text generation split into CPU and GPU rows.

## Sourcing

Every number is from the repo, not invented. GPU 20-40 tok/s from `docs/ARCHITECTURE.md:998`. Concurrency cap from `MAX_CONCURRENT_DOWNLOADS` in `src/services/backgroundDownloadService.ts:21`. Accelerable quants from `src/utils/acceleration.ts:17`. Mode labels and copy from `ModelLoadingModeSelector` in `src/components/settings/textGenAdvancedSections.tsx:221`.

## Deliberately not in scope

- The Pro **"Sync, landing through July"** line stays date-bound — author is handling it separately.
- Remote-server **auto-discovery** is not written up; it is still unmerged on `feat/setting-disable-remote-autodiscovery`.
- License stays MIT.

## Risk

Docs only. No `src` change, so no Provit run required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project branding, repository links, badges, and installation instructions.
  * Added documentation for GPU and NPU acceleration.
  * Expanded performance guidance with memory controls and download management.
  * Added GPU/OpenCL text-generation throughput details to the performance table.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->