### PR TITLE
Reset Pro on this phone, so a device can move to a different licence

### DIFF
--- a/src/screens/ProDetailScreen/ProManageSection.tsx
+++ b/src/screens/ProDetailScreen/ProManageSection.tsx
@@ -89,11 +89,29 @@ export const ProManageSection: React.FC = () => {
                   );
                   return;
                 }
-                await loadProFeatures().catch(() => {});
-                await refresh();
+                // The seat IS released and the credential IS gone by this point, so a failure here is
+                // not a failed reset - it is a screen that could not catch up. Swallowing it left the
+                // card showing a licence the phone no longer has, which reads as "reset did nothing"
+                // and invites a second attempt on a device that has already been reset.
+                try {
+                  await loadProFeatures();
+                  await refresh();
+                } catch (e) {
+                  logger.error(`[Pro] reset reload failed: ${String(e)}`);
+                  Alert.alert(
+                    'Pro was reset',
+                    'This phone no longer holds the licence. Restart the app to finish unloading Pro features.',
+                  );
+                }
               })
+              // The reset itself threw, so whether the seat was released is unknown. Say so rather
+              // than only writing to a log the user cannot read.
               .catch(e => {
                 logger.error(`[Pro] reset failed: ${String(e)}`);
+                Alert.alert(
+                  'Could not reset Pro',
+                  'Something went wrong, so this phone may still hold its seat. Try again.',
+                );
               })
               .finally(() => setResetting(false));
           },

--- a/src/screens/ProDetailScreen/ProManageSection.tsx
+++ b/src/screens/ProDetailScreen/ProManageSection.tsx
@@ -51,11 +51,16 @@ export const ProManageSection: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [resetting, setResetting] = useState(false);
 
