### PR TITLE
feat(remote): Settings toggle to disable auto-discovery of remote LLMs (off by default)

### DIFF
--- a/__tests__/e2e/device/remoteAutoDiscoveryToggle.e2e.sh
+++ b/__tests__/e2e/device/remoteAutoDiscoveryToggle.e2e.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# On-device e2e: the "Auto-discover on Wi-Fi" Settings toggle actually gates the automatic LAN scan.
+#
+# The automatic remote-LLM discovery (background scan that finds + auto-adds Ollama/LM Studio/gateway
+# servers) must run ONLY when the toggle is ON. Fresh installs are OFF. This asserts the un-fakeable
+# gate decision from the app's own debug log after a Home mount:
+#
+#   PHASE=off  → the log shows "[HomeScreen] LAN auto-discovery disabled in settings — skipping",
+#               NO "enabled — scanning" line, and ZERO new-server auto-adds this launch.
+#   PHASE=on   → the log shows "[HomeScreen] LAN auto-discovery enabled — scanning" and NO skip line.
+#
+# Both phases key on the runLANDiscovery gate's OWN decision line — not on RemoteServerManager
+# health-checks of ALREADY-configured servers (those refresh regardless of this setting and must not
+# be counted as auto-discovery).
+#
+# The toggle flip + app reload are operator-driven (Settings → Remote Servers → Auto-discover switch,
+# then reload Home); this script owns the deterministic log assertion. PLATFORM=android|ios.
+#
+#   PLATFORM=android bash remoteAutoDiscoveryToggle.e2e.sh <off|on>
+set -uo pipefail
+PLATFORM="${PLATFORM:-android}"
+IOS_UDID="${IOS_UDID:-00008150-000225103CD8C01C}"
+PKG=ai.offgridmobile.dev
+SKIP_LINE='LAN auto-discovery disabled in settings'
+
+read_log() {
+  if [ "$PLATFORM" = ios ]; then
+    xcrun devicectl device copy from --device "$IOS_UDID" --domain-type appDataContainer \
+      --domain-identifier "$PKG" --source Documents/offgrid-debug.log --destination /tmp/autodisc-ios.log >/dev/null 2>&1
+    cat /tmp/autodisc-ios.log 2>/dev/null
+  else
+    export PATH="$PATH:$HOME/Library/Android/sdk/platform-tools"
+    adb exec-out run-as "$PKG" sh -c 'cat files/offgrid-debug.log 2>/dev/null'
+  fi
+}
+
+# Only look at the CURRENT launch: everything after the last "session start" marker.
+current_session() { read_log | awk 'BEGIN{s=""} /session start/{s=""} {s=s $0 "\n"} END{printf "%s", s}'; }
+
+SCAN_LINE='LAN auto-discovery enabled — scanning'
+ADD_LINE='Auto-adding discovered server'
+DUMP=$(current_session)
+SKIP=$(printf '%s' "$DUMP" | grep -ac "$SKIP_LINE")
+SCAN=$(printf '%s' "$DUMP" | grep -ac "$SCAN_LINE")
+ADDS=$(printf '%s' "$DUMP" | grep -ac "$ADD_LINE")
+
+case "${1:?phase: off|on}" in
+  off)
+    echo "[$PLATFORM] skip=$SKIP scanning=$SCAN new-server-adds=$ADDS"
+    if [ "$SKIP" -ge 1 ] && [ "$SCAN" -eq 0 ] && [ "$ADDS" -eq 0 ]; then
+      echo "PASS(off): auto-discovery gated OFF — logged skip, never entered the scan, added no servers"
+    else
+      echo "FAIL(off): expected skip>=1 & scanning=0 & adds=0; got skip=$SKIP scanning=$SCAN adds=$ADDS"; exit 1
+    fi ;;
+  on)
+    echo "[$PLATFORM] skip=$SKIP scanning=$SCAN new-server-adds=$ADDS"
+    if [ "$SKIP" -eq 0 ] && [ "$SCAN" -ge 1 ]; then
+      echo "PASS(on): auto-discovery ON — entered the scan this session, no skip"
+    else
+      echo "FAIL(on): expected skip=0 & scanning>=1; got skip=$SKIP scanning=$SCAN"; exit 1
+    fi ;;
+  *) echo "unknown phase $1"; exit 2 ;;
+esac

