### PR TITLE
Enlarge Home logo to 40 px

### DIFF
--- a/src/screens/HomeScreen/styles.ts
+++ b/src/screens/HomeScreen/styles.ts
@@ -24,8 +24,8 @@ const createLayoutStyles = (colors: ThemeColors) => ({
     gap: SPACING.sm,
   },
   appLogo: {
-    width: SPACING.xxl,
-    height: SPACING.xxl,
+    width: SPACING.xxl + SPACING.sm,
+    height: SPACING.xxl + SPACING.sm,
   },
   headerActions: {
     flexDirection: 'row' as const,


### PR DESCRIPTION
## What changed
- set the Home logo width and height to 40 px using existing spacing tokens

## Verification
- ESLint passed
- TypeScript passed
- HomeScreen rendered suite passed: 91 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the home screen app logo size for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->