### PR TITLE
Release mobile 0.0.107

### DIFF
--- a/__tests__/rntl/screens/ProDetailScreen.test.tsx
+++ b/__tests__/rntl/screens/ProDetailScreen.test.tsx
@@ -10,7 +10,10 @@ import { Alert, Linking } from 'react-native';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { projectPersonalMeshActivationFailure } from '@offgrid/sync';
 import { useAppStore } from '../../../src/stores/appStore';
-import { OFF_GRID_DESKTOP_URL } from '../../../src/constants';
+import {
+  OFF_GRID_DESKTOP_BENEFIT,
+  OFF_GRID_DESKTOP_URL,
+} from '../../../src/constants';
 import { withUtm } from '../../../src/utils/utm';
 
 const PAY_URL = 'https://offgridmobileai.co/pay';
@@ -86,7 +89,9 @@ describe('ProDetailScreen', () => {
   });
 
   it('links to Off Grid AI Desktop from the Pro pitch', () => {
-    const { getByText } = render(<ProDetailScreen />);
+    const { getByText, queryByText } = render(<ProDetailScreen />);
+    expect(getByText(OFF_GRID_DESKTOP_BENEFIT)).toBeTruthy();
+    expect(queryByText(/building this through July/i)).toBeNull();
     fireEvent.press(getByText('Get Off Grid AI Desktop'));
     expect(linkingSpy).toHaveBeenCalledWith(
       withUtm(OFF_GRID_DESKTOP_URL, 'pro-detail'),

--- a/__tests__/rntl/screens/SettingsScreen.test.tsx
+++ b/__tests__/rntl/screens/SettingsScreen.test.tsx
@@ -94,7 +94,9 @@ describe('SettingsScreen', () => {
 
   it('shows the Pro upsell banner when Pro is not active and not dismissed', () => {
     const { getByText } = render(<SettingsScreen />);
-    expect(getByText(/democratized/i)).toBeTruthy();
+    expect(
+      getByText('Your private AI stays current across your devices with live sync.'),
+    ).toBeTruthy();
   });
 
   it('hides the Pro upsell banner once Pro is active', () => {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,8 +93,8 @@ android {
         applicationId "ai.offgridmobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1787307884
-        versionName "0.0.106"
+        versionCode 1787309345
+        versionName "0.0.107"
     }
     signingConfigs {
         debug {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,8 +93,8 @@ android {
         applicationId "ai.offgridmobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1787295341
-        versionName "0.0.105"
+        versionCode 1787307884
+        versionName "0.0.106"
     }
     signingConfigs {
         debug {

--- a/ios/OffgridMobile.xcodeproj/project.pbxproj
+++ b/ios/OffgridMobile.xcodeproj/project.pbxproj
@@ -487,7 +487,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = OffgridMobile/OffgridMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 1787295341;
+				CURRENT_PROJECT_VERSION = 1787307884;
 				DEVELOPMENT_TEAM = 84V6KCAC49;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = OffgridMobile/Info.plist;
@@ -498,7 +498,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.105;
+				MARKETING_VERSION = 0.0.106;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -520,7 +520,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = OffgridMobile/OffgridMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 1787295341;
+				CURRENT_PROJECT_VERSION = 1787307884;
 				DEVELOPMENT_TEAM = 84V6KCAC49;
 				INFOPLIST_FILE = OffgridMobile/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Off Grid AI";
@@ -530,7 +530,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.105;
+				MARKETING_VERSION = 0.0.106;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/OffgridMobile.xcodeproj/project.pbxproj
+++ b/ios/OffgridMobile.xcodeproj/project.pbxproj
@@ -487,7 +487,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = OffgridMobile/OffgridMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 1787307884;
+				CURRENT_PROJECT_VERSION = 1787309345;
 				DEVELOPMENT_TEAM = 84V6KCAC49;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = OffgridMobile/Info.plist;
@@ -498,7 +498,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.106;
+				MARKETING_VERSION = 0.0.107;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -520,7 +520,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = OffgridMobile/OffgridMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 1787307884;
+				CURRENT_PROJECT_VERSION = 1787309345;
 				DEVELOPMENT_TEAM = 84V6KCAC49;
 				INFOPLIST_FILE = OffgridMobile/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Off Grid AI";
@@ -530,7 +530,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.106;
+				MARKETING_VERSION = 0.0.107;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "offgrid-mobile",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "offgrid-mobile",
-      "version": "0.0.105",
+      "version": "0.0.106",
       "hasInstallScript": true,
       "dependencies": {
         "@dr.pogodin/react-native-fs": "^2.38.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "offgrid-mobile",
-  "version": "0.0.106",
+  "version": "0.0.107",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "offgrid-mobile",
-      "version": "0.0.106",
+      "version": "0.0.107",
       "hasInstallScript": true,
       "dependencies": {
         "@dr.pogodin/react-native-fs": "^2.38.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offgrid-mobile",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "private": true,
   "scripts": {
     "android": "react-native run-android --mode=debug --appId ai.offgridmobile.dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offgrid-mobile",
-  "version": "0.0.106",
+  "version": "0.0.107",
   "private": true,
   "scripts": {
     "android": "react-native run-android --mode=debug --appId ai.offgridmobile.dev",

--- a/src/components/models/VoiceModelsUpsell.tsx
+++ b/src/components/models/VoiceModelsUpsell.tsx
@@ -4,7 +4,12 @@ import Icon from 'react-native-vector-icons/Feather';
 import { Button } from '../Button';
 import { useTheme, useThemedStyles } from '../../theme';
 import type { ThemeColors } from '../../theme';
-import { TYPOGRAPHY, SPACING, OFF_GRID_DESKTOP_URL } from '../../constants';
+import {
+  TYPOGRAPHY,
+  SPACING,
+  OFF_GRID_DESKTOP_BENEFIT,
+  OFF_GRID_DESKTOP_URL,
+} from '../../constants';
 import { withUtm } from '../../utils/utm';
 
 interface VoiceModelsUpsellProps {
@@ -40,7 +45,7 @@ export const VoiceModelsUpsell: React.FC<VoiceModelsUpsellProps> = ({ onGetPro }
         accessibilityLabel="Get Off Grid AI Desktop"
       >
         <Icon name="monitor" size={14} color={colors.textMuted} />
-        <Text style={styles.desktopLinkText}>Off Grid AI Desktop is free for Mac. Get it.</Text>
+        <Text style={styles.desktopLinkText}>{OFF_GRID_DESKTOP_BENEFIT}</Text>
       </TouchableOpacity>
     </View>
   );

--- a/src/components/settings/ProUpsellBanner.tsx
+++ b/src/components/settings/ProUpsellBanner.tsx
@@ -13,7 +13,7 @@ import { getPricingCopy } from '../../utils/proPricing';
 
 const FEATURE_ROWS = [
   [{ icon: 'layers', label: 'AMBIENT' }, { icon: 'sunrise', label: 'PROACTIVE' }],
-  [{ icon: 'shield', label: 'PRIVATE' }, { icon: 'refresh-cw', label: 'CROSS-DEVICE' }],
+  [{ icon: 'shield', label: 'PRIVATE' }, { icon: 'refresh-cw', label: 'LIVE SYNC' }],
 ];
 
 interface Props {
@@ -49,7 +49,7 @@ export const ProUpsellBanner: React.FC<Props> = ({ trigger, onGetPro }) => {
           <View style={styles.headerText}>
             <Text style={styles.title}>Off Grid AI Pro</Text>
             <Text style={styles.desc}>
-              Intelligence, democratized and on your device. Ambient, proactive, and private.
+              Your private AI stays current across your devices with live sync.
             </Text>
           </View>
           <TouchableOpacity

--- a/src/components/settings/ProUpsellBanner.tsx
+++ b/src/components/settings/ProUpsellBanner.tsx
@@ -7,7 +7,12 @@ import { selectHasProAccess } from '../../stores/proAccessSlice';
 import { useAppStore } from '../../stores';
 import { useTheme, useThemedStyles } from '../../theme';
 import type { ThemeColors, ThemeShadows } from '../../theme';
-import { SPACING, TYPOGRAPHY, OFF_GRID_DESKTOP_URL } from '../../constants';
+import {
+  SPACING,
+  TYPOGRAPHY,
+  OFF_GRID_DESKTOP_BENEFIT,
+  OFF_GRID_DESKTOP_URL,
+} from '../../constants';
 import { withUtm } from '../../utils/utm';
 import { getPricingCopy } from '../../utils/proPricing';
 
@@ -85,7 +90,7 @@ export const ProUpsellBanner: React.FC<Props> = ({ trigger, onGetPro }) => {
           accessibilityLabel="Get Off Grid AI Desktop"
         >
           <Icon name="monitor" size={14} color={colors.textMuted} />
-          <Text style={styles.desktopLinkText}>Off Grid AI Desktop is free for Mac. Get it.</Text>
+          <Text style={styles.desktopLinkText}>{OFF_GRID_DESKTOP_BENEFIT}</Text>
         </TouchableOpacity>
       </View>
     </AnimatedEntry>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,6 +13,8 @@ export const WEDNESDAY_URL = 'https://wednesday.is';
 // Off Grid AI Desktop: the free, open-source desktop app (not a Pro feature).
 // Linked from Pro screens and from remote-server discovery alike.
 export const OFF_GRID_DESKTOP_URL = 'https://getoffgridai.co/desktop';
+export const OFF_GRID_DESKTOP_BENEFIT =
+  'More power, same privacy. Run bigger models on Mac or Windows and keep every device in sync.';
 
 export const PRO_AHA_FEATURES = [
   'Ambient across your devices',

--- a/src/screens/ProDetailScreen/ProIncludedSection.tsx
+++ b/src/screens/ProDetailScreen/ProIncludedSection.tsx
@@ -30,8 +30,8 @@ const ROWS: IncludedRow[] = [
   {
     screen: 'Sync',
     icon: 'refresh-cw',
-    title: 'One mind across your devices',
-    description: 'Your chats, projects and files land on every device you own.',
+    title: 'Live sync across your devices',
+    description: 'Your chats, projects, files, models and copied text stay current.',
   },
   {
     screen: 'Clipboard',

--- a/src/screens/ProDetailScreen/index.tsx
+++ b/src/screens/ProDetailScreen/index.tsx
@@ -47,8 +47,8 @@ const PILLARS = [
   },
   {
     icon: 'refresh-cw',
-    title: 'One mind across devices',
-    desc: 'Your laptop knows your work, your phone knows your life. They sync over your own network, never a cloud relay.',
+    title: 'Live sync across your devices',
+    desc: 'Your chats, projects, files, models, and copied text stay current over your own network, never a cloud relay.',
   },
   {
     icon: 'check-circle',

--- a/src/screens/ProDetailScreen/index.tsx
+++ b/src/screens/ProDetailScreen/index.tsx
@@ -13,7 +13,12 @@ import Icon from 'react-native-vector-icons/Feather';
 import { Button } from '../../components';
 import { useTheme, useThemedStyles } from '../../theme';
 import type { ThemeColors, ThemeShadows } from '../../theme';
-import { SPACING, TYPOGRAPHY, OFF_GRID_DESKTOP_URL } from '../../constants';
+import {
+  SPACING,
+  TYPOGRAPHY,
+  OFF_GRID_DESKTOP_BENEFIT,
+  OFF_GRID_DESKTOP_URL,
+} from '../../constants';
 import { selectHasProAccess } from '../../stores/proAccessSlice';
 import { useAppStore } from '../../stores';
 import { PRO_PAY_PAGE_URL } from '../../services/proLicenseService';
@@ -172,7 +177,7 @@ export const ProDetailScreen: React.FC = () => {
               </Text>
             </View>
 
-            {/* Pricing — flat themed surface, flips at the July 1 cutover. */}
+            {/* Pricing — flat themed surface. */}
             <View style={styles.pricingBanner}>
               <View style={styles.pricingLabelRow}>
                 <Icon name="zap" size={13} color={colors.primary} />
@@ -196,10 +201,6 @@ export const ProDetailScreen: React.FC = () => {
                   </View>
                 </View>
               ))}
-              <Text style={styles.julyNote}>
-                We are building this through July. The full layer lands over the
-                month, added as it ships.
-              </Text>
             </View>
 
             {/* CTAs — shared Button (outline). Buy is primary, verify is secondary. */}
@@ -240,10 +241,7 @@ export const ProDetailScreen: React.FC = () => {
           </View>
           <View style={styles.desktopText}>
             <Text style={styles.desktopTitle}>Get Off Grid AI Desktop</Text>
-            <Text style={styles.desktopDesc}>
-              Free for your Mac. Run your models there and use them from this
-              phone over your own network.
-            </Text>
+            <Text style={styles.desktopDesc}>{OFF_GRID_DESKTOP_BENEFIT}</Text>
           </View>
           <Icon name="external-link" size={16} color={colors.textMuted} />
         </TouchableOpacity>
@@ -412,13 +410,6 @@ const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     color: colors.textSecondary,
     lineHeight: 18,
   },
-  julyNote: {
-    ...TYPOGRAPHY.bodySmall,
-    color: colors.textMuted,
-    lineHeight: 18,
-    marginTop: SPACING.md,
-  },
-
   // CTAs (Button supplies its own colours/border; these are layout-only).
   ctaButton: {
     marginHorizontal: SPACING.xl,


### PR DESCRIPTION
## Outcome

Ships mobile 0.0.107 with live sync presented clearly across Pro surfaces and removes the obsolete July rollout message.

## Verified

- Android AAB uploaded to Play internal testing
- iOS IPA uploaded to TestFlight internal testing
- Exact tested build: 1787309345
- Local release gates passed before upload

## Release lineage

The stable release will promote the exact binaries tagged `v0.0.107-beta.1`; it will not rebuild them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Pro messaging to highlight private, live syncing across devices, including chats, projects, files, models, and copied text.
  * Added consistent desktop app benefit messaging across Pro screens and upsell components.
  * Refreshed the Pro upsell banner’s feature label and description.

* **Chores**
  * Updated the Android and mobile app versions to 0.0.107.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->