--- a/__tests__/rntl/screens/OnboardingScreen.test.tsx
+++ b/__tests__/rntl/screens/OnboardingScreen.test.tsx
@@ -55,14 +55,18 @@ jest.mock('../../../src/components/Button', () => ({
 
 const mockSetOnboardingComplete = jest.fn();
 
-jest.mock('../../../src/stores', () => ({
-  useAppStore: jest.fn((selector?: any) => {
-    const state = {
-      setOnboardingComplete: mockSetOnboardingComplete,
-    };
-    return selector ? selector(state) : state;
-  }),
-}));
+// Mutable so individual tests can flip the auto-discovery gate (fresh installs are OFF by default).
+let mockAutoDiscoverEnabled = false;
+jest.mock('../../../src/stores', () => {
+  // Getters resolve lazily at access time so the `mock*` closures are defined by then.
+  const state = {
+    get setOnboardingComplete() { return mockSetOnboardingComplete; },
+    get settings() { return { autoDiscoverRemoteModels: mockAutoDiscoverEnabled }; },
+  };
+  const useAppStore: any = jest.fn((selector?: any) => (selector ? selector(state) : state));
+  useAppStore.getState = () => state;
+  return { useAppStore };
+});
 
 jest.mock('../../../src/constants', () => ({
   ...jest.requireActual('../../../src/constants'),
@@ -123,6 +127,7 @@ const navigation = {
 describe('OnboardingScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAutoDiscoverEnabled = false; // fresh install default — auto-discovery OFF
   });
 
   it('renders first slide content', () => {
@@ -222,8 +227,24 @@ describe('OnboardingScreen', () => {
     expect(getByTestId('onboarding-next')).toBeTruthy();
   });
 
-  it('kicks off LAN discovery on mount', async () => {
+  it('does NOT scan on mount when auto-discovery is off (fresh-install default)', async () => {
     const { act: reactAct } = require('@testing-library/react-native');
+    mockAutoDiscoverEnabled = false;
+    mockDiscoverLANServers.mockResolvedValue([
+      { endpoint: 'http://192.168.1.10:11434', type: 'ollama', name: 'Ollama' },
+    ]);
+
+    render(<OnboardingScreen navigation={navigation} />);
+    await reactAct(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    // Gated OFF by default — the fresh-install onboarding must not scan the network unprompted.
+    expect(mockDiscoverLANServers).not.toHaveBeenCalled();
+    expect(mockAddServer).not.toHaveBeenCalled();
+  });
+
+  it('kicks off LAN discovery on mount when auto-discovery is enabled', async () => {
+    const { act: reactAct } = require('@testing-library/react-native');
+    mockAutoDiscoverEnabled = true;
     mockDiscoverLANServers.mockResolvedValue([
       {
         endpoint: 'http://192.168.1.10:11434',
@@ -249,6 +270,7 @@ describe('OnboardingScreen', () => {
 
   it('does not add duplicate servers during LAN discovery', async () => {
     const { act: reactAct } = require('@testing-library/react-native');
+    mockAutoDiscoverEnabled = true;
     const {
       useRemoteServerStore,
     } = require('../../../src/stores/remoteServerStore');
@@ -271,6 +293,7 @@ describe('OnboardingScreen', () => {
 
   it('handles LAN discovery errors gracefully', async () => {
     const { act: reactAct } = require('@testing-library/react-native');
+    mockAutoDiscoverEnabled = true;
     mockDiscoverLANServers.mockRejectedValue(new Error('Network error'));
 
     render(<OnboardingScreen navigation={navigation} />);

--- a/__tests__/unit/hooks/useHomeScreen.test.ts
+++ b/__tests__/unit/hooks/useHomeScreen.test.ts
@@ -64,41 +64,44 @@ const mockCreateConversation = jest.fn(() => 'conv-new');
 const mockSetActiveConversation = jest.fn();
 const mockDeleteConversation = jest.fn();
 
-jest.mock('../../../src/stores', () => ({
-  useAppStore: jest.fn((selector?: any) => {
-    const state = {
-      downloadedModels: [],
-      setDownloadedModels: jest.fn(),
-      activeModelId: null,
-      setActiveModelId: jest.fn(),
-      downloadedImageModels: [],
-      setDownloadedImageModels: jest.fn(),
-      activeImageModelId: null,
-      setActiveImageModelId: jest.fn(),
-      deviceInfo: { deviceName: 'TestPhone' },
-      setDeviceInfo: jest.fn(),
-      generatedImages: [],
-      settings: { contextLength: 4096 },
-    };
-    return selector ? selector(state) : state;
-  }),
-  useChatStore: jest.fn(() => ({
-    conversations: [],
-    createConversation: mockCreateConversation,
-    setActiveConversation: mockSetActiveConversation,
-    deleteConversation: mockDeleteConversation,
-  })),
-  useRemoteServerStore: jest.fn((selector?: any) => {
-    const state = {
-      servers: [],
-      discoveredModels: {},
-      activeRemoteTextModelId: null,
-      activeRemoteImageModelId: null,
-      activeServerId: null,
-    };
-    return selector ? selector(state) : state;
-  }),
-}));
+jest.mock('../../../src/stores', () => {
+  const appState = {
+    downloadedModels: [],
+    setDownloadedModels: jest.fn(),
+    activeModelId: null,
+    setActiveModelId: jest.fn(),
+    downloadedImageModels: [],
+    setDownloadedImageModels: jest.fn(),
+    activeImageModelId: null,
+    setActiveImageModelId: jest.fn(),
+    deviceInfo: { deviceName: 'TestPhone' },
+    setDeviceInfo: jest.fn(),
+    generatedImages: [],
+    settings: { contextLength: 4096 },
+    updateSettings: jest.fn(),
+  };
+  const remoteState = {
+    servers: [] as any[],
+    discoveredModels: {},
+    activeRemoteTextModelId: null,
+    activeRemoteImageModelId: null,
+    activeServerId: null,
+  };
+  const useAppStore: any = jest.fn((selector?: any) => (selector ? selector(appState) : appState));
+  useAppStore.getState = () => appState;
+  const useRemoteServerStore: any = jest.fn((selector?: any) => (selector ? selector(remoteState) : remoteState));
+  useRemoteServerStore.getState = () => remoteState;
+  return {
+    useAppStore,
+    useChatStore: jest.fn(() => ({
+      conversations: [],
+      createConversation: mockCreateConversation,
+      setActiveConversation: mockSetActiveConversation,
+      deleteConversation: mockDeleteConversation,
+    })),
+    useRemoteServerStore,
+  };
+});
 
 jest.mock('../../../src/utils/logger', () => ({
   __esModule: true,

--- a/__tests__/unit/utils/remoteAutoDiscovery.test.ts
+++ b/__tests__/unit/utils/remoteAutoDiscovery.test.ts
@@ -1,0 +1,32 @@
+import {
+  shouldAutoDiscoverRemoteModels,
+  resolveAutoDiscoverMigration,
+} from '../../../src/utils/remoteAutoDiscovery';
+
+describe('shouldAutoDiscoverRemoteModels — auto LAN scan runs only when explicitly ON', () => {
+  it('OFF when unset (fresh install)', () => {
+    expect(shouldAutoDiscoverRemoteModels({})).toBe(false);
+    expect(shouldAutoDiscoverRemoteModels({ autoDiscoverRemoteModels: undefined })).toBe(false);
+  });
+  it('OFF when explicitly false', () => {
+    expect(shouldAutoDiscoverRemoteModels({ autoDiscoverRemoteModels: false })).toBe(false);
+  });
+  it('ON only when explicitly true', () => {
+    expect(shouldAutoDiscoverRemoteModels({ autoDiscoverRemoteModels: true })).toBe(true);
+  });
+});
+
+describe('resolveAutoDiscoverMigration — one-time default (grandfather existing gateway users)', () => {
+  it('fresh install (unset, no gateway) → OFF', () => {
+    expect(resolveAutoDiscoverMigration(undefined, false)).toBe(false);
+  });
+  it('upgrading user with a gateway already added (unset) → ON', () => {
+    expect(resolveAutoDiscoverMigration(undefined, true)).toBe(true);
+  });
+  it('already decided → no change (undefined), regardless of gateways', () => {
+    expect(resolveAutoDiscoverMigration(true, false)).toBeUndefined();
+    expect(resolveAutoDiscoverMigration(false, true)).toBeUndefined();
+    expect(resolveAutoDiscoverMigration(true, true)).toBeUndefined();
+    expect(resolveAutoDiscoverMigration(false, false)).toBeUndefined();
+  });
+});

--- a/src/screens/HomeScreen/hooks/useHomeScreen.ts
+++ b/src/screens/HomeScreen/hooks/useHomeScreen.ts
@@ -8,6 +8,7 @@ import { useModelLoading } from './useModelLoading';
 import { useLANDiscovery } from './useLANDiscovery';
 import { useRemoteModelHandlers } from './useRemoteModelHandlers';
 import { useActiveTextModel } from '../../../hooks/useActiveTextModel';
+import { resolveAutoDiscoverMigration } from '../../../utils/remoteAutoDiscovery';
 import logger from '../../../utils/logger';
 // Shared hook types live in ./types so the sub-hooks can import them without importing this file
 // (which imports them back — a cycle). Re-exported here for existing external importers.
@@ -126,6 +127,22 @@ export const useHomeScreen = (navigation: HomeScreenNavigationProp) => {
       }
       if (!hasRunLANDiscovery) {
         hasRunLANDiscovery = true;
+        // One-time default for the auto-discover toggle: fresh installs → OFF; grandfather users who
+        // already had a gateway → ON. Guard on the remote-server store being hydrated so we read the
+        // real (persisted) server list, not the empty initial state. runLANDiscovery self-gates on
+        // the resulting setting, so a slow hydration simply skips this launch (correct next launch).
+        const migrateAutoDiscover = (): void => {
+          const next = resolveAutoDiscoverMigration(
+            useAppStore.getState().settings.autoDiscoverRemoteModels,
+            useRemoteServerStore.getState().servers.length > 0,
+          );
+          if (next !== undefined) useAppStore.getState().updateSettings({ autoDiscoverRemoteModels: next });
+        };
+        // `.persist` is a zustand-middleware addition; guard it so this is safe under test mocks
+        // that don't include it (treat "no persist API" as already-hydrated).
+        const persistApi = (useRemoteServerStore as { persist?: { hasHydrated?: () => boolean; onFinishHydration?: (cb: () => void) => void } }).persist;
+        if (!persistApi?.hasHydrated || persistApi.hasHydrated()) migrateAutoDiscover();
+        else persistApi.onFinishHydration?.(migrateAutoDiscover);
         // Delay LAN scan so the home screen is fully rendered and interactive first
         setTimeout(runLANDiscovery, 3000);
       }

--- a/src/screens/HomeScreen/hooks/useLANDiscovery.ts
+++ b/src/screens/HomeScreen/hooks/useLANDiscovery.ts
@@ -3,6 +3,8 @@ import { showAlert, hideAlert } from '../../../components';
 import { useRemoteServerStore } from '../../../stores/remoteServerStore';
 import { remoteServerManager } from '../../../services';
 import { discoverLANServers } from '../../../services/networkDiscovery';
+import { useAppStore } from '../../../stores/appStore';
+import { shouldAutoDiscoverRemoteModels } from '../../../utils/remoteAutoDiscovery';
 import type { HomeScreenNavigationProp } from './types';
 import type { RemoteServer } from '../../../types';
 import logger from '../../../utils/logger';
@@ -67,6 +69,14 @@ export function useLANDiscovery({ navigation, setAlertState }: LANDiscoveryParam
   }, [navigation, setAlertState]);
 
   const runLANDiscovery = useCallback(async () => {
+    // The automatic LAN scan runs only when the user has enabled auto-discovery. Fresh installs are
+    // OFF — never scan the network unprompted. (The "Scan Network" button is a separate, explicit
+    // action and is NOT gated here.)
+    if (!shouldAutoDiscoverRemoteModels(useAppStore.getState().settings)) {
+      logger.log('[HomeScreen] LAN auto-discovery disabled in settings — skipping');
+      return;
+    }
+    logger.log('[HomeScreen] LAN auto-discovery enabled — scanning');
     let discovered: Awaited<ReturnType<typeof discoverLANServers>>;
     try {
       discovered = await discoverLANServers();

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -31,6 +31,7 @@ import {
 import { useAppStore } from '../stores';
 import { useRemoteServerStore } from '../stores/remoteServerStore';
 import { discoverLANServers } from '../services/networkDiscovery';
+import { shouldAutoDiscoverRemoteModels } from '../utils/remoteAutoDiscovery';
 import { remoteServerManager } from '../services';
 import { RootStackParamList } from '../navigation/types';
 import logger from '../utils/logger';
@@ -161,11 +162,14 @@ export const OnboardingScreen: React.FC<OnboardingScreenProps> = ({
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
 
-  // Kick off non-blocking LAN scan so results are ready by ModelDownloadScreen
+  // Kick off non-blocking LAN scan so results are ready by ModelDownloadScreen — but only if the
+  // user has opted into auto-discovery. Onboarding is a fresh install (auto-discovery OFF by
+  // default), so this normally no-ops; it stays gated for correctness.
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
+        if (!shouldAutoDiscoverRemoteModels(useAppStore.getState().settings)) return;
         const discovered = await discoverLANServers();
         if (cancelled || discovered.length === 0) return;
         const store = useRemoteServerStore.getState();

--- a/src/screens/RemoteServersScreen.styles.ts
+++ b/src/screens/RemoteServersScreen.styles.ts
@@ -31,6 +31,27 @@ export function createStyles(colors: ThemeColors, _shadows: ThemeShadows) {
     content: {
       padding: 16,
     },
+    autoDiscoverRow: {
+      flexDirection: 'row' as const,
+      alignItems: 'center' as const,
+      gap: SPACING.md,
+      padding: SPACING.md,
+      marginBottom: SPACING.md,
+      borderRadius: 12,
+      backgroundColor: colors.surfaceLight,
+    },
+    autoDiscoverTextCol: {
+      flex: 1,
+    },
+    autoDiscoverTitle: {
+      ...TYPOGRAPHY.body,
+      color: colors.text,
+      marginBottom: 2,
+    },
+    autoDiscoverDesc: {
+      ...TYPOGRAPHY.bodySmall,
+      color: colors.textSecondary,
+    },
     emptyState: {
       alignItems: 'center' as const,
       paddingVertical: 40,

--- a/src/screens/RemoteServersScreen.tsx
+++ b/src/screens/RemoteServersScreen.tsx
@@ -12,13 +12,14 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   Linking,
+  Switch,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Icon from 'react-native-vector-icons/Feather';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTheme, useThemedStyles } from '../theme';
-import { useRemoteServerStore } from '../stores';
+import { useRemoteServerStore, useAppStore } from '../stores';
 import { RemoteServerModal } from '../components/RemoteServerModal';
 import { RootStackParamList } from '../navigation/types';
 import { remoteServerManager } from '../services/remoteServerManager';
@@ -37,6 +38,8 @@ export const RemoteServersScreen: React.FC = () => {
   const theme = useTheme();
   const styles = useThemedStyles(createStyles);
   const { servers, serverHealth, testConnection, activeServerId, setActiveServerId } = useRemoteServerStore();
+  const autoDiscover = useAppStore(s => s.settings.autoDiscoverRemoteModels === true);
+  const updateSettings = useAppStore(s => s.updateSettings);
   const [showAddModal, setShowAddModal] = useState(false);
   const [editingServer, setEditingServer] = useState<typeof servers[0] | null>(null);
   const [testingId, setTestingId] = useState<string | null>(null);
@@ -135,6 +138,21 @@ export const RemoteServersScreen: React.FC = () => {
       </View>
 
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.content}>
+        <View style={styles.autoDiscoverRow}>
+          <View style={styles.autoDiscoverTextCol}>
+            <Text style={styles.autoDiscoverTitle}>Auto-discover on Wi-Fi</Text>
+            <Text style={styles.autoDiscoverDesc}>
+              Automatically find and add Ollama, LM Studio, and gateway servers on your network. Off by default — turn on to scan automatically.
+            </Text>
+          </View>
+          <Switch
+            testID="auto-discover-toggle"
+            value={autoDiscover}
+            onValueChange={(v) => updateSettings({ autoDiscoverRemoteModels: v })}
+            trackColor={{ false: theme.colors.border, true: theme.colors.primary }}
+          />
+        </View>
+
         {servers.length === 0 ? (
           <View style={styles.emptyState}>
             <View style={styles.emptyIcon}>

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -76,6 +76,11 @@ type AppSettings = {
   liteRTTemperature: number;
   liteRTTopP: number;
   liteRTMaxTokens: number;
+  /** Auto-discover remote LLMs: the background LAN scan that finds + auto-adds Ollama / LM Studio /
+   *  gateway servers. Fresh installs are OFF (never scan the network unprompted); a one-time
+   *  migration turns it ON for users who already had a gateway. `undefined` = never set (reads OFF).
+   *  Optional so the migration can distinguish "never set" from an explicit choice. */
+  autoDiscoverRemoteModels?: boolean;
 };
 
 type ThemeMode = 'system' | 'light' | 'dark';

--- a/src/utils/remoteAutoDiscovery.ts
+++ b/src/utils/remoteAutoDiscovery.ts
@@ -1,0 +1,39 @@
+/**
+ * Auto-discovery of remote LLMs (the background LAN scan that finds + auto-adds Ollama / LM Studio /
+ * gateway servers) is gated by a Settings toggle. Policy:
+ *   - Fresh installs are always OFF — the app must not scan the local network unprompted.
+ *   - Existing users who ALREADY configured a gateway keep it ON (a one-time migration), so the
+ *     upgrade doesn't silently break a setup they rely on.
+ *
+ * Both rules are pure functions here so they're unit-testable and have a single source of truth,
+ * separate from the React/store I/O that calls them.
+ */
+
+/** The toggle's runtime shape (a slice of AppSettings). */
+export interface AutoDiscoverSettings {
+  autoDiscoverRemoteModels?: boolean;
+}
+
+/**
+ * Whether the automatic LAN scan may run. It runs ONLY when explicitly enabled — an unset value
+ * (fresh install, never migrated) reads as OFF. User-initiated scans (the "Scan Network" button)
+ * are NOT gated by this; they're an explicit action.
+ */
+export function shouldAutoDiscoverRemoteModels(settings: AutoDiscoverSettings): boolean {
+  return settings.autoDiscoverRemoteModels === true;
+}
+
+/**
+ * One-time default resolution for the toggle. Returns the value to persist, or `undefined` when the
+ * setting is already decided (already true/false) so the caller writes nothing.
+ *   - already set  → undefined (leave the user's / prior migration's choice alone)
+ *   - never set + a gateway already exists → true  (grandfather existing setups)
+ *   - never set + no gateway               → false (fresh install / no prior remote use → OFF)
+ */
+export function resolveAutoDiscoverMigration(
+  current: boolean | undefined,
+  hasExistingGateway: boolean,
+): boolean | undefined {
+  if (current !== undefined) return undefined;
+  return hasExistingGateway;
+}


### PR DESCRIPTION
## What

Adds an **"Auto-discover on Wi-Fi"** toggle in **Settings → Remote Servers**. The background LAN scan that finds + auto-adds Ollama / LM Studio / gateway servers now runs **only when the user opts in**.

## Policy (pure, unit-tested — `remoteAutoDiscovery.ts`)
- **Fresh installs are always OFF** — the app never scans the local network unprompted.
- **One-time migration grandfathers existing gateway users to ON** — if a gateway was already configured, the upgrade keeps auto-discovery on so it doesn't silently break their setup. The setting is optional (`undefined`) so "never set" is distinguishable from an explicit choice.

## Gating
- The two **automatic** discovery sites are gated on `shouldAutoDiscoverRemoteModels`: the HomeScreen 3s-after-mount scan (`runLANDiscovery`) and the OnboardingScreen pre-scan.
- The user-initiated **"Scan Network" button is NOT gated** (explicit action).
- `runLANDiscovery` logs its gate decision either way (`disabled … skipping` / `enabled … scanning`) so behaviour is verifiable and never confused with `RemoteServerManager` health-checks of already-configured servers.
- Migration runs once at Home init, guarded on the remote-server store being hydrated.

## Verified on BOTH real devices (iPhone 17 Pro Max + Android), device e2e `remoteAutoDiscoveryToggle.e2e.sh`:

| | iOS | Android |
|---|---|---|
| migration (gateway present) → **ON** | ✅ skip=0 scanning=1 | ✅ skip=0 scanning=1 |
| toggle **OFF** → next launch | ✅ skip=1 scanning=0 adds=0 | ✅ skip=1 scanning=0 adds=0 |

Toggling OFF genuinely stops auto-discovery — the only remaining network activity is a health-refresh of servers you already added, which is not discovery.

## Tests
6 unit tests (gate + migration logic), updated Onboarding/HomeScreen suites (gated-off default + enabled path), RemoteServersScreen render — all green. tsc/depcruise clean; no new lint. Full suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Auto-discover on Wi‑Fi” setting for controlling automatic remote server discovery.
  * Automatic LAN discovery now runs only when the setting is enabled.
  * Existing gateway users receive a one-time migrated default, while fresh installations keep discovery disabled.

* **Bug Fixes**
  * Prevented onboarding from discovering or adding remote servers when auto-discovery is disabled.

* **Tests**
  * Added coverage for setting behavior, migration scenarios, onboarding, and LAN discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->