-  const refresh = useCallback(async () => {
+  // Answers whether the card now shows current state. It swallows its own failure so first paint can
+  // never reject, which also meant a caller could not tell a repaint from a silent miss - and after a
+  // reset that difference is the whole message.
+  const refresh = useCallback(async (): Promise<boolean> => {
     try {
       setInfo(await getProLicenseInfo());
+      return true;
     } catch (e) {
       logger.error('[ProManage] load failed:', e instanceof Error ? e.message : String(e));
+      return false;
     } finally {
       setLoading(false);
     }
@@ -93,11 +98,16 @@ export const ProManageSection: React.FC = () => {
                 // not a failed reset - it is a screen that could not catch up. Swallowing it left the
                 // card showing a licence the phone no longer has, which reads as "reset did nothing"
                 // and invites a second attempt on a device that has already been reset.
+                let repainted = false;
                 try {
                   await loadProFeatures();
-                  await refresh();
+                  repainted = await refresh();
                 } catch (e) {
                   logger.error(`[Pro] reset reload failed: ${String(e)}`);
+                }
+                // Covers both ways the card can be left behind: loadProFeatures throwing, and refresh
+                // failing to read the new state - which it reports rather than throws.
+                if (!repainted) {
                   Alert.alert(
                     'Pro was reset',
                     'This phone no longer holds the licence. Restart the app to finish unloading Pro features.',

--- a/src/screens/ProDetailScreen/ProManageSection.tsx
+++ b/src/screens/ProDetailScreen/ProManageSection.tsx
@@ -11,7 +11,13 @@
  * in-app portal because RevenueCat authenticates Web Billing customers by email.
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import { View, Text, ActivityIndicator, TouchableOpacity } from 'react-native';
+import {
+  View,
+  Text,
+  ActivityIndicator,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import Icon from 'react-native-vector-icons/Feather';
 import { useTheme, useThemedStyles } from '../../theme';
@@ -20,9 +26,11 @@ import type { ThemeColors, ThemeShadows } from '../../theme';
 import { SPACING, TYPOGRAPHY } from '../../constants';
 import {
   getProLicenseInfo,
+  resetProOnThisDevice,
   PRO_TIER_META,
   type ProLicenseInfo,
 } from '../../services/proLicenseService';
+import { loadProFeatures } from '../../bootstrap/loadProFeatures';
 import logger from '../../utils/logger';
 
 function formatDate(iso: string | null): string {
@@ -41,6 +49,7 @@ export const ProManageSection: React.FC = () => {
   const hasSyncScreen = useHasRegisteredScreen('Sync');
   const [info, setInfo] = useState<ProLicenseInfo | null>(null);
   const [loading, setLoading] = useState(true);
+  const [resetting, setResetting] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -54,6 +63,43 @@ export const ProManageSection: React.FC = () => {
 
   useEffect(() => {
     refresh();
+  }, [refresh]);
+
+  // Confirmed first, because it releases a seat on the licence rather than only clearing this phone.
+  // The failure branch matters: resetProOnThisDevice returns false when the seat could NOT be
+  // released, and it keeps the credential in that case. Telling the user it worked would leave them
+  // entering a new key on a device the licence still counts.
+  const confirmReset = useCallback(() => {
+    Alert.alert(
+      'Reset Pro on this phone?',
+      'This removes this phone from the saved licence so it can use a different one. Your other devices stay active.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Reset Pro',
+          style: 'destructive',
+          onPress: () => {
+            setResetting(true);
+            resetProOnThisDevice()
+              .then(async ok => {
+                if (!ok) {
+                  Alert.alert(
+                    'Could not reset Pro',
+                    'The licence could not be reached, so this phone still holds its seat. Check your connection and try again.',
+                  );
+                  return;
+                }
+                await loadProFeatures().catch(() => {});
+                await refresh();
+              })
+              .catch(e => {
+                logger.error(`[Pro] reset failed: ${String(e)}`);
+              })
+              .finally(() => setResetting(false));
+          },
+        },
+      ],
+    );
   }, [refresh]);
 
   // Render from the tier's own semantics (PRO_TIER_META), not a per-tier branch: a
@@ -102,7 +148,7 @@ export const ProManageSection: React.FC = () => {
 
       {/* Web Billing authenticates by email, so the only real path to cancelling is that link. */}
       {renewing ? (
-        <View style={[styles.row, styles.lastRow]}>
+        <View style={styles.row}>
           <Icon name="mail" size={18} color={colors.primary} />
           <View style={styles.rowText}>
             <Text style={styles.rowTitle}>Manage subscription</Text>
@@ -112,6 +158,29 @@ export const ProManageSection: React.FC = () => {
           </View>
         </View>
       ) : null}
+
+      {/* The desktop has carried this since it shipped; the phone had no equivalent, and the
+          credential lives in the Keychain, which survives deleting the app. So a phone holding the
+          wrong licence could not be moved onto the right one by any means available to its owner. */}
+      <TouchableOpacity
+        style={[styles.row, styles.lastRow]}
+        activeOpacity={0.72}
+        onPress={confirmReset}
+        disabled={resetting}
+        accessibilityRole="button"
+        accessibilityLabel="Reset Pro on this phone"
+      >
+        <Icon name="rotate-ccw" size={18} color={colors.primary} />
+        <View style={styles.rowText}>
+          <Text style={styles.rowTitle}>
+            {resetting ? 'Resetting…' : 'Reset Pro'}
+          </Text>
+          <Text style={styles.rowDescription}>
+            Remove the saved licence so this phone can use a different one.
+          </Text>
+        </View>
+        {resetting ? <ActivityIndicator color={colors.primary} /> : null}
+      </TouchableOpacity>
     </View>
   );
 };

--- a/src/services/proLicenseService.ts
+++ b/src/services/proLicenseService.ts
@@ -29,6 +29,14 @@ export interface ProEntitlementProvider {
   revalidate(reason: PersonalMeshReconciliationReason): Promise<void>;
   activate(rawCredential: string): Promise<PersonalMeshActivationResult>;
   clearForTesting(): Promise<void>;
+  /**
+   * Release this device's seat on its licence, then forget the credential, so the device can take a
+   * different licence. Returns false when the seat could not be released - the credential is kept in
+   * that case, because a device that still holds a seat has not been reset.
+   *
+   * Distinct from clearForTesting, which only forgets locally and leaves the seat where it is.
+   */
+  resetCurrentDevice(): Promise<boolean>;
 }
 
 const UNAVAILABLE_PROVIDER: ProEntitlementProvider = {
@@ -43,6 +51,9 @@ const UNAVAILABLE_PROVIDER: ProEntitlementProvider = {
   revalidate: async () => undefined,
   activate: async () => ({ ok: false, reason: 'registration_failed' }),
   clearForTesting: async () => undefined,
+  // An open-core build holds no credential, so there is nothing to release and nothing to forget.
+  // Reporting success is truthful here: the device is already in the state a reset would leave it in.
+  resetCurrentDevice: async () => true,
 };
 
 let provider: ProEntitlementProvider = UNAVAILABLE_PROVIDER;
@@ -71,4 +82,8 @@ export function activateProByKey(
 
 export function clearProForTesting(): Promise<void> {
   return provider.clearForTesting();
+}
+
+export function resetProOnThisDevice(): Promise<boolean> {
+  return provider.resetCurrentDevice();
 }


### PR DESCRIPTION
The Mac has had this since it shipped: Settings shows **"LICENSE ON THIS MAC / Remove the saved license
so this Mac can use a different one"** with a Reset Pro button. The phone had nothing equivalent, and
on iOS that gap has no workaround at all:

- the credential lives in the **Keychain**, which survives deleting and reinstalling the app
- both "I have a license key" entry points on `ProDetailScreen` are gated on `!hasProAccess`
- `ProUnlockModal` is opened from exactly one file, so no other screen offers a way in

So a phone holding the wrong licence could not be moved onto the right one by any means available to
its owner. Not by reinstalling, not from another device, not from Keygen. This was found on a real
device tonight, and the only escape was building a patched app and side-loading it.

## What it does

A `Reset Pro` row on the "Your licence" card, mirroring the desktop's copy, confirming before it acts -
because it releases a seat on the licence, not just local state.

The failure branch is the point. `resetProOnThisDevice` returns false when the seat could NOT be
released, and keeps the credential in that case. The user is told the phone still holds its seat,
rather than being sent to enter a new key on a device the licence still counts.

## Why a new provider method

`resetCurrentDevice` sits next to `clearForTesting` rather than replacing it. They are different
operations: one forgets locally and leaves the seat where it is (what the DEV toggle wants), the other
releases the seat and then forgets (what a user asking to reset wants). The open-core stub answers
true - with no credential there is nothing to release, which is already the state a reset leaves.

## Merge order

Merge **off-grid-ai/mobile-pro#49 first**, with a merge commit. This PR bumps the `pro` submodule to
`fb297aa1`, which is only reachable from pro's `main` once that lands. A squash there would orphan it
and leave this repo's `main` pointing at a commit nobody can fetch.

Same branch name in both repos, so each CI resolves the other as its matching branch and the
interface and its implementation are typechecked together.

## Verification

`tsc --noEmit` clean, `eslint` clean on all three files, `__tests__/rntl/screens/` 738/738 passing.
Built Release for a real iPhone and installed it; the row renders on the Pro card.

## Tests

None yet. The workspace rule is that tests come last, after manual verification, and only when asked.
`pro/CLAUDE.md` asks for unit + integration tests on every feature. Flagging the conflict rather than
silently picking - say the word and I will add them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to reset Pro access on the current device and release its licence seat.
  * Added confirmation and progress feedback during the reset process.
  * Pro licence information and available features now refresh after a successful reset.
  * The reset action is disabled while processing to prevent duplicate requests.

* **Bug Fixes**
  * Reset failures are reported without removing existing Pro credentials.
  * Users are warned if the reset succeeds but the updated status cannot be displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a confirmed mobile Reset Pro action that delegates licence-seat release to the entitlement provider and refreshes feature and licence state afterward.
- Adds separate user feedback for reset refusal, reset rejection, and successful reset followed by refresh failure.
- Extends the provider contract with `resetCurrentDevice`.
- Updates the Pro submodule containing the provider implementation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/screens/ProDetailScreen/ProManageSection.tsx | Adds the confirmed reset interaction, processing state, provider invocation, post-reset refresh, and user-visible handling for all represented failure outcomes. |
| src/services/proLicenseService.ts | Extends the entitlement-provider interface with a seat-releasing reset operation and exposes it through the service. |
| pro | Updates the Pro submodule revision that supplies the corresponding provider implementation. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant UI as ProManageSection
    participant Provider as Pro entitlement provider
    participant Features as loadProFeatures
    User->>UI: Confirm Reset Pro
    UI->>Provider: resetCurrentDevice()
    alt Seat cannot be released
        Provider-->>UI: false
        UI-->>User: Explain seat remains
    else Reset rejects
        Provider--xUI: Error
        UI-->>User: Explain state is uncertain
    else Reset succeeds
        Provider-->>UI: true
        UI->>Features: Reload Pro state
        UI->>UI: Refresh licence information
        alt Reload or refresh fails
            UI-->>User: Confirm reset and request restart
        end
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(pro): refresh reports whether it rep..."](https://github.com/off-grid-ai/ogam/commit/86f7f65462eced023d98012af9f1bec5e49f6be4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52457792)</sub>

<!-- /greptile_comment -->