### PR TITLE
Match Home logo to header action size

### DIFF
--- a/src/screens/HomeScreen/styles.ts
+++ b/src/screens/HomeScreen/styles.ts
@@ -24,8 +24,8 @@ const createLayoutStyles = (colors: ThemeColors) => ({
     gap: SPACING.sm,
   },
   appLogo: {
-    width: SPACING.xl,
-    height: SPACING.xl,
+    width: SPACING.xxl,
+    height: SPACING.xxl,
   },
   headerActions: {
     flexDirection: 'row' as const,


### PR DESCRIPTION
## What changed
- increase the Home logo from the 24 px token to the existing 32 px token
- match the notification and Pro header controls

## Verification
- ESLint passed
- TypeScript passed
- HomeScreen rendered suite passed: 91 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the app logo size on the home screen for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->