### PR TITLE
chore(release): 0.0.105

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,8 +93,8 @@ android {
         applicationId "ai.offgridmobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1786458677
-        versionName "0.0.104"
+        versionCode 1787295341
+        versionName "0.0.105"
     }
     signingConfigs {
         debug {

--- a/ios/OffgridMobile.xcodeproj/project.pbxproj
+++ b/ios/OffgridMobile.xcodeproj/project.pbxproj
@@ -487,7 +487,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = OffgridMobile/OffgridMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 1786458677;
+				CURRENT_PROJECT_VERSION = 1787295341;
 				DEVELOPMENT_TEAM = 84V6KCAC49;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = OffgridMobile/Info.plist;
@@ -498,7 +498,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.104;
+				MARKETING_VERSION = 0.0.105;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -520,7 +520,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = OffgridMobile/OffgridMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 1786458677;
+				CURRENT_PROJECT_VERSION = 1787295341;
 				DEVELOPMENT_TEAM = 84V6KCAC49;
 				INFOPLIST_FILE = OffgridMobile/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Off Grid AI";
@@ -530,7 +530,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.104;
+				MARKETING_VERSION = 0.0.105;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "offgrid-mobile",
-  "version": "0.0.104",
+  "version": "0.0.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "offgrid-mobile",
-      "version": "0.0.104",
+      "version": "0.0.105",
       "hasInstallScript": true,
       "dependencies": {
         "@dr.pogodin/react-native-fs": "^2.38.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offgrid-mobile",
-  "version": "0.0.104",
+  "version": "0.0.105",
   "private": true,
   "scripts": {
     "android": "react-native run-android --mode=debug --appId ai.offgridmobile.dev",


### PR DESCRIPTION
Bump Android, iOS, and package versions to 0.0.105 with build number 1787295341.\n\nRelease gates passed locally: typecheck, lint, JavaScript tests, Android tests, iOS tests, Android debug and release builds, and iOS simulator build.\n\nGenerated Fastlane files are not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the mobile app to version 0.0.105.
  * Published a new Android build with updated version metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->