### PR TITLE
fix(sync): device-row pairing scanner reads the full pairing QR (+ Gradle 8.13)

### DIFF
--- a/__tests__/rntl/components/pairingCodeSheet.test.tsx
+++ b/__tests__/rntl/components/pairingCodeSheet.test.tsx
@@ -12,6 +12,7 @@
 
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react-native';
+import { encodePairingQrPayload } from '@offgrid/sync';
 
 jest.mock('react-native-vector-icons/Feather', () => {
   const { Text } = require('react-native');
@@ -104,6 +105,24 @@ maybe('PairingCodeSheet scan-to-pair', () => {
     fireEvent.press(getByTestId('sync-test-scan'));
     await act(async () => {
       scanConfig!.onCodeScanned([{ value: VALID_QR }]);
+    });
+    expect(props.onPair).toHaveBeenCalledWith(VALID_QR);
+  });
+
+  it('pairs from the full pairing QR URL the other device shows, not just a bare code', async () => {
+    // The desktop/mobile pairing QR is an offgrid://pair/... URL carrying code=..., NOT a
+    // bare 8-char code. This sheet (opened from a device row) must read the code out of that
+    // URL - otherwise every real scan is rejected as "not a pairing code" (the shipped bug).
+    const url = encodePairingQrPayload({
+      device: { id: 'abc123def', name: 'Studio Mac', platform: 'macos', version: '0.0.107' },
+      pairingCode: VALID_QR,
+      routes: [{ kind: 'lan', host: '192.168.1.18', port: 37878 }],
+    });
+    const props = baseProps();
+    const { getByTestId } = render(<PairingCodeSheet {...props} />);
+    fireEvent.press(getByTestId('sync-test-scan'));
+    await act(async () => {
+      scanConfig!.onCodeScanned([{ value: url }]);
     });
     expect(props.onPair).toHaveBeenCalledWith(VALID_QR);
   });

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
-distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionSha256Sum=20f1b1176237254a6fc204d8434196fa11a4cfb387567519c61556e8710aed78
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## What

Fixes the mobile pairing bug where scanning the pairing QR from a **listed device's Pair** flow failed with "That is not a pairing code," while the pairing-code-section scanner worked.

- **Root cause:** `PairingCodeSheet.onScan` used `parsePairingCode`, which only accepts an exactly-8-char code. The other device's QR encodes the full `offgrid://pair/v1/...` URL (code carried inside), so every real scan was rejected. `PairingQrScanner` worked because it uses `validatePairingQrPayload`.
- **Fix (mobile-pro #54):** `onScan` reads the code out of the pairing-QR payload first, falling back to a bare code.

## This PR (OGAM)
- **RNTL regression test** that scans the actual `offgrid://pair/...` URL — the prior test used a bare 8-char code, which is why it never caught this. Fails before the fix (onScan → undefined → onPair never called), passes after.
- **Submodule bump** to the mobile-pro fix (`aba20eb`).
- **Gradle wrapper 9.1.0 → 8.13** (`9787d67e`): Gradle 9 removed `JvmVendorSpec.IBM_SEMERU`, which the foojay-resolver-convention plugin bundled with RN 0.83 references, so `compileDebugKotlin` failed. `99c0445c` already pinned 8.13 for this exact reason; `1efbb68a` re-bumped to 9.1.0 only to silence an F-Droid jar/url-mismatch warning, reintroducing the break. AGP 8.8.2 is compatible with 8.13.

## Verified
- Repro'd + fixed on a **real device** — device-row scan now reads the QR and pairs.
- Full pre-push gate green: **546/546 test suites**, dependency-cruiser, knip, iOS build, Android `assembleDebug` + `assembleRelease` (`BUILD SUCCESSFUL`).

## Merge note
Depends on **mobile-pro #54** (the submodule pointer here targets its commit). Merge mobile-pro #54 first, then